### PR TITLE
Add playlist retrieval commands (get-playlist, get-playlists, list-playlists)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,6 +615,37 @@ staqan-yt --help
 
 ## Git Workflow
 
+### Branch Strategy
+
+**CRITICAL: NEVER commit directly to main.** Always use feature branches.
+
+**Branch naming convention:**
+- `feature/feature-name` - New features
+- `fix/bug-name` - Bug fixes
+- `refactor/name` - Code refactoring
+
+**Workflow:**
+```bash
+# 1. Create a feature branch
+git checkout -b feature/your-feature-name
+
+# 2. Make changes and commit
+git add -A
+git commit -m "Description"
+
+# 3. Push feature branch
+git push -u origin feature/your-feature-name
+
+# 4. Create PR via GitHub or gh CLI
+gh pr create --title "Feature: Your Feature" --body "Description"
+
+# 5. After PR merge, delete the branch
+git branch -d feature/your-feature-name
+```
+
+**Protecting main branch:**
+Consider enabling branch protection rules on GitHub to prevent direct commits to main.
+
 ### Commit Message Format
 
 Follow the established pattern:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A powerful command-line interface for managing YouTube videos and metadata using
 - **Metadata Updates** - Update video titles and descriptions
 - **Video Localizations** - Manage multilingual titles and descriptions (English, Japanese, Russian)
 - **Channel Search** - Search for specific videos within a channel
+- **Playlist Management** - List and retrieve YouTube playlists
 - **Analytics & SEO** - Performance metrics, search terms, traffic sources, and CTR analysis
 - **Tags Management** - View and update video tags for better discoverability
 - **Thumbnail Access** - Retrieve video thumbnail URLs in all available qualities
@@ -255,6 +256,24 @@ staqan-yt search-videos @channelname "keyword" --output json
 Update a single video's metadata:
 ```bash
 staqan-yt update-video dQw4w9WgXcQ --title "New Title" --description "New Desc" --dry-run
+```
+
+#### get-playlist (singular)
+Get metadata for a single playlist:
+```bash
+staqan-yt get-playlist PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO- --output json
+```
+
+#### get-playlists (plural - batch operation)
+Get metadata for multiple playlists:
+```bash
+staqan-yt get-playlists PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO- PLjkl012MNOP345 --output json
+```
+
+#### list-playlists
+List all playlists from a channel:
+```bash
+staqan-yt list-playlists @channelname --limit 50 --output json
 ```
 
 ---
@@ -911,7 +930,171 @@ Available Thumbnails:
 
 ---
 
