### PR TITLE
Add comment listing command (list-comments)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A powerful command-line interface for managing YouTube videos and metadata using
 - **Video Localizations** - Manage multilingual titles and descriptions (English, Japanese, Russian)
 - **Channel Search** - Search for specific videos within a channel
 - **Playlist Management** - List and retrieve YouTube playlists
+- **Comments** - List video comments for engagement monitoring
 - **Analytics & SEO** - Performance metrics, search terms, traffic sources, and CTR analysis
 - **Tags Management** - View and update video tags for better discoverability
 - **Thumbnail Access** - Retrieve video thumbnail URLs in all available qualities
@@ -1094,7 +1095,67 @@ staqan-yt list-playlists @mkbhd --output json
 
 ---
 
-#### 16. Get Video Analytics
+#### 16. List Comments
+
+```bash
+staqan-yt list-comments <videoId> [options]
+```
+
+List comments for a YouTube video.
+
+**Arguments:**
+- `videoId` - Video ID or URL
+
+**Options:**
+- `--output <format>` - Output format: `json`, `table`, `text`, `pretty` (default: `pretty`, or from config)
+- `-l, --limit <number>` - Limit number of results (default: 20)
+- `-s, --sort <order>` - Sort order: `top` (by relevance) or `new` (by recency, default: `top`)
+- `-v, --verbose` - Enable verbose logging
+
+**Examples:**
+
+```bash
+# List top 20 comments (default)
+staqan-yt list-comments dQw4w9WgXcQ
+
+# List 50 most recent comments
+staqan-yt list-comments dQw4w9WgXcQ --limit 50 --sort new
+
+# Export to CSV
+staqan-yt list-comments dQw4w9WgXcQ --output csv > comments.csv
+
+# JSON output
+staqan-yt list-comments dQw4w9WgXcQ --output json
+```
+
+**Sample Output:**
+```
+✔ Found 5 comment(s)
+
+[1] @YouTube
+  ID: Ugzge340dBgB75hWBm54AaABAg
+  can confirm: he never gave us up
+  ♥ Likes: 175045 | Replies: 1001
+  Posted: Apr 23, 2025
+
+[2] @Oatman69
+  ID: UgyEnXfdC-umwvTt8JF4AaABAg
+  Gonna flag this for nudity so I can rick roll the YouTube staff
+  ♥ Likes: 544998 | Replies: 587
+  Posted: Nov 23, 2019
+```
+
+**Use Cases:**
+- **Engagement monitoring** - See top comments on a video
+- **Moderation** - Review flagged comments
+- **Feedback analysis** - Export comments for sentiment analysis
+- **Community insights** - Understand audience response
+
+**Note:** This command fetches top-level comments only. Replies are counted but not expanded.
+
+---
+
+#### 17. Get Video Analytics
 
 ```bash
 staqan-yt get-video-analytics <videoId> [options]

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -25,6 +25,7 @@ import mcpCommand = require('../commands/mcp');
 import getPlaylistCommand = require('../commands/get-playlist');
 import getPlaylistsCommand = require('../commands/get-playlists');
 import listPlaylistsCommand = require('../commands/list-playlists');
+import listCommentsCommand = require('../commands/list-comments');
 
 // Get version - try to read from package.json, fallback to hardcoded version for compiled binaries
 let version = '1.3.3'; // Fallback version for compiled binaries
@@ -238,6 +239,16 @@ program
   .option('-l, --limit <number>', 'Limit number of results', '50')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(listPlaylistsCommand);
+
+// List comments command (plural - list collection)
+program
+  .command('list-comments <videoId>')
+  .description('List comments for a YouTube video')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
+  .option('-l, --limit <number>', 'Limit number of results', '20')
+  .option('-s, --sort <order>', 'Sort order: top or new', 'top')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action(listCommentsCommand);
 
 // Show help if no command provided
 if (!process.argv.slice(2).length) {

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -1,0 +1,111 @@
+import ora from 'ora';
+import chalk from 'chalk';
+import { listVideoComments } from '../lib/youtube';
+import { formatDate, error, setVerbose, debug } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { ListCommentsOptions } from '../types';
+
+async function listCommentsCommand(videoId: string, options: ListCommentsOptions = {}): Promise<void> {
+  // Enable verbose mode if requested
+  if (options.verbose) {
+    setVerbose(true);
+    debug('Verbose mode enabled');
+  }
+
+  // Validate video ID format (basic check)
+  if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+    error('Invalid video ID format. Video IDs should be 11 characters.');
+    process.exit(1);
+  }
+
+  // Determine sort order
+  const sortOrder = options.sort === 'new' ? 'time' : 'relevance';
+  const limit = parseInt(options.limit || '20');
+
+  debug(`Fetching comments for video: ${videoId}, limit: ${limit}, sort: ${sortOrder}`);
+
+  const spinner = ora(`Fetching comments for video ${videoId}...`).start();
+
+  try {
+    const comments = await listVideoComments(videoId, limit, sortOrder);
+
+    spinner.succeed(`Found ${comments.length} comment(s)`);
+    console.log('');
+
+    if (comments.length === 0) {
+      console.log(chalk.yellow('No comments found for this video.'));
+      return;
+    }
+
+    const outputFormat = await getOutputFormat(options.output);
+
+    switch (outputFormat) {
+      case 'json':
+        console.log(formatJson(comments));
+        break;
+
+      case 'table':
+        const tableData = comments.map(comment => ({
+          id: comment.id,
+          author: comment.authorName,
+          text: comment.textDisplay.substring(0, 50) + (comment.textDisplay.length > 50 ? '...' : ''),
+          likes: comment.likeCount,
+          replies: comment.replyCount,
+          date: formatDate(comment.publishedAt),
+        }));
+        console.log(formatTable(tableData));
+        break;
+
+      case 'text':
+        comments.forEach(comment => {
+          console.log([
+            comment.id,
+            comment.authorName,
+            comment.likeCount,
+            comment.replyCount,
+            comment.publishedAt,
+            comment.textOriginal.replace(/\n/g, ' '),
+          ].join('\t'));
+        });
+        break;
+
+      case 'csv':
+        const csvData = comments.map(comment => ({
+          id: comment.id,
+          videoId: comment.videoId,
+          authorName: comment.authorName,
+          authorChannelId: comment.authorChannelId,
+          textDisplay: comment.textDisplay,
+          textOriginal: comment.textOriginal,
+          likeCount: comment.likeCount,
+          replyCount: comment.replyCount,
+          isReply: comment.isReply,
+          parentId: comment.parentId,
+          publishedAt: comment.publishedAt,
+          updatedAt: comment.updatedAt,
+        }));
+        console.log(formatCsv(csvData));
+        break;
+
+      case 'pretty':
+      default:
+        comments.forEach((comment, index) => {
+          console.log(chalk.cyan(`[${index + 1}]`) + ' ' + chalk.bold(comment.authorName));
+          console.log('  ID: ' + chalk.yellow(comment.id));
+          console.log('  ' + chalk.gray(comment.textDisplay));
+          console.log('  ' + chalk.green('♥') + ' Likes: ' + chalk.yellow(comment.likeCount) + ' | ' + chalk.blue('Replies: ') + chalk.yellow(comment.replyCount));
+          console.log('  Posted: ' + formatDate(comment.publishedAt));
+          console.log('');
+        });
+        break;
+    }
+  } catch (err) {
+    spinner.fail('Failed to fetch comments');
+    console.log('');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = listCommentsCommand;

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import chalk from 'chalk';
 import { listVideoComments } from '../lib/youtube';
-import { formatDate, error, setVerbose, debug } from '../lib/utils';
+import { formatDate, error, setVerbose, debug, parseVideoId } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ListCommentsOptions } from '../types';
@@ -12,6 +12,9 @@ async function listCommentsCommand(videoId: string, options: ListCommentsOptions
     setVerbose(true);
     debug('Verbose mode enabled');
   }
+
+  // Parse video ID from URL or raw ID
+  videoId = parseVideoId(videoId);
 
   // Validate video ID format (basic check)
   if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,7 +1,7 @@
 import { google, youtube_v3 } from 'googleapis';
 import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName } from './language';
-import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PlaylistInfo, PlaylistListItem } from '../types';
+import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PlaylistInfo, PlaylistListItem, CommentInfo } from '../types';
 import { debug } from './utils';
 
 /**
@@ -672,6 +672,61 @@ async function listChannelPlaylists(channelHandle: string, maxResults = 50): Pro
   return playlists;
 }
 
+/**
+ * List comments for a video
+ * @param videoId - YouTube video ID
+ * @param maxResults - Maximum number of comments to return
+ * @param order - Sort order: 'relevance' (top) or 'time' (newest first)
+ * @returns Array of comment info
+ */
+async function listVideoComments(videoId: string, maxResults = 20, order: 'relevance' | 'time' = 'relevance'): Promise<CommentInfo[]> {
+  debug(`Listing comments for video: ${videoId}, maxResults: ${maxResults}, order: ${order}`);
+  const youtube = await getYouTubeClient();
+
+  const comments: CommentInfo[] = [];
+  let nextPageToken: string | undefined = undefined;
+
+  do {
+    debug(`Fetching comment thread page with token: ${nextPageToken || 'none'}`);
+    const response: youtube_v3.Schema$CommentThreadListResponse = (await youtube.commentThreads.list({
+      part: ['snippet'],
+      videoId,
+      maxResults: Math.min(100, maxResults - comments.length),
+      order,
+      pageToken: nextPageToken,
+    })).data;
+
+    const items = response.items || [];
+    debug(`Retrieved ${items.length} comment thread(s) from API`);
+
+    // Extract top-level comments from threads
+    comments.push(...items.map((item: youtube_v3.Schema$CommentThread) => {
+      const topLevelComment = item.snippet!.topLevelComment!;
+      const snippet = topLevelComment.snippet!;
+
+      return {
+        id: topLevelComment.id!,
+        videoId: snippet.videoId!,
+        authorName: snippet.authorDisplayName!,
+        authorChannelId: snippet.authorChannelId!.value!,
+        textDisplay: snippet.textDisplay || '',
+        textOriginal: snippet.textOriginal || '',
+        likeCount: snippet.likeCount || 0,
+        replyCount: item.snippet!.totalReplyCount || 0,
+        isReply: false,
+        parentId: null,
+        publishedAt: snippet.publishedAt!,
+        updatedAt: snippet.updatedAt!,
+      };
+    }));
+
+    nextPageToken = response.nextPageToken || undefined;
+  } while (nextPageToken && comments.length < maxResults);
+
+  debug(`Total comments retrieved: ${comments.length}`);
+  return comments;
+}
+
 export {
   getYouTubeClient,
   getChannelId,
@@ -687,4 +742,5 @@ export {
   getPlaylistInfo,
   getPlaylistsById,
   listChannelPlaylists,
+  listVideoComments,
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -31,6 +31,22 @@ export interface PlaylistListItem {
   privacyStatus: string;
 }
 
+// Comment-related types
+export interface CommentInfo {
+  id: string;
+  videoId: string;
+  authorName: string;
+  authorChannelId: string;
+  textDisplay: string;
+  textOriginal: string;
+  likeCount: number;
+  replyCount: number;
+  isReply: boolean;
+  parentId: string | null;
+  publishedAt: string;
+  updatedAt: string;
+}
+
 // Video-related types
 export interface VideoInfo {
   id: string;
@@ -159,6 +175,11 @@ export interface UpdateThumbnailOptions extends VerboseOption {
   file: string;
   dryRun?: boolean;
   yes?: boolean;
+}
+
+// Comments command options
+export interface ListCommentsOptions extends OutputOption, VerboseOption, LimitOption {
+  sort?: 'top' | 'new';
 }
 
 // OAuth types


### PR DESCRIPTION
## Summary

Implements the `list-comments` command for retrieving YouTube video comments using the YouTube Data API v3 `commentThreads.list` endpoint.

## Changes

- **New command**: `staqan-yt list-comments <videoId>`
- **New type**: `CommentInfo` in `types/index.ts`
- **New function**: `listVideoComments()` in `lib/youtube.ts`

## Features

- List top-level comments for any video
- Sort by relevance (top) or recency (new) via `--sort` flag
- Configurable limit via `--limit` flag (default: 20)
- Pagination support for videos with 100+ comments
- All output formats supported: json, table, text, pretty, csv
- Video ID validation (11 character format check)
- Detailed comment metadata: author, likes, replies, dates

## Examples

```bash
# List top 20 comments (default)
staqan-yt list-comments dQw4w9WgXcQ

# List 50 most recent comments
staqan-yt list-comments dQw4w9WgXcQ --limit 50 --sort new

# Export to CSV
staqan-yt list-comments dQw4w9gXcQ --output csv > comments.csv
```

## Testing

Tested with real YouTube video (dQw4w9WgXcQ - Rick Roll):
- Verified all output formats (json, table, text, pretty, csv)
- Verified sort orders (top, new)
- Verified pagination
- Verified video ID validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)