### PR TITLE
Fix: Remove unused 'err' variables in catch blocks

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -32,7 +32,7 @@ let version = '1.3.6'; // Fallback version for compiled binaries
 try {
   const packageJson = require(path.join(__dirname, '../../package.json'));
   version = packageJson.version;
-} catch (err) {
+} catch {
   // Running as compiled binary - use hardcoded version
 }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -48,7 +48,7 @@ export async function loadConfig(): Promise<Config> {
         ...config.default,
       },
     };
-  } catch (err) {
+  } catch {
     // File doesn't exist or is invalid - return defaults
     return { ...DEFAULT_CONFIG };
   }


### PR DESCRIPTION
## Summary
- Remove unused 'err' parameter in lib/config.ts (line 51)
- Remove unused 'err' parameter in bin/staqan-yt.ts (line 35)
- Both catch blocks intentionally ignore errors and use fallback behavior
- Resolves ESLint warnings for unused variables

Closes #7
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)