### PR TITLE
Feature: Add get-channel-analytics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1434,7 +1434,7 @@ Total: 10 result(s)
 - Requires YouTube Analytics API to be enabled in Google Cloud Console
 - Requires re-authentication after enabling analytics API: `staqan-yt auth`
 - Channel must have sufficient views and activity to report analytics
-
+- **Demographic Limitation:** The `demographics` report type (age, gender) requires channel owner permissions and may not be available for all channels, especially smaller or newer channels. If unavailable, try: `devices`, `geography`, `traffic-sources`, or `subscription-status`.
 ---
 
 ### Localization Features

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A powerful command-line interface for managing YouTube videos and metadata using
 - **Channel Search** - Search for specific videos within a channel
 - **Playlist Management** - List and retrieve YouTube playlists
 - **Comments** - List video comments for engagement monitoring
-- **Analytics & SEO** - Performance metrics, search terms, traffic sources, and CTR analysis
+- **Channel Analytics** - Channel-level analytics reports (demographics, devices, geography, traffic sources, subscription status)
+- **Video Analytics & SEO** - Performance metrics, search terms, traffic sources, and CTR analysis
 - **Tags Management** - View and update video tags for better discoverability
 - **Thumbnail Access** - Retrieve video thumbnail URLs in all available qualities
 - **Multiple Output Formats** - JSON, table, text, pretty, or CSV output for any workflow
@@ -170,6 +171,7 @@ The MCP server exposes **15 operations** covering all CLI functionality:
 - `youtube_update_localization` - Update existing localization
 
 **Analytics:**
+- `youtube_get_channel_analytics` - Get channel-level analytics reports (demographics, devices, geography, etc.)
 - `youtube_get_video_analytics` - Get performance metrics (views, watch time, CTR, etc.)
 - `youtube_get_search_terms` - Get YouTube search terms that led to video
 - `youtube_get_traffic_sources` - Get traffic source breakdown
@@ -1358,6 +1360,80 @@ Total Views: 51
 - **Playlists** - Found in playlists
 - **Notifications** - Push notifications
 - **Subscriber Feed** - Subscriber home feed
+
+---
+
+#### 16. Get Channel Analytics
+```bash
+staqan-yt get-channel-analytics [channelHandle] [options]
+```
+
+Get channel-level analytics reports from YouTube Analytics API (demographics, devices, geography, etc.).
+
+**Arguments:**
+- `channelHandle` - (Optional) Channel @handle, username, or URL. Uses `default.channel` from config if not provided.
+
+**Options:**
+- `--report <type>` - Predefined report type: `demographics`, `devices`, `geography`, `traffic-sources`, or `subscription-status`
+- `--start-date <date>` - Start date (YYYY-MM-DD), defaults to 30 days ago
+- `--end-date <date>` - End date (YYYY-MM-DD), defaults to today
+- `--dimensions <dims>` - Custom dimensions (comma-separated, requires `--metrics`)
+- `--metrics <metrics>` - Custom metrics (comma-separated, requires `--dimensions`)
+- `--output <format>` - Output format: `json`, `table`, `text`, `pretty` (default: `pretty`), or from config
+- `-v, --verbose` - Enable verbose output with debug information
+
+**Predefined Report Types:**
+
+| Report Type | Dimensions | Metrics |
+|-------------|------------|---------|
+| demographics | ageGroup,gender | views,estimatedMinutesWatched |
+| devices | deviceType,operatingSystem | views,estimatedMinutesWatched |
+| geography | country | views,estimatedMinutesWatched |
+| traffic-sources | insightTrafficSourceType | views,estimatedMinutesWatched |
+| subscription-status | subscribedStatus | views,estimatedMinutesWatched |
+
+**Examples:**
+```bash
+# Predefined reports
+staqan-yt get-channel-analytics @channel --report demographics
+staqan-yt get-channel-analytics @channel --report devices --output csv
+
+# Custom query
+staqan-yt get-channel-analytics @channel \
+  --dimensions "deviceType,operatingSystem" \
+  --metrics "views,estimatedMinutesWatched" \
+  --start-date 2025-01-01 \
+  --end-date 2025-01-31
+
+# Using config default channel
+staqan-yt get-channel-analytics --report geography
+```
+
+**Sample Output:**
+```
+✓ Analytics data retrieved
+
+My Channel
+Channel ID: UCxxxxxxxxxxxxxxxxxx
+Report Type: demographics
+Date Range: 2025-01-13 to 2026-02-13
+
+Age Group:    age13-17
+Views:        12,345
+Watch Time:    234,567
+
+Age Group:    age18-24
+Views:        45,678
+Watch Time:    890,123
+
+...
+Total: 10 result(s)
+```
+
+**Important:**
+- Requires YouTube Analytics API to be enabled in Google Cloud Console
+- Requires re-authentication after enabling analytics API: `staqan-yt auth`
+- Channel must have sufficient views and activity to report analytics
 
 ---
 

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -29,6 +29,7 @@ import listCommentsCommand = require('../commands/list-comments');
 import getChannelCommand = require('../commands/get-channel');
 import listCaptionsCommand = require('../commands/list-captions');
 import getCaptionCommand = require('../commands/get-caption');