-#### 13. Get Video Analytics
+#### 13. Get Playlist (singular)
+
+```bash
+staqan-yt get-playlist <playlistId> [options]
+```
+
+Get detailed metadata for a single playlist.
+
+**Arguments:**
+- `playlistId` - Playlist ID or URL
+
+**Options:**
+- `--output <format>` - Output format: `json`, `table`, `text`, `pretty` (default: `pretty`, or from config)
+- `-v, --verbose` - Enable verbose logging
+
+**Examples:**
+
+```bash
+# Get playlist details
+staqan-yt get-playlist PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+
+# Using playlist URL
+staqan-yt get-playlist https://www.youtube.com/playlist?list=PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+
+# JSON output
+staqan-yt get-playlist PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO- --output json
+```
+
+**Sample Output:**
+```
+✓ Retrieved playlist: My Awesome Playlist
+
+My Awesome Playlist
+
+Playlist ID:   PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+Channel:       STAQAN (@staqan)
+Videos:        42
+Privacy:       public
+Published:     Jan 15, 2024
+
+Description:
+  A collection of my favorite videos about craft beer and brewing...
+
+URL:           https://youtube.com/playlist?list=PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+```
+
+---
+
+#### 14. Get Playlists (plural - batch operation)
+
+```bash
+staqan-yt get-playlists <playlistIds...> [options]
+```
+
+Get detailed metadata for multiple playlists at once.
+
+**Arguments:**
+- `playlistIds` - One or more playlist IDs or URLs
+
+**Options:**
+- `--output <format>` - Output format: `json`, `table`, `text`, `pretty` (default: `pretty`, or from config)
+- `-v, --verbose` - Enable verbose logging
+
+**Examples:**
+
+```bash
+# Get multiple playlists
+staqan-yt get-playlists PLabc123 PLdef456 PLghi789
+
+# Using URLs
+staqan-yt get-playlists \
+  https://www.youtube.com/playlist?list=PLabc123 \
+  https://www.youtube.com/playlist?list=PLdef456
+
+# JSON output
+staqan-yt get-playlists PLabc123 PLdef456 --output json
+```
+
+**Sample Output:**
+```
+✓ Retrieved information for 2 playlist(s)
+
+[1] My Awesome Playlist
+
+Playlist ID:   PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+Channel:       STAQAN (@staqan)
+Videos:        42
+Privacy:       public
+Published:     Jan 15, 2024
+
+URL:           https://youtube.com/playlist?list=PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+
+────────────────────────────────────────────────────────────────────────────────
+
+[2] Another Great Playlist
+
+Playlist ID:   PLjkl012MNOP345
+Channel:       STAQAN (@staqan)
+Videos:        15
+Privacy:       public
+Published:     Dec 20, 2023
+
+URL:           https://youtube.com/playlist?list=PLjkl012MNOP345
+```
+
+---
+
+#### 15. List Playlists
+
+```bash
+staqan-yt list-playlists [channelHandle] [options]
+```
+
+List all playlists from a YouTube channel.
+
+**Arguments:**
+- `channelHandle` - (Optional) Channel @handle, username, or URL. Uses `default.channel` from config if not provided.
+
+**Options:**
+- `--output <format>` - Output format: `json`, `table`, `text`, `pretty` (default: `pretty`, or from config)
+- `-l, --limit <number>` - Limit number of results (default: 50)
+- `-v, --verbose` - Enable verbose logging
+
+**Examples:**
+
+```bash
+# List playlists for a channel
+staqan-yt list-playlists @mkbhd
+
+# Using default channel from config
+staqan-yt list-playlists
+
+# Limit results
+staqan-yt list-playlists @mkbhd --limit 10
+
+# JSON output
+staqan-yt list-playlists @mkbhd --output json
+```
+
+**Sample Output:**
+```
+✓ Found 5 playlist(s)
+
+[1] MKBHD Videos
+  ID: PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+  Videos: 500
+  Published: Jan 15, 2024
+  URL: https://youtube.com/playlist?list=PLrAXtmRdnEQy4NANFFH59wXOyi5Mk5cO-
+
+[2] MKBHD Shorts
+  ID: PLjkl012MNOP345
+  Videos: 150
+  Published: Dec 20, 2023
+  URL: https://youtube.com/playlist?list=PLjkl012MNOP345
+
+[3] MKBHD Reviews [Private]
+  ID: PLghi789xyz012
+  Videos: 25
+  Published: Nov 10, 2023
+  URL: https://youtube.com/playlist?list=PLghi789xyz012
+```
+
+---
+
+#### 16. Get Video Analytics
 
 ```bash
 staqan-yt get-video-analytics <videoId> [options]

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -22,6 +22,9 @@ import getVideoTags = require('../commands/get-video-tags');
 import updateVideoTags = require('../commands/update-video-tags');
 import getThumbnail = require('../commands/get-thumbnail');
 import mcpCommand = require('../commands/mcp');
+import getPlaylistCommand = require('../commands/get-playlist');
+import getPlaylistsCommand = require('../commands/get-playlists');
+import listPlaylistsCommand = require('../commands/list-playlists');
 
 // Get version - try to read from package.json, fallback to hardcoded version for compiled binaries
 let version = '1.3.3'; // Fallback version for compiled binaries
@@ -209,6 +212,32 @@ program
   .command('mcp')
   .description('Start MCP server for AI assistant integration')
   .action(mcpCommand);
+
+// Playlist commands
+// Get single playlist command (singular)
+program
+  .command('get-playlist <playlistId>')
+  .description('Get detailed metadata for a single playlist')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action(getPlaylistCommand);
+
+// Get multiple playlists command (plural - batch operation)
+program
+  .command('get-playlists <playlistIds...>')
+  .description('Get detailed metadata for multiple playlists')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action(getPlaylistsCommand);
+
+// List playlists command (plural - list collection)
+program
+  .command('list-playlists [channelHandle]')
+  .description('List all playlists from a YouTube channel')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
+  .option('-l, --limit <number>', 'Limit number of results', '50')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action(listPlaylistsCommand);
 
 // Show help if no command provided
 if (!process.argv.slice(2).length) {

--- a/commands/get-playlist.ts
+++ b/commands/get-playlist.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import chalk from 'chalk';
 import { getPlaylistInfo } from '../lib/youtube';
-import { formatDate, formatNumber, error, setVerbose, debug } from '../lib/utils';
+import { formatDate, formatNumber, error, setVerbose, debug, parsePlaylistId } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { OutputOption, VerboseOption } from '../types';
@@ -16,8 +16,9 @@ async function getPlaylistCommand(playlistId: string, options: OutputOption & Ve
   const spinner = ora('Fetching playlist information...').start();
 
   try {
-    debug(`Fetching playlist: ${playlistId}`);
-    const playlist = await getPlaylistInfo(playlistId);
+    const parsedId = parsePlaylistId(playlistId);
+    debug(`Fetching playlist: ${parsedId} (parsed from: ${playlistId})`);
+    const playlist = await getPlaylistInfo(parsedId);
 
     spinner.succeed(`Retrieved playlist: ${playlist.title}`);
     console.log('');

--- a/commands/get-playlist.ts
+++ b/commands/get-playlist.ts
@@ -1,0 +1,103 @@
+import ora from 'ora';
+import chalk from 'chalk';
+import { getPlaylistInfo } from '../lib/youtube';
+import { formatDate, formatNumber, error, setVerbose, debug } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { OutputOption, VerboseOption } from '../types';
+
+async function getPlaylistCommand(playlistId: string, options: OutputOption & VerboseOption): Promise<void> {
+  // Enable verbose mode if requested
+  if (options.verbose) {
+    setVerbose(true);
+    debug('Verbose mode enabled');
+  }
+
+  const spinner = ora('Fetching playlist information...').start();
+
+  try {
+    debug(`Fetching playlist: ${playlistId}`);
+    const playlist = await getPlaylistInfo(playlistId);
+
+    spinner.succeed(`Retrieved playlist: ${playlist.title}`);
+    console.log('');
+
+    const outputFormat = await getOutputFormat(options.output);
+
+    switch (outputFormat) {
+      case 'json':
+        console.log(formatJson(playlist));
+        break;
+
+      case 'table':
+        const tableData = [{
+          id: playlist.id,
+          title: playlist.title,
+          channel: playlist.channelTitle,
+          items: playlist.itemCount,
+          privacy: playlist.privacyStatus,
+          published: formatDate(playlist.publishedAt),
+        }];
+        console.log(formatTable(tableData));
+        break;
+
+      case 'text':
+        console.log([
+          playlist.id,
+          playlist.title,
+          playlist.channelId,
+          playlist.channelTitle,
+          playlist.itemCount,
+          playlist.privacyStatus,
+          playlist.publishedAt,
+        ].join('\t'));
+        break;
+
+      case 'csv':
+        const csvData = [{
+          id: playlist.id,
+          title: playlist.title,
+          description: playlist.description,
+          channelId: playlist.channelId,
+          channelTitle: playlist.channelTitle,
+          itemCount: playlist.itemCount,
+          privacyStatus: playlist.privacyStatus,
+          publishedAt: playlist.publishedAt,
+        }];
+        console.log(formatCsv(csvData));
+        break;
+
+      case 'pretty':
+      default:
+        console.log(chalk.bold.cyan(playlist.title));
+        console.log('');
+        console.log(chalk.gray('Playlist ID:  ') + chalk.yellow(playlist.id));
+        console.log(chalk.gray('Channel:      ') + playlist.channelTitle + chalk.gray(` (${playlist.channelId})`));
+        console.log(chalk.gray('Videos:       ') + formatNumber(playlist.itemCount));
+        console.log(chalk.gray('Privacy:      ') + playlist.privacyStatus);
+        console.log(chalk.gray('Published:    ') + formatDate(playlist.publishedAt));
+        console.log('');
+
+        if (playlist.description) {
+          console.log(chalk.bold('Description:'));
+          const description = playlist.description;
+          const preview = description.length > 200
+            ? description.substring(0, 200) + '...'
+            : description;
+          console.log('  ' + preview.replace(/\n/g, '\n  '));
+          console.log('');
+        }
+
+        console.log(chalk.gray('URL:          ') + chalk.blue(`https://youtube.com/playlist?list=${playlist.id}`));
+        console.log('');
+        break;
+    }
+  } catch (err) {
+    spinner.fail('Failed to fetch playlist information');
+    console.log('');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = getPlaylistCommand;

--- a/commands/get-playlists.ts
+++ b/commands/get-playlists.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import chalk from 'chalk';
 import { getPlaylistsById } from '../lib/youtube';
-import { formatDate, formatNumber, error, setVerbose, debug } from '../lib/utils';
+import { formatDate, formatNumber, error, setVerbose, debug, parsePlaylistId } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { OutputOption, VerboseOption } from '../types';
@@ -16,8 +16,10 @@ async function getPlaylistsCommand(playlistIds: string[], options: OutputOption 
   const spinner = ora('Fetching playlist information...').start();
 
   try {
+    const parsedIds = playlistIds.map(parsePlaylistId);
     debug(`Parsing ${playlistIds.length} playlist ID(s)`, playlistIds);
-    const playlists = await getPlaylistsById(playlistIds);
+    debug(`Parsed IDs:`, parsedIds);
+    const playlists = await getPlaylistsById(parsedIds);
 
     spinner.succeed(`Retrieved information for ${playlists.length} playlist(s)`);
     console.log('');

--- a/commands/get-playlists.ts
+++ b/commands/get-playlists.ts
@@ -1,0 +1,110 @@
+import ora from 'ora';
+import chalk from 'chalk';
+import { getPlaylistsById } from '../lib/youtube';
+import { formatDate, formatNumber, error, setVerbose, debug } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { OutputOption, VerboseOption } from '../types';
+
+async function getPlaylistsCommand(playlistIds: string[], options: OutputOption & VerboseOption): Promise<void> {
+  // Enable verbose mode if requested
+  if (options.verbose) {
+    setVerbose(true);
+    debug('Verbose mode enabled');
+  }
+
+  const spinner = ora('Fetching playlist information...').start();
+
+  try {
+    debug(`Parsing ${playlistIds.length} playlist ID(s)`, playlistIds);
+    const playlists = await getPlaylistsById(playlistIds);
+
+    spinner.succeed(`Retrieved information for ${playlists.length} playlist(s)`);
+    console.log('');
+
+    const outputFormat = await getOutputFormat(options.output);
+
+    switch (outputFormat) {
+      case 'json':
+        console.log(formatJson(playlists));
+        break;
+
+      case 'table':
+        const tableData = playlists.map(playlist => ({
+          id: playlist.id,
+          title: playlist.title,
+          channel: playlist.channelTitle,
+          items: playlist.itemCount,
+          privacy: playlist.privacyStatus,
+          published: formatDate(playlist.publishedAt),
+        }));
+        console.log(formatTable(tableData));
+        break;
+
+      case 'text':
+        playlists.forEach(playlist => {
+          console.log([
+            playlist.id,
+            playlist.title,
+            playlist.channelId,
+            playlist.channelTitle,
+            playlist.itemCount,
+            playlist.privacyStatus,
+            playlist.publishedAt,
+          ].join('\t'));
+        });
+        break;
+
+      case 'csv':
+        const csvData = playlists.map(playlist => ({
+          id: playlist.id,
+          title: playlist.title,
+          description: playlist.description,
+          channelId: playlist.channelId,
+          channelTitle: playlist.channelTitle,
+          itemCount: playlist.itemCount,
+          privacyStatus: playlist.privacyStatus,
+          publishedAt: playlist.publishedAt,
+        }));
+        console.log(formatCsv(csvData));
+        break;
+
+      case 'pretty':
+      default:
+        playlists.forEach((playlist, index) => {
+          if (index > 0) console.log(chalk.gray('─'.repeat(80)));
+          console.log('');
+
+          console.log(chalk.bold.cyan(`[${index + 1}] ${playlist.title}`));
+          console.log('');
+          console.log(chalk.gray('Playlist ID:  ') + chalk.yellow(playlist.id));
+          console.log(chalk.gray('Channel:      ') + playlist.channelTitle + chalk.gray(` (${playlist.channelId})`));
+          console.log(chalk.gray('Videos:       ') + formatNumber(playlist.itemCount));
+          console.log(chalk.gray('Privacy:      ') + playlist.privacyStatus);
+          console.log(chalk.gray('Published:    ') + formatDate(playlist.publishedAt));
+          console.log('');
+
+          if (playlist.description) {
+            console.log(chalk.bold('Description:'));
+            const description = playlist.description;
+            const preview = description.length > 150
+              ? description.substring(0, 150) + '...'
+              : description;
+            console.log('  ' + preview.replace(/\n/g, '\n  '));
+            console.log('');
+          }
+
+          console.log(chalk.gray('URL:          ') + chalk.blue(`https://youtube.com/playlist?list=${playlist.id}`));
+          console.log('');
+        });
+        break;
+    }
+  } catch (err) {
+    spinner.fail('Failed to fetch playlist information');
+    console.log('');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = getPlaylistsCommand;

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -1,0 +1,103 @@
+import ora from 'ora';
+import chalk from 'chalk';
+import { listChannelPlaylists } from '../lib/youtube';
+import { formatDate, formatNumber, error, setVerbose, debug } from '../lib/utils';
+import { getConfigValue, getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { OutputOption, LimitOption, VerboseOption } from '../types';
+
+async function listPlaylistsCommand(channelHandle: string | undefined, options: OutputOption & LimitOption & VerboseOption): Promise<void> {
+  // Enable verbose mode if requested
+  if (options.verbose) {
+    setVerbose(true);
+    debug('Verbose mode enabled');
+  }
+
+  const spinner = ora('Fetching channel playlists...').start();
+
+  try {
+    // Use provided channelHandle or load from config
+    let channel = channelHandle;
+    if (!channel) {
+      channel = await getConfigValue('default.channel');
+      if (!channel) {
+        spinner.fail('No channel specified');
+        console.log('');
+        error('Please provide a channel handle or set a default: staqan-yt config set default.channel @yourChannel');
+        process.exit(1);
+      }
+      debug(`Using default channel from config: ${channel}`);
+    }
+
+    const limit = parseInt(options.limit || '50');
+    debug(`Channel handle: ${channel}, limit: ${limit}`);
+
+    const playlists = await listChannelPlaylists(channel, limit);
+
+    spinner.succeed(`Found ${playlists.length} playlist(s)`);
+    console.log('');
+
+    const outputFormat = await getOutputFormat(options.output);
+
+    switch (outputFormat) {
+      case 'json':
+        console.log(formatJson(playlists));
+        break;
+
+      case 'table':
+        const tableData = playlists.map(playlist => ({
+          id: playlist.id,
+          title: playlist.title,
+          items: playlist.itemCount,
+          privacy: playlist.privacyStatus,
+          published: formatDate(playlist.publishedAt),
+        }));
+        console.log(formatTable(tableData));
+        break;
+
+      case 'text':
+        playlists.forEach(playlist => {
+          console.log([playlist.id, playlist.title, playlist.itemCount, playlist.privacyStatus, playlist.publishedAt].join('\t'));
+        });
+        break;
+
+      case 'csv':
+        const csvData = playlists.map(playlist => ({
+          id: playlist.id,
+          title: playlist.title,
+          description: playlist.description,
+          channelId: playlist.channelId,
+          channelTitle: playlist.channelTitle,
+          itemCount: playlist.itemCount,
+          privacyStatus: playlist.privacyStatus,
+          publishedAt: playlist.publishedAt,
+        }));
+        console.log(formatCsv(csvData));
+        break;
+
+      case 'pretty':
+      default:
+        playlists.forEach((playlist, index) => {
+          const privacyIndicator = playlist.privacyStatus === 'private'
+            ? chalk.red(' [Private]')
+            : playlist.privacyStatus === 'unlisted'
+              ? chalk.yellow(' [Unlisted]')
+              : '';
+          console.log(chalk.cyan(`[${index + 1}]`) + ' ' + chalk.bold(playlist.title) + privacyIndicator);
+          console.log('  ID: ' + chalk.yellow(playlist.id));
+          console.log('  Videos: ' + formatNumber(playlist.itemCount));
+          console.log('  Published: ' + formatDate(playlist.publishedAt));
+          console.log('  URL: ' + chalk.blue(`https://youtube.com/playlist?list=${playlist.id}`));
+          console.log('');
+        });
+        break;
+    }
+  } catch (err) {
+    spinner.fail('Failed to fetch playlists');
+    console.log('');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = listPlaylistsCommand;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -77,6 +77,32 @@ function parseVideoId(input: string): string {
 }
 
 /**
+ * Extract playlist ID from various input formats
+ */
+function parsePlaylistId(input: string): string {
+  // Playlist IDs are longer and typically start with PL
+  // If it looks like a raw playlist ID (no slashes or question marks), return as-is
+  if (!input.includes('/') && !input.includes('?')) {
+    return input;
+  }
+
+  // Extract from URL
+  const patterns = [
+    /(?:[?&]list=)([^&]+)/,
+    /youtube\.com\/playlist\?list=([^&\?\/]+)/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = input.match(pattern);
+    if (match) {
+      return match[1];
+    }
+  }
+
+  return input;
+}
+
+/**
  * Format date for display
  */
 function formatDate(dateString: string): string {
@@ -302,6 +328,7 @@ export {
   ensureConfigDir,
   parseChannelHandle,
   parseVideoId,
+  parsePlaylistId,
   formatDate,
   formatNumber,
   parseDuration,

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,7 +1,7 @@
 import { google, youtube_v3 } from 'googleapis';
 import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName } from './language';
-import { VideoInfo, VideoListItem, VideoLocalization, VideoType } from '../types';
+import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PlaylistInfo, PlaylistListItem } from '../types';
 import { debug } from './utils';
 
 /**
@@ -565,4 +565,126 @@ export {
   getAllVideoLocalizations,
   putVideoLocalization,
   updateVideoLocalization,
+  getPlaylistInfo,
+  getPlaylistsById,
+  listChannelPlaylists,
 };
+
+/**
+ * Get detailed playlist information
+ * @param playlistId - YouTube playlist ID
+ * @returns Playlist details with full metadata
+ */
+async function getPlaylistInfo(playlistId: string): Promise<PlaylistInfo> {
+  debug(`Fetching playlist info for: ${playlistId}`);
+  const youtube = await getYouTubeClient();
+
+  const response = await youtube.playlists.list({
+    part: ['snippet', 'contentDetails', 'status'],
+    id: [playlistId],
+  });
+
+  if (!response.data.items || response.data.items.length === 0) {
+    throw new Error(`Playlist not found: ${playlistId}`);
+  }
+
+  const item = response.data.items[0];
+  debug(`Retrieved playlist: ${item.snippet?.title}`);
+
+  return {
+    id: item.id!,
+    title: item.snippet!.title!,
+    description: item.snippet!.description!,
+    channelId: item.snippet!.channelId!,
+    channelTitle: item.snippet!.channelTitle!,
+    publishedAt: item.snippet!.publishedAt!,
+    itemCount: item.contentDetails!.itemCount || 0,
+    privacyStatus: item.status!.privacyStatus!,
+    thumbnails: item.snippet!.thumbnails!,
+  };
+}
+
+/**
+ * Get multiple playlists by ID (batch operation)
+ * @param playlistIds - Array of YouTube playlist IDs
+ * @returns Array of playlist details
+ */
+async function getPlaylistsById(playlistIds: string[]): Promise<PlaylistInfo[]> {
+  debug(`Fetching info for ${playlistIds.length} playlist(s)`, playlistIds);
+  const youtube = await getYouTubeClient();
+
+  // YouTube API allows up to 50 IDs per request
+  const results: PlaylistInfo[] = [];
+  const batchSize = 50;
+
+  for (let i = 0; i < playlistIds.length; i += batchSize) {
+    const batch = playlistIds.slice(i, i + batchSize);
+    debug(`Fetching batch ${Math.floor(i / batchSize) + 1}: ${batch.join(', ')}`);
+
+    const response = await youtube.playlists.list({
+      part: ['snippet', 'contentDetails', 'status'],
+      id: batch,
+    });
+
+    const items = response.data.items || [];
+    debug(`Retrieved ${items.length} playlist(s) from API`);
+
+    results.push(...items.map((item: youtube_v3.Schema$Playlist) => ({
+      id: item.id!,
+      title: item.snippet!.title!,
+      description: item.snippet!.description!,
+      channelId: item.snippet!.channelId!,
+      channelTitle: item.snippet!.channelTitle!,
+      publishedAt: item.snippet!.publishedAt!,
+      itemCount: item.contentDetails!.itemCount || 0,
+      privacyStatus: item.status!.privacyStatus!,
+      thumbnails: item.snippet!.thumbnails!,
+    })));
+  }
+
+  return results;
+}
+
+/**
+ * List all playlists for a channel
+ * @param channelHandle - Channel handle or ID
+ * @param maxResults - Maximum number of playlists to return
+ * @returns Array of playlist list items (lighter weight than full info)
+ */
+async function listChannelPlaylists(channelHandle: string, maxResults = 50): Promise<PlaylistListItem[]> {
+  debug(`Listing playlists for channel: ${channelHandle}, maxResults: ${maxResults}`);
+  const youtube = await getYouTubeClient();
+  const channelId = await getChannelId(channelHandle);
+
+  const playlists: PlaylistListItem[] = [];
+  let nextPageToken: string | undefined = undefined;
+
+  do {
+    debug(`Fetching page with token: ${nextPageToken || 'none'}`);
+    const playlistResponse: youtube_v3.Schema$PlaylistListResponse = (await youtube.playlists.list({
+      part: ['snippet', 'contentDetails', 'status'],
+      channelId,
+      maxResults: Math.min(50, maxResults - playlists.length),
+      pageToken: nextPageToken,
+    })).data;
+
+    const items = playlistResponse.items || [];
+    debug(`Retrieved ${items.length} playlist(s) from API`);
+
+    playlists.push(...items.map((item: youtube_v3.Schema$Playlist) => ({
+      id: item.id!,
+      title: item.snippet!.title!,
+      description: item.snippet!.description!,
+      channelId: item.snippet!.channelId!,
+      channelTitle: item.snippet!.channelTitle!,
+      publishedAt: item.snippet!.publishedAt!,
+      itemCount: item.contentDetails!.itemCount || 0,
+      privacyStatus: item.status!.privacyStatus!,
+    })));
+
+    nextPageToken = playlistResponse.nextPageToken || undefined;
+  } while (nextPageToken && playlists.length < maxResults);
+
+  debug(`Total playlists retrieved: ${playlists.length}`);
+  return playlists;
+}

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -553,23 +553,6 @@ async function updateVideoLocalization(videoId: string, language: string, title:
   }
 }
 
-export {
-  getYouTubeClient,
-  getChannelId,
-  getChannelVideos,
-  getVideoInfo,
-  updateVideoMetadata,
-  searchChannelVideos,
-  getVideoWithLocalizations,
-  getVideoLocalization,
-  getAllVideoLocalizations,
-  putVideoLocalization,
-  updateVideoLocalization,
-  getPlaylistInfo,
-  getPlaylistsById,
-  listChannelPlaylists,
-};
-
 /**
  * Get detailed playlist information
  * @param playlistId - YouTube playlist ID
@@ -688,3 +671,20 @@ async function listChannelPlaylists(channelHandle: string, maxResults = 50): Pro
   debug(`Total playlists retrieved: ${playlists.length}`);
   return playlists;
 }
+
+export {
+  getYouTubeClient,
+  getChannelId,
+  getChannelVideos,
+  getVideoInfo,
+  updateVideoMetadata,
+  searchChannelVideos,
+  getVideoWithLocalizations,
+  getVideoLocalization,
+  getAllVideoLocalizations,
+  putVideoLocalization,
+  updateVideoLocalization,
+  getPlaylistInfo,
+  getPlaylistsById,
+  listChannelPlaylists,
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,6 +7,30 @@ import { youtube_v3 } from 'googleapis';
 // Video type enum
 export type VideoType = 'short' | 'regular';
 
+// Playlist-related types
+export interface PlaylistInfo {
+  id: string;
+  title: string;
+  description: string;
+  channelId: string;
+  channelTitle: string;
+  publishedAt: string;
+  itemCount: number;
+  privacyStatus: string;
+  thumbnails: youtube_v3.Schema$ThumbnailDetails;
+}
+
+export interface PlaylistListItem {
+  id: string;
+  title: string;
+  description: string;
+  channelId: string;
+  channelTitle: string;
+  publishedAt: string;
+  itemCount: number;
+  privacyStatus: string;
+}
+
 // Video-related types
 export interface VideoInfo {
   id: string;


### PR DESCRIPTION
Implements #2. This PR adds three new commands for programmatic access to YouTube playlist metadata.

## Changes

- **get-playlist \<playlistId\>** - Get detailed metadata for a single playlist
- **get-playlists \<id1\> \<id2\> ...** - Batch get multiple playlists
- **list-playlists [channelHandle]** - List all playlists in a channel

All commands support the standard output formats: `json`, `table`, `text`, `pretty`, `csv`.

## AWS Naming Convention Compliance

- ✅ `get-playlist` - Singular, single-item operation
- ✅ `get-playlists` - Plural, batch operation
- ✅ `list-playlists` - Plural, list collection operation

## Features

- Uses default channel from config when `channelHandle` is omitted
- Handles pagination automatically for channels with 50+ playlists
- Outputs: Playlist ID, title, description, channel info, published date, item count, privacy status, thumbnails

## Additional Changes

- Updated `CLAUDE.md` with Git branch strategy section to prevent direct commits to main

## Testing

Tested with all output formats against real YouTube playlists and channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>