### PR TITLE
Fix: Output format support and help command for reporting API commands

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -42,18 +42,33 @@ import fetchReportsCommand = require('../commands/fetch-reports');
 // then forward args to the properly-typed command function
 function withHelpWrapper(commandName: string, actionFn: (...args: any[]) => Promise<void> | void) {
   return async (...args: any[]) => {
-    // Check if any argument is "help" (but not in options)
+    // Check if "help" is in the command arguments (before Commander's validation)
+    // This works even for commands with required options
+    const commandIndex = process.argv.indexOf(commandName);
+    if (commandIndex !== -1 && process.argv[commandIndex + 1] === 'help') {
+      // Find the command and show its help
+      const cmd = program.commands.find((c: Command) => c.name() === commandName);
+      if (cmd) {
+        cmd.outputHelp();
+        process.exit(0);
+      }
+      return;
+    }
+
+    // Also check if any argument passed to the action is "help" (for commands without positional args)
     for (const arg of args) {
       // Only check string arguments that aren't part of options object
       if (typeof arg === 'string' && arg === 'help') {
         // Find the command and show its help
         const cmd = program.commands.find((c: Command) => c.name() === commandName);
         if (cmd) {
-          cmd.help();
+          cmd.outputHelp();
+          process.exit(0);
         }
         return;
       }
     }
+
     // Otherwise, execute the original action
     return actionFn(...args);
   };
@@ -359,17 +374,17 @@ program
 program
   .command('list-report-types')
   .description('List all available YouTube Reporting API report types')
-  .option('--output <format>', 'Output format: json, table, text')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
-  .action(listReportTypesCommand);
+  .action(withHelpWrapper('list-report-types', listReportTypesCommand));
 
 program
   .command('list-report-jobs')
   .description('List YouTube Reporting API jobs with status and expiration warnings')
   .option('--type <id>', 'Filter by report type ID (e.g., channel_reach_basic_a1)')
-  .option('--output <format>', 'Output format: json, table, text')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
-  .action(listReportJobsCommand);
+  .action(withHelpWrapper('list-report-jobs', listReportJobsCommand));
 
 program
   .command('get-report-data')
@@ -380,7 +395,7 @@ program
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
   .option('--output <format>', 'Output format: json, csv', 'json')
   .option('-v, --verbose', 'Enable verbose output with debug information')
-  .action(getReportDataCommand);
+  .action(withHelpWrapper('get-report-data', getReportDataCommand));
 
 program
   .command('fetch-reports')
@@ -392,7 +407,7 @@ program
   .option('-f, --force', 'Re-download even if cached')
   .option('--verify', 'Verify cached file completeness')
   .option('-v, --verbose', 'Enable verbose output with debug information')
-  .action(fetchReportsCommand);
+  .action(withHelpWrapper('fetch-reports', fetchReportsCommand));
 
 // Show help if no command provided
 if (!process.argv.slice(2).length) {
@@ -411,18 +426,23 @@ const shutdownHandler = (signal: string) => {
 process.on('SIGINT', () => shutdownHandler('SIGINT'));
 process.on('SIGTERM', () => shutdownHandler('SIGTERM'));
 
-// Error handling: suppress stack traces, show only user-friendly messages
-// Use configureOutput to prevent Commander from writing errors to stderr
-program.configureOutput({
-  writeErr: (_str) => {
-    // Suppress Commander's default error output
-    // We'll display user-friendly errors in exitOverride below
-  },
-  writeOut: (str) => process.stdout.write(str)
-});
-
 program.exitOverride((err) => {
   const error = err as { code?: string; message?: string; exitCode?: number };
+
+  // Check if user is asking for help (even with missing required options)
+  const args = process.argv.slice(2);
+  const helpIndex = args.indexOf('help');
+
+  if (helpIndex !== -1 && helpIndex > 0) {
+    // Found "help" after a command name
+    const commandName = args[helpIndex - 1];
+    const cmd = program.commands.find((c: Command) => c.name() === commandName);
+    if (cmd) {
+      cmd.outputHelp();
+      process.exit(0);
+      return; // Make sure we return after showing help
+    }
+  }
 
   // Extract clean message (remove Commander's "error: " prefix if present)
   const cleanMessage = error.message?.replace(/^error:\s*/, '') || 'An unknown error occurred';
@@ -440,6 +460,10 @@ program.exitOverride((err) => {
     console.error(chalk.red(`Error: ${cleanMessage}`));
     console.log(chalk.yellow("\nUse 'staqan-yt help <command>' for usage information"));
     process.exit(1);
+  } else if (error.code?.includes('option') || error.code?.includes('required')) {
+    console.error(chalk.red(`Error: ${cleanMessage}`));
+    console.log(chalk.yellow("\nUse 'staqan-yt help <command>' for usage information"));
+    process.exit(1);
   } else if (error.code === 'commander.help' || error.code === 'commander.helpDisplayed' || error.code === 'commander.version') {
     // Help or version was displayed, exit normally
     process.exit(0);
@@ -450,11 +474,18 @@ program.exitOverride((err) => {
   }
 });
 
-try {
-  program.parse(process.argv);
-} catch (err) {
-  const error = err as { code?: string; message?: string };
-  // Show only the error message, not the stack trace
-  console.error(chalk.red(`Error: ${error.message || 'An unexpected error occurred'}`));
-  process.exit(1);
+// Check for "help" argument BEFORE Commander parses
+// This ensures help works even for commands with required options
+const args = process.argv.slice(2);
+const helpIndex = args.indexOf('help');
+if (helpIndex > 0 && args[helpIndex - 1] !== 'help') {
+  // Found "help" after a command name
+  const commandName = args[helpIndex - 1];
+  const cmd = program.commands.find((c: Command) => c.name() === commandName);
+  if (cmd) {
+    cmd.outputHelp();
+    process.exit(0);
+  }
 }
+
+program.parse(process.argv);

--- a/commands/list-report-jobs.ts
+++ b/commands/list-report-jobs.ts
@@ -1,10 +1,13 @@
 import { google } from 'googleapis';
+import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { error, info, success, debug, initCommand, formatTimestampWithTimezone } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 
 interface ListReportJobsOptions {
   type?: string;
-  output?: 'json' | 'table' | 'text';
+  output?: 'json' | 'table' | 'text' | 'csv' | 'pretty';
   verbose?: boolean;
 }
 
@@ -45,17 +48,34 @@ async function listReportJobsCommand(options: ListReportJobsOptions): Promise<vo
 
     success(`Found ${jobs.length} job(s)\n`);
 
-    // For each job, fetch report details
+    // Collect job data for all formats
     const now = new Date();
+    const jobsData: Array<{
+      jobId: string;
+      reportTypeId: string;
+      name: string;
+      created: string;
+      daysSinceCreation: number;
+      status: string;
+      reportsCount: number;
+      latestReport: string;
+      oldestReport: string;
+      expiringReportsCount: number;
+      expirationWarnings: string[];
+      expirationCriticals: string[];
+    }> = [];
+
+    // For each job, fetch report details
     for (const job of jobs) {
       const jobCreated = new Date(job.createTime || '');
       const daysSinceCreation = Math.floor((now.getTime() - jobCreated.getTime()) / (1000 * 60 * 60 * 24));
 
-      console.log(`Job ID:     ${job.id}`);
-      console.log(`Report Type: ${job.reportTypeId}`);
-      console.log(`Name:       ${job.name}`);
-      console.log(`Created:    ${job.createTime}`);
-      console.log(`Status:     Active (${daysSinceCreation} days ago)\n`);
+      let reportsCount = 0;
+      let latestReport = 'N/A';
+      let oldestReport = 'N/A';
+      let expiringReportsCount = 0;
+      const warnings: string[] = [];
+      const criticals: string[] = [];
 
       // Fetch reports for this job
       try {
@@ -65,81 +85,139 @@ async function listReportJobsCommand(options: ListReportJobsOptions): Promise<vo
         });
 
         const reports = reportsResponse.data.reports || [];
+        reportsCount = reports.length;
 
-        if (reports.length === 0) {
-          const readyAt = new Date(jobCreated.getTime() + 48 * 60 * 60 * 1000);
-          const hoursUntilReady = Math.max(0, Math.ceil((readyAt.getTime() - now.getTime()) / (1000 * 60 * 60)));
-          const formatted = formatTimestampWithTimezone(readyAt);
+        if (reports.length > 0) {
+          latestReport = `${reports[0].startTime} to ${reports[0].endTime}`;
+          oldestReport = `${reports[reports.length - 1].startTime} to ${reports[reports.length - 1].endTime}`;
 
-          console.log('  ⏳  No reports yet (within 48-hour window)');
-          console.log(`      Ready: ${formatted.local} (${formatted.timezone})`);
-          console.log(`      Wait:  ${hoursUntilReady} hours remaining\n`);
-        } else {
           // Calculate expiration warnings
-          const warnings: string[] = [];
-          const criticals: string[] = [];
-
           for (const report of reports) {
             const reportCreated = new Date(report.createTime || '');
-            const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000; // Within 4 days = historical
+            const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
             const expirationDays = isHistorical ? 30 : 60;
             const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
             const daysUntilExpiration = Math.ceil((expiresAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
 
             if (daysUntilExpiration <= 3) {
-              criticals.push(`      🚨 CRITICAL: ${report.startTime} to ${report.endTime} (expires ${expiresAt.toISOString().split('T')[0]}, ${daysUntilExpiration} days)`);
+              criticals.push(`🚨 CRITICAL: ${report.startTime} to ${report.endTime} (expires ${expiresAt.toISOString().split('T')[0]}, ${daysUntilExpiration} days)`);
             } else if (daysUntilExpiration <= 7) {
-              warnings.push(`      ⚠️  Expiring soon: ${report.startTime} to ${report.endTime} (expires ${expiresAt.toISOString().split('T')[0]}, ${daysUntilExpiration} days)`);
+              warnings.push(`⚠️  Expiring soon: ${report.startTime} to ${report.endTime} (expires ${expiresAt.toISOString().split('T')[0]}, ${daysUntilExpiration} days)`);
+            }
+
+            if (daysUntilExpiration <= 7) {
+              expiringReportsCount++;
             }
           }
-
-          console.log(`  Reports: ${reports.length} available`);
-          console.log(`    Latest: ${reports[0].startTime} to ${reports[0].endTime} (created ${reports[0].createTime})`);
-          console.log(`    Oldest: ${reports[reports.length - 1].startTime} to ${reports[reports.length - 1].endTime} (created ${reports[reports.length - 1].createTime})`);
-
-          if (criticals.length > 0) {
-            console.log(`\n${criticals.length} report(s) expiring SOON:`);
-            criticals.forEach(c => console.log(c));
-          }
-
-          if (warnings.length > 0) {
-            if (criticals.length === 0) console.log('');
-            console.log(`${warnings.length} report(s) expiring soon:`);
-            warnings.forEach(w => console.log(w));
-          }
-
-          if (criticals.length > 0 || warnings.length > 0) {
-            console.log(`\n  💡 Run 'staqan-yt download-expiring-reports --type=${job.reportTypeId}' to save them`);
-          }
-
-          console.log('');
         }
       } catch (err) {
         debug(`Failed to fetch reports for job ${job.id}: ${err}`);
       }
 
-      console.log('---\n');
+      jobsData.push({
+        jobId: job.id || '',
+        reportTypeId: job.reportTypeId || '',
+        name: job.name || '',
+        created: job.createTime || '',
+        daysSinceCreation,
+        status: 'Active',
+        reportsCount,
+        latestReport,
+        oldestReport,
+        expiringReportsCount,
+        expirationWarnings: warnings,
+        expirationCriticals: criticals,
+      });
     }
 
-    // Show sliding window status
-    if (jobs.length > 0) {
-      const oldestJob = jobs.reduce((oldest, job) => {
-        const jobDate = new Date(job.createTime || '');
-        const oldestDate = new Date(oldest.createTime || '');
-        return jobDate < oldestDate ? job : oldest;
-      });
+    // Determine output format
+    const outputFormat = await getOutputFormat(options.output);
 
-      const oldestJobCreated = new Date(oldestJob.createTime || '');
-      const daysSinceOldestJob = Math.floor((now.getTime() - oldestJobCreated.getTime()) / (1000 * 60 * 60 * 24));
+    // Output based on format
+    switch (outputFormat) {
+      case 'json':
+        console.log(formatJson(jobsData));
+        break;
 
-      if (daysSinceOldestJob < 60) {
-        info(`📊 Sliding window phase: Growing (will stabilize at 60 days around ${new Date(oldestJobCreated.getTime() + 60 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]})`);
-      } else {
-        info(`📊 Sliding window phase: Stable (60-day rolling window)`);
-      }
+      case 'csv':
+        console.log(formatCsv(jobsData));
+        break;
 
-      info(`⚠️  Reports expire after 30 days (historical) or 60 days (regular)`);
-      info(`💡 Download reports before expiration to avoid data loss\n`);
+      case 'text':
+        console.log(formatText(jobsData));
+        break;
+
+      case 'table':
+        console.log(formatTable(jobsData));
+        break;
+
+      case 'pretty':
+      default:
+        // Pretty format with colors
+        jobsData.forEach((job, idx) => {
+          console.log(chalk.cyan(`Job ID:`) + ' ' + chalk.yellow(job.jobId));
+          console.log(chalk.gray('Report Type:') + ' ' + job.reportTypeId);
+          console.log(chalk.gray('Name:') + ' ' + job.name);
+          console.log(chalk.gray('Created:') + ' ' + job.created);
+          console.log(chalk.gray('Status:') + ' ' + chalk.green(`${job.status} (${job.daysSinceCreation} days ago)`));
+          console.log(chalk.gray('Reports:') + ' ' + chalk.yellow(job.reportsCount.toString()));
+
+          if (job.reportsCount > 0) {
+            console.log(chalk.gray('  Latest:') + ' ' + job.latestReport);
+            console.log(chalk.gray('  Oldest:') + ' ' + job.oldestReport);
+
+            // Show detailed expiration warnings
+            if (job.expirationCriticals.length > 0) {
+              console.log(`\n  ${job.expirationCriticals.length} report(s) expiring SOON:`);
+              job.expirationCriticals.forEach(c => console.log(`      ${chalk.red(c)}`));
+            }
+
+            if (job.expirationWarnings.length > 0) {
+              if (job.expirationCriticals.length === 0) console.log('');
+              console.log(`  ${job.expirationWarnings.length} report(s) expiring soon:`);
+              job.expirationWarnings.forEach(w => console.log(`      ${chalk.yellow(w)}`));
+            }
+
+            if (job.expirationCriticals.length > 0 || job.expirationWarnings.length > 0) {
+              console.log(`\n  💡 Run 'staqan-yt fetch-reports --type=${job.reportTypeId}' to download them`);
+            }
+          } else {
+            const readyAt = new Date(new Date(job.created).getTime() + 48 * 60 * 60 * 1000);
+            const hoursUntilReady = Math.max(0, Math.ceil((readyAt.getTime() - now.getTime()) / (1000 * 60 * 60)));
+            const formatted = formatTimestampWithTimezone(readyAt);
+            console.log(chalk.gray('  ⏳  No reports yet (within 48-hour window)'));
+            console.log(chalk.gray('      Ready:') + ' ' + formatted.local + chalk.gray(` (${formatted.timezone})`));
+            console.log(chalk.gray('      Wait:') + ' ' + chalk.yellow(`${hoursUntilReady} hours remaining`));
+          }
+
+          console.log('');
+          if (idx < jobsData.length - 1) {
+            console.log(chalk.gray('---'));
+            console.log('');
+          }
+        });
+
+        // Show sliding window status
+        if (jobsData.length > 0) {
+          const oldestJobData = jobsData.reduce((oldest, job) => {
+            const jobDate = new Date(job.created || '');
+            const oldestDate = new Date(oldest.created || '');
+            return jobDate < oldestDate ? job : oldest;
+          });
+
+          const oldestJobCreated = new Date(oldestJobData.created || '');
+          const daysSinceOldestJob = Math.floor((now.getTime() - oldestJobCreated.getTime()) / (1000 * 60 * 60 * 24));
+
+          if (daysSinceOldestJob < 60) {
+            info(`📊 Sliding window phase: Growing (will stabilize at 60 days around ${new Date(oldestJobCreated.getTime() + 60 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]})`);
+          } else {
+            info(`📊 Sliding window phase: Stable (60-day rolling window)`);
+          }
+
+          info(`⚠️  Reports expire after 30 days (historical) or 60 days (regular)`);
+          info(`💡 Download reports before expiration to avoid data loss\n`);
+        }
+        break;
     }
 
   } catch (err: unknown) {

--- a/commands/list-report-types.ts
+++ b/commands/list-report-types.ts
@@ -1,9 +1,12 @@
 import { google } from 'googleapis';
+import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { error, info, success, initCommand } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 
 interface ReportTypesOptions {
-  output?: 'json' | 'table' | 'text';
+  output?: 'json' | 'table' | 'text' | 'csv' | 'pretty';
   verbose?: boolean;
 }
 
@@ -42,12 +45,20 @@ async function listReportTypesCommand(options: ReportTypesOptions): Promise<void
       return acc;
     }, {});
 
-    // Output by category
-    const output = options.output || 'table';
+    // Determine output format
+    const outputFormat = await getOutputFormat(options.output);
 
-    switch (output) {
+    // Output based on format
+    switch (outputFormat) {
       case 'json':
-        console.log(JSON.stringify({ reportTypes }, null, 2));
+        console.log(formatJson({ reportTypes }));
+        break;
+
+      case 'csv':
+        console.log(formatCsv(reportTypes.map(rt => ({
+          id: rt.id || '',
+          name: rt.name || '',
+        }))));
         break;
 
       case 'text':
@@ -61,14 +72,22 @@ async function listReportTypesCommand(options: ReportTypesOptions): Promise<void
         });
         break;
 
+      case 'table':
+        console.log(formatTable(reportTypes.map(rt => ({
+          id: rt.id || '',
+          name: rt.name || '',
+        }))));
+        break;
+
+      case 'pretty':
       default:
-        // Table format
-        console.log('Available Report Types:\n');
+        // Pretty format with colors
         reportTypes.forEach(rt => {
-          console.log(`ID:     ${rt.id}`);
-          console.log(`Name:   ${rt.name}`);
+          console.log(chalk.cyan(rt.id || ''));
+          console.log(chalk.gray('  Name:') + ' ' + (rt.name || ''));
           console.log('');
         });
+        break;
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

This PR fixes two critical issues with the YouTube Reporting API commands:

1. **Output format not working**: `list-report-jobs` and `list-report-types` completely ignored the `--output` parameter
2. **Help command not working**: `list-report-jobs help`, `list-report-types help`, `get-report-data help`, and `fetch-reports help` did not show help

## Changes

### Output Format Support (commit 1)

**Fixed Commands:**
- `list-report-jobs` - Now supports all 5 output formats (json, csv, text, table, pretty)
- `list-report-types` - Added missing csv and pretty formats

**Implementation:**
- Used `getOutputFormat()` for proper config integration
- Added formatters for machine-readable output
- Restored detailed expiration warnings in pretty format
- Updated command reference from `download-expiring-reports` to `fetch-reports`

### Help Command Support (commit 2)

**Root Cause:**
- Commands without positional parameters couldn't receive the 'help' argument
- Commands with required options threw errors before help could be displayed
- A try/catch block prevented exitOverride from being called

**Solution:**
- Added pre-parse check to intercept 'help' before Commander validation
- Removed redundant [help] parameters from command definitions
- Removed duplicate configureOutput call
- Removed try/catch that was masking errors

## Test Plan

All commands now work with help:

```bash
staqan-yt list-report-jobs help
staqan-yt list-report-types help
staqan-yt get-report-data help
staqan-yt fetch-reports help
```

All output formats work:

```bash
staqan-yt list-report-jobs --output json
staqan-yt list-report-jobs --output csv
staqan-yt list-report-jobs --output table
staqan-yt list-report-types --output json
staqan-yt list-report-types --output csv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)