+import getChannelAnalyticsCommand = require('../commands/get-channel-analytics');
 
 // Get version - try to read from package.json, fallback to hardcoded version for compiled binaries
 let version = '1.3.12'; // Fallback version for compiled binaries
@@ -279,6 +280,31 @@ program
   .option('--format <format>', 'Caption format: srt, vtt, sbv, srv2, ttml, json (default: json)', 'json')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(getCaptionCommand);
+
+// Channel analytics command (singular - single channel report)
+program
+  .command('get-channel-analytics [channelHandle]')
+  .description('Get channel-level analytics reports (demographics, devices, geography, etc.)')
+  .option('--report <type>', 'Predefined report type: demographics, devices, geography, traffic-sources, subscription-status')
+  .option('--start-date <date>', 'Start date (YYYY-MM-DD), defaults to 30 days ago')
+  .option('--end-date <date>', 'End date (YYYY-MM-DD), defaults to today')
+  .option('--dimensions <dims>', 'Custom dimensions (comma-separated, requires --metrics)')
+  .option('--metrics <metrics>', 'Custom metrics (comma-separated, requires --dimensions)')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action((channelHandle: string | undefined, options: { report?: 'demographics' | 'devices' | 'geography' | 'traffic-sources' | 'subscription-status'; start_date?: string; end_date?: string; dimensions?: string; metrics?: string; output?: 'json' | 'table' | 'text' | 'pretty' | 'csv'; verbose?: boolean }) => {
+    // Convert kebab-case to camelCase for options
+    const normalizedOptions = {
+      report: options.report,
+      startDate: options.start_date,
+      endDate: options.end_date,
+      dimensions: options.dimensions,
+      metrics: options.metrics,
+      output: options.output,
+      verbose: options.verbose,
+    };
+    getChannelAnalyticsCommand(channelHandle, normalizedOptions);
+  });
 
 // Show help if no command provided
 if (!process.argv.slice(2).length) {

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -296,6 +296,11 @@ async function getChannelAnalyticsCommand(channelHandle: string | undefined, opt
         error('Invalid analytics request. Check your date range, dimensions, and metrics.');
         console.log('');
         console.log('Valid report types: demographics, devices, geography, traffic-sources, subscription-status');
+      } else if (errorMessage.includes('not supported')) {
+        error('Report type not available for this channel.');
+        console.log('');
+        console.log(chalk.dim('Demographic data (age, gender) requires channel owner permissions.'));
+        console.log(chalk.dim('Try other report types: devices, geography, traffic-sources, subscription-status'));
       } else {
         error(errorMessage);
       }

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -1,0 +1,313 @@
+import ora from 'ora';
+import chalk from 'chalk';
+import { getAuthenticatedClient } from '../lib/auth';
+import { google } from 'googleapis';
+import { parseChannelHandle, error, setVerbose, debug, formatNumber } from '../lib/utils';
+import { getConfigValue } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { ChannelAnalyticsOptions } from '../types';
+
+// Predefined report type mappings
+const REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
+  demographics: {
+    dimensions: 'ageGroup,gender',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  devices: {
+    dimensions: 'deviceType,operatingSystem',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  geography: {
+    dimensions: 'country',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  'traffic-sources': {
+    dimensions: 'insightTrafficSourceType',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  'subscription-status': {
+    dimensions: 'subscribedStatus',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+};
+
+async function getChannelAnalyticsCommand(channelHandle: string | undefined, options: ChannelAnalyticsOptions): Promise<void> {
+  // Enable verbose mode if requested
+  if (options.verbose) {
+    setVerbose(true);
+    debug('Verbose mode enabled');
+  }
+
+  const spinner = ora('Fetching channel analytics...').start();
+
+  try {
+    // Determine channel ID
+    let channelId = channelHandle;
+
+    if (!channelId) {
+      // Try to get from config
+      const defaultChannel = await getConfigValue('default.channel');
+      if (!defaultChannel) {
+        spinner.fail('Channel not specified');
+        error('No channel provided and no default channel configured.');
+        console.log('');
+        console.log('Provide a channel handle:');
+        console.log('  staqan-yt get-channel-analytics @channel');
+        console.log('');
+        console.log('Or set a default channel:');
+        console.log('  staqan-yt config set default.channel @channel');
+        process.exit(1);
+      }
+      channelId = defaultChannel;
+    }
+
+    debug('Channel ID', channelId);
+    const parsedChannel = parseChannelHandle(channelId);
+    debug('Parsed channel', parsedChannel);
+
+    // Get authenticated client
+    const auth = await getAuthenticatedClient();
+    const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+
+    // Get channel info for title
+    const youtube = google.youtube({ version: 'v3', auth });
+    let channelTitle = '';
+    let actualChannelId = parsedChannel.value;
+
+    try {
+      // Resolve channel handle to ID if needed
+      if (parsedChannel.type === 'handle') {
+        debug('Looking up channel by handle:', parsedChannel.value);
+        const channelResponse = await youtube.channels.list({
+          part: ['id', 'snippet'],
+          forHandle: parsedChannel.value.replace('@', ''),
+        });
+
+        if (channelResponse.data.items && channelResponse.data.items.length > 0) {
+          actualChannelId = channelResponse.data.items[0].id!;
+          channelTitle = channelResponse.data.items[0].snippet?.title || '';
+        } else {
+          spinner.fail('Channel not found');
+          error(`Channel not found: ${channelId}`);
+          process.exit(1);
+        }
+      } else {
+        // Get channel by ID
+        const channelResponse = await youtube.channels.list({
+          part: ['snippet'],
+          id: [parsedChannel.value],
+        });
+
+        if (channelResponse.data.items && channelResponse.data.items.length > 0) {
+          channelTitle = channelResponse.data.items[0].snippet?.title || '';
+        }
+      }
+
+      debug('Resolved channel ID:', actualChannelId);
+      debug('Channel title:', channelTitle);
+    } catch (err) {
+      debug('Error fetching channel info:', err);
+    }
+
+    spinner.succeed('Channel information retrieved');
+
+    // Determine date range (default: last 30 days)
+    const endDate = options.endDate || new Date().toISOString().split('T')[0];
+    const startDate = options.startDate ||
+      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
+    debug(`Date range: ${startDate} to ${endDate}`);
+
+    // Determine dimensions and metrics based on report type or custom
+    let dimensions: string;
+    let metrics: string;
+    let reportName = '';
+
+    if (options.report) {
+      // Use predefined report type
+      const reportConfig = REPORT_TYPES[options.report];
+      if (!reportConfig) {
+        spinner.fail('Invalid report type');
+        error(`Unknown report type: ${options.report}`);
+        process.exit(1);
+      }
+      dimensions = reportConfig.dimensions;
+      metrics = reportConfig.metrics;
+      reportName = options.report;
+      debug(`Using predefined report: ${options.report}`);
+      debug(`Dimensions: ${dimensions}, Metrics: ${metrics}`);
+    } else if (options.dimensions && options.metrics) {
+      // Custom query
+      dimensions = options.dimensions;
+      metrics = options.metrics;
+      reportName = 'custom';
+      debug('Using custom dimensions and metrics');
+    } else {
+      spinner.fail('Report specification required');
+      error('Must specify either --report type or both --dimensions and --metrics');
+      console.log('');
+      console.log('Predefined report types:');
+      console.log('  demographics    - Audience age and gender');
+      console.log('  devices         - Device and OS breakdown');
+      console.log('  geography       - Top countries');
+      console.log('  traffic-sources - Traffic source types');
+      console.log('  subscription-status - Subscribed vs non-subscribed');
+      console.log('');
+      console.log('Or use custom query:');
+      console.log('  --dimensions "deviceType,operatingSystem" --metrics "views,estimatedMinutesWatched"');
+      process.exit(1);
+    }
+
+    // Fetch analytics
+    const analyticsSpinner = ora('Fetching analytics data...').start();
+
+    try {
+      const response = await youtubeAnalytics.reports.query({
+        ids: `channel==${actualChannelId}`,
+        startDate,
+        endDate,
+        dimensions,
+        metrics,
+        sort: '-views', // Sort by views descending
+      });
+
+      analyticsSpinner.succeed('Analytics data retrieved');
+
+      if (!response.data.rows || response.data.rows.length === 0) {
+        console.log('');
+        console.log(chalk.yellow('No analytics data available for this channel and time period.'));
+        console.log('');
+        console.log(chalk.dim('Note: Channel must have sufficient views and activity.'));
+        console.log('');
+        return;
+      }
+
+      const columnHeaders = response.data.columnHeaders || [];
+      const rows = response.data.rows || [];
+
+      debug(`Retrieved ${rows.length} row(s)`);
+      debug('Column headers:', columnHeaders);
+
+      // Format output
+      const outputFormat = options.output;
+
+      if (outputFormat === 'json') {
+        const jsonData = {
+          channelId: actualChannelId,
+          channelTitle,
+          reportType: reportName,
+          dateRange: { startDate, endDate },
+          columnHeaders: columnHeaders.map(h => h.name),
+          rows,
+        };
+        console.log(formatJson(jsonData));
+      } else if (outputFormat === 'csv') {
+        // Build CSV data
+        const csvData: Record<string, unknown>[] = [];
+        for (const row of rows) {
+          const rowData: Record<string, unknown> = {};
+          for (let i = 0; i < row.length; i++) {
+            const headerName = columnHeaders[i]?.name || `column_${i}`;
+            rowData[headerName] = row[i];
+          }
+          csvData.push(rowData);
+        }
+        console.log(formatCsv(csvData));
+      } else if (outputFormat === 'table') {
+        // Build table data
+        const tableData: Record<string, string>[] = [];
+        for (const row of rows) {
+          const rowData: Record<string, string> = {};
+          for (let i = 0; i < row.length; i++) {
+            const headerName = columnHeaders[i]?.name || `column_${i}`;
+            const val = row[i];
+            rowData[headerName] = typeof val === 'number' ? formatNumber(val) : String(val);
+          }
+          tableData.push(rowData);
+        }
+        console.log(formatTable(tableData));
+      } else if (outputFormat === 'text') {
+        // Tab-delimited output
+        const headerNames = columnHeaders.map(h => h.name || '').join('\t');
+        console.log(headerNames);
+        for (const row of rows) {
+          console.log(row.join('\t'));
+        }
+      } else {
+        // Pretty output (default)
+        console.log('');
+        if (channelTitle) {
+          console.log(chalk.bold.cyan(channelTitle));
+          console.log(chalk.gray(`Channel ID: ${actualChannelId}`));
+        } else {
+          console.log(chalk.bold.cyan(`Channel: ${actualChannelId}`));
+        }
+        console.log(chalk.gray(`Report Type: ${reportName}`));
+        console.log(chalk.gray(`Date Range: ${startDate} to ${endDate}`));
+        console.log('');
+
+        // Display each row
+        for (let i = 0; i < rows.length; i++) {
+          const row = rows[i];
+          if (i > 0) {
+            console.log(chalk.gray('─'.repeat(80)));
+            console.log('');
+          }
+
+          for (let j = 0; j < row.length; j++) {
+            const value = row[j];
+            const header = columnHeaders[j];
+            const headerName = header?.name || `Column ${j}`;
+            const formattedHeader = headerName
+              .replace(/([a-z])/g, ' $1')
+              .replace(/^./, str => str.toUpperCase())
+              .trim();
+
+            // Format value
+            let formattedValue: string;
+            if (typeof value === 'number') {
+              formattedValue = formatNumber(value);
+            } else {
+              formattedValue = String(value);
+            }
+
+            console.log(chalk.gray(`${formattedHeader}:`) + ' ' + chalk.white(formattedValue));
+          }
+
+          console.log('');
+        }
+
+        console.log(chalk.dim(`Total: ${rows.length} result(s)`));
+        console.log('');
+      }
+    } catch (analyticsErr) {
+      analyticsSpinner.fail('Failed to fetch analytics');
+      console.log('');
+      const errorMessage = (analyticsErr as Error).message || '';
+
+      // Handle common errors
+      if (errorMessage.includes('403') || errorMessage.includes('insufficientPermissions')) {
+        error('YouTube Analytics API access denied. Make sure you have:');
+        console.log('  1. Enabled YouTube Analytics API in Google Cloud Console');
+        console.log('  2. Re-authenticated with: staqan-yt auth');
+        console.log('');
+        console.log('Required scope: https://www.googleapis.com/auth/yt-analytics.readonly');
+      } else if (errorMessage.includes('400')) {
+        error('Invalid analytics request. Check your date range, dimensions, and metrics.');
+        console.log('');
+        console.log('Valid report types: demographics, devices, geography, traffic-sources, subscription-status');
+      } else {
+        error(errorMessage);
+      }
+
+      process.exit(1);
+    }
+  } catch (err) {
+    spinner.fail('Failed to fetch channel analytics');
+    console.log('');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = getChannelAnalyticsCommand;

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -199,6 +199,41 @@ const TOOLS: Tool[] = [
     },
   },
   {
+    name: 'youtube_get_channel_analytics',
+    description: 'Get channel-level analytics reports from YouTube Analytics API (demographics, devices, geography, traffic sources, subscription status, etc.)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        channelHandle: {
+          type: 'string',
+          description: 'Channel handle (e.g., @mkbhd) or channel ID',
+        },
+        report: {
+          type: 'string',
+          description: 'Predefined report type: demographics, devices, geography, traffic-sources, subscription-status',
+          enum: ['demographics', 'devices', 'geography', 'traffic-sources', 'subscription-status'],
+        },
+        dimensions: {
+          type: 'string',
+          description: 'Custom dimensions (comma-separated, requires metrics)',
+        },
+        metrics: {
+          type: 'string',
+          description: 'Custom metrics (comma-separated, requires dimensions)',
+        },
+        startDate: {
+          type: 'string',
+          description: 'Start date in YYYY-MM-DD format (defaults to 30 days ago)',
+        },
+        endDate: {
+          type: 'string',
+          description: 'End date in YYYY-MM-DD format (defaults to today)',
+        },
+      },
+      required: [],
+    },
+  },
+  {
     name: 'youtube_get_video_analytics',
     description: 'Get video performance analytics including views, watch time, average view duration, likes, comments, and more',
     inputSchema: {
@@ -477,6 +512,107 @@ async function handleToolCall(name: string, args: any) {
           {
             type: 'text',
             text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+    case 'youtube_get_channel_analytics': {
+      const auth = await getAuthenticatedClient();
+      const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+      const youtube = google.youtube({ version: 'v3', auth });
+
+      // Resolve channel ID
+      let channelId = args.channelHandle;
+      if (!channelId) {
+        channelId = await getConfigValue('default.channel');
+      }
+      if (!channelId) {
+        throw new Error('No channel specified and no default channel configured.');
+      }
+
+      const parsedChannel = channelId.startsWith('@')
+        ? { type: 'handle', value: channelId }
+        : { type: 'id', value: channelId };
+
+      let actualChannelId = parsedChannel.value;
+
+      // Resolve handle to ID if needed
+      if (parsedChannel.type === 'handle') {
+        const channelResponse = await youtube.channels.list({
+          part: ['id'],
+          forHandle: parsedChannel.value.replace('@', ''),
+        });
+
+        if (channelResponse.data.items && channelResponse.data.items.length > 0) {
+          actualChannelId = channelResponse.data.items[0].id!;
+        }
+      }
+
+      // Determine date range (default: last 30 days)
+      const endDate = args.endDate || new Date().toISOString().split('T')[0];
+      const startDate = args.startDate ||
+        new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
+      // Determine dimensions and metrics
+      let dimensions: string;
+      let metrics: string;
+
+      if (args.report) {
+        const REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
+          demographics: { dimensions: 'ageGroup,gender', metrics: 'views,estimatedMinutesWatched' },
+          devices: { dimensions: 'deviceType,operatingSystem', metrics: 'views,estimatedMinutesWatched' },
+          geography: { dimensions: 'country', metrics: 'views,estimatedMinutesWatched' },
+          'traffic-sources': { dimensions: 'insightTrafficSourceType', metrics: 'views,estimatedMinutesWatched' },
+          'subscription-status': { dimensions: 'subscribedStatus', metrics: 'views,estimatedMinutesWatched' },
+        };
+        const reportConfig = REPORT_TYPES[args.report];
+        if (!reportConfig) {
+          throw new Error(`Unknown report type: ${args.report}`);
+        }
+        dimensions = reportConfig.dimensions;
+        metrics = reportConfig.metrics;
+      } else if (args.dimensions && args.metrics) {
+        dimensions = args.dimensions;
+        metrics = args.metrics;
+      } else {
+        throw new Error('Must specify either --report type or both --dimensions and --metrics');
+      }
+
+      // Fetch analytics
+      const response = await youtubeAnalytics.reports.query({
+        ids: `channel==${actualChannelId}`,
+        startDate,
+        endDate,
+        dimensions,
+        metrics,
+        sort: '-views',
+      });
+
+      if (!response.data.rows || response.data.rows.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'No analytics data available for this channel and time period.',
+            },
+          ],
+        };
+      }
+
+      const columnHeaders = response.data.columnHeaders || [];
+      const rows = response.data.rows || [];
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              channelId: actualChannelId,
+              reportType: args.report || 'custom',
+              dateRange: { startDate, endDate },
+              columnHeaders: columnHeaders.map(h => h.name),
+              rows,
+            }, null, 2),
           },
         ],
       };

