### PR TITLE
Fix: Add scripts/ to TypeScript project includes (Issue #9)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "bin/**/*",
     "lib/**/*",
     "commands/**/*",
-    "types/**/*"
+    "types/**/*",
+    "scripts/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

- **Added** `scripts/**/*` to `tsconfig.json` include array
- **Fixes** ESLint parsing error for `scripts/sync-version.ts`
- **Ensures** build scripts are type-checked and linted

## Problem

The script `scripts/sync-version.ts` was matching ESLint's `**/*.ts` pattern but was excluded from the TypeScript project configuration. This caused a parser error when ESLint tried to parse the file because `parserOptions.project` pointed to a TypeScript project that excluded this file.

## Solution

Added `"scripts/**/*"` to the `include` array in `tsconfig.json` so that:
1. ESLint can properly parse and lint the script
2. The script is type-checked during development
3. Consistent code quality is maintained across all TypeScript files

## Changes

- `tsconfig.json`: Added `"scripts/**/*"` to include array

## Verification

- ✅ `npm run lint` - Passes without errors for scripts/sync-version.ts
- ✅ `npm run type-check` - Type-checks the scripts directory
- ✅ `npm run build` - Compiles all files successfully

## Related Issues

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)