--- a/types/index.ts
+++ b/types/index.ts
@@ -266,6 +266,15 @@ export interface GetCaptionOptions extends OutputOption, VerboseOption {
   format?: CaptionFormat;
 }
 
+// Channel analytics command options
+export interface ChannelAnalyticsOptions extends OutputOption, VerboseOption {
+  report?: 'demographics' | 'devices' | 'geography' | 'traffic-sources' | 'subscription-status';
+  startDate?: string;
+  endDate?: string;
+  dimensions?: string;
+  metrics?: string;
+}
+
 // Utility types
 export interface ChannelHandle {
   type: 'handle' | 'id';


### PR DESCRIPTION
## Summary
Implements the `get-channel-analytics` command to fetch channel-level analytics reports from YouTube Analytics API.

## Changes
- ✅ New command: `get-channel-analytics`
- ✅ Predefined report types: demographics, devices, geography, traffic-sources, subscription-status
- ✅ Custom query support: `--dimensions` and `--metrics`
- ✅ Default date range: last 30 days
- ✅ All output formats: json, table, text, pretty, csv
- ✅ Resolves channel handles to IDs automatically

## Predefined Report Types
| Report Type | Dimensions | Metrics |
|-------------|------------|---------|
| demographics | ageGroup,gender | views,estimatedMinutesWatched |
| devices | deviceType,operatingSystem | views,estimatedMinutesWatched |
| geography | country | views,estimatedMinutesWatched |
| traffic-sources | insightTrafficSourceType | views,estimatedMinutesWatched |
| subscription-status | subscribedStatus | views,estimatedMinutesWatched |

## Usage Examples
```bash
# Predefined reports
staqan-yt get-channel-analytics @channel --report demographics
staqan-yt get-channel-analytics @channel --report devices --output csv

# Custom query
staqan-yt get-channel-analytics @channel \
  --dimensions "deviceType,operatingSystem" \
  --metrics "views,estimatedMinutesWatched" \
  --start-date 2025-01-01 \
  --end-date 2025-01-31
```

## Testing
- Command help output verified
- All output formats implemented
- Error handling for missing channel/report type
- Channel resolution from handle to ID

Resolves #5