### PR TITLE
Fix: Channel-isolated cache and report data storage

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,3 +1,27 @@
+# Breaking Changes
+
+## v1.5.0: Channel-isolated cache and data storage
+
+**Directory structure change** — all per-channel data now lives under a channel ID namespace:
+
+| Before | After |
+|---|---|
+| `~/.staqan-yt-cli/completion-cache.json` | `~/.staqan-yt-cli/data/{channelId}/completion_cache.json` |
+| `~/.staqan-yt-cli/data/cache-index.json` | `~/.staqan-yt-cli/data/{channelId}/reports/cache-index.json` |
+| `~/.staqan-yt-cli/data/reports/{reportTypeId}/` | `~/.staqan-yt-cli/data/{channelId}/reports/{reportTypeId}/` |
+
+**Required**: `default.channel` must be set in config (or pass `--channel`) for `fetch-reports` and `get-report-data`:
+```bash
+staqan-yt config set default.channel @yourchannel
+```
+
+**Safety**: Before upgrading, optionally back up existing cached data:
+```bash
+tar -czf ~/staqan-data-backup.tar.gz ~/.staqan-yt-cli/data/
+```
+
+---
+
 # Migration Guide: v1.2.x → v1.3.0
 
 ## Breaking Changes

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -40,6 +40,112 @@ rm -rf ~/.staqan-yt-cli/data/cache-index.json
 rm -rf ~/.staqan-yt-cli/data/reports/
 ```
 
+### Advanced: Manual migration
+
+If you want to preserve your cached reports, you can manually migrate them. The schema changes are minimal:
+
+**1. Cache index changes** (`cache-index.json`):
+
+Before (v1.0):
+```json
+{
+  "version": "1.0",
+  "lastUpdated": "2026-03-16T00:00:37.235Z",
+  "entries": [
+    {
+      "reportId": "18715771037",
+      "reportTypeId": "channel_reach_basic_a1",
+      "startTime": "2026-02-28T08:00:00Z",
+      "endTime": "2026-03-01T08:00:00Z",
+      "fileSize": 1244,
+      "row_count": 23
+    }
+  ]
+}
+```
+
+After (v2.0):
+```json
+{
+  "version": "2.0",
+  "lastUpdated": "2026-03-16T00:00:37.235Z",
+  "entries": [
+    {
+      "reportId": "18715771037",
+      "reportTypeId": "channel_reach_basic_a1",
+      "startTime": "2026-02-28T08:00:00Z",
+      "endTime": "2026-03-01T08:00:00Z",
+      "fileSize": 1244,
+      "row_count": 23,
+      "channelId": "UCBQQNUsrd9mgCjsrLogKW6Q"
+    }
+  ]
+}
+```
+
+**2. Report metadata changes** (`{reportId}.metadata.json`):
+
+Before:
+```json
+{
+  "reportId": "18715771037",
+  "reportTypeId": "channel_reach_basic_a1",
+  "jobId": "daa51074-6e66-439b-82a2-ac956262b4a2",
+  ...
+  "isComplete": true,
+  "fileSize": 1244,
+  "row_count": 23
+}
+```
+
+After:
+```json
+{
+  "reportId": "18715771037",
+  "reportTypeId": "channel_reach_basic_a1",
+  "jobId": "daa51074-6e66-439b-82a2-ac956262b4a2",
+  ...
+  "isComplete": true,
+  "fileSize": 1244,
+  "row_count": 23,
+  "channelId": "UCBQQNUsrd9mgCjsrLogKW6Q"
+}
+```
+
+**Migration script example** (for advanced users):
+
+```bash
+#!/bin/bash
+# Manual migration script - BACKUP FIRST!
+
+CHANNEL_ID="UCBQQNUsrd9mgCjsrLogKW6Q"  # Your channel ID
+OLD_DIR="$HOME/.staqan-yt-cli/data"
+NEW_DIR="$HOME/.staqan-yt-cli/data/$CHANNEL_ID"
+
+# Create new directory structure
+mkdir -p "$NEW_DIR/reports"
+
+# Migrate cache-index.json
+jq --arg cid "$CHANNEL_ID" \
+  '.version = "2.0" | .entries[]?.channelId = $cid' \
+  "$OLD_DIR/cache-index.json" > "$NEW_DIR/reports/cache-index.json"
+
+# Move and migrate report directories
+for report_type in "$OLD_DIR/reports"/*; do
+  type_name=$(basename "$report_type")
+  mkdir -p "$NEW_DIR/reports/$type_name"
+
+  for metadata_file in "$report_type"/*.metadata.json; do
+    jq --arg cid "$CHANNEL_ID" \
+      '.entries[]?.channelId = $cid' \
+      "$metadata_file" > "$NEW_DIR/reports/$type_name/$(basename $metadata_file)"
+  done
+
+  # Move CSV data files (no changes needed)
+  cp "$report_type"/*.csv "$NEW_DIR/reports/$type_name/" 2>/dev/null
+done
+```
+
 ### Safety: Backup before upgrading
 
 If you want to preserve your old cache (not required, but cautious):

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -10,12 +10,39 @@
 | `~/.staqan-yt-cli/data/cache-index.json` | `~/.staqan-yt-cli/data/{channelId}/reports/cache-index.json` |
 | `~/.staqan-yt-cli/data/reports/{reportTypeId}/` | `~/.staqan-yt-cli/data/{channelId}/reports/{reportTypeId}/` |
 
-**Required**: `default.channel` must be set in config (or pass `--channel`) for `fetch-reports` and `get-report-data`:
+### ⚠️ Important: Old cached data will not be migrated
+
+After upgrading to v1.5.0:
+- Existing report cache will be ignored (not deleted, but not used)
+- Tab completion will rebuild on first use
+- You'll need to re-download reports
+
+### Steps after upgrade
+
+1. **Set your default channel** (required):
+   ```bash
+   staqan-yt config set default.channel @yourchannel
+   ```
+
+2. **Re-download your reports** (if you had cached data):
+   ```bash
+   staqan-yt fetch-reports --type channel_reach_basic_a1
+   ```
+
+3. **Tab completion will auto-rebuild** on first use
+
+### Optional: Clean up old data
+
+If you want to remove the old unused cache files:
 ```bash
-staqan-yt config set default.channel @yourchannel
+rm ~/.staqan-yt-cli/completion-cache.json
+rm -rf ~/.staqan-yt-cli/data/cache-index.json
+rm -rf ~/.staqan-yt-cli/data/reports/
 ```
 
-**Safety**: Before upgrading, optionally back up existing cached data:
+### Safety: Backup before upgrading
+
+If you want to preserve your old cache (not required, but cautious):
 ```bash
 tar -czf ~/staqan-data-backup.tar.gz ~/.staqan-yt-cli/data/
 ```

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,6 +1,6 @@
 # Breaking Changes
 
-## v1.5.0: Channel-isolated cache and data storage
+## v2.0.0: Channel-isolated cache and data storage
 
 **Directory structure change** — all per-channel data now lives under a channel ID namespace:
 
@@ -12,7 +12,7 @@
 
 ### ⚠️ Important: Old cached data will not be migrated
 
-After upgrading to v1.5.0:
+After upgrading to v2.0.0:
 - Existing report cache will be ignored (not deleted, but not used)
 - Tab completion will rebuild on first use
 - You'll need to re-download reports
@@ -155,202 +155,149 @@ tar -czf ~/staqan-data-backup.tar.gz ~/.staqan-yt-cli/data/
 
 ---
 
-# Migration Guide: v1.2.x → v1.3.0
+## v2.0.0: All positional arguments migrated to named flags
 
-## Breaking Changes
+**Command syntax change** — all positional arguments have been removed. Commands now use required named flags exclusively.
 
-All positional arguments have been removed. Commands now use required named flags exclusively (AWS CLI style).
+### What changed?
 
-## Command Migrations
+| Command type | Before (v1.x) | After (v2.0.0) |
+|---|---|---|
+| **Single video operations** | `staqan-yt get-video dQw4w9WgXcQ` | `staqan-yt get-video --video-id dQw4w9WgXcQ` |
+| **Batch video operations** | `staqan-yt get-videos id1 id2 id3` | `staqan-yt get-videos --video-ids id1 id2 id3` |
+| **Channel operations** | `staqan-yt list-videos @mkbhd` | `staqan-yt list-videos --channel @mkbhd` |
+| **Search operations** | `staqan-yt search-videos "query"` | `staqan-yt search-videos --query "query"` |
+| **Update operations** | `staqan-yt update-video ID --title "X"` | `staqan-yt update-video --video-id ID --title "X"` |
 
-### Video Operations
+### ⚠️ Important: All existing scripts and aliases will break
 
-#### Get Video(s)
-```bash
-# Old (v1.2.x)
-staqan-yt get-video dQw4w9WgXcQ
-staqan-yt get-videos id1 id2 id3
+After upgrading to v2.0.0:
+- Any scripts using positional arguments will fail
+- Shell aliases with hardcoded positional args will need updating
+- Command-line history with old syntax won't work
 
-# New (v1.3.0+)
-staqan-yt get-video --video-id dQw4w9WgXcQ
-staqan-yt get-videos --video-ids id1 id2 id3
-```
+### Steps after upgrade
 
-#### Update Video
-```bash
-# Old (v1.2.x)
-staqan-yt update-video dQw4w9WgXcQ --title "New Title"
+**1. Update your scripts**
 
-# New (v1.3.0+)
-staqan-yt update-video --video-id dQw4w9WgXcQ --title "New Title"
-```
-
-#### Video Analytics
-```bash
-# Old (v1.2.x)
-staqan-yt get-video-analytics dQw4w9WgXcQ
-
-# New (v1.3.0+)
-staqan-yt get-video-analytics --video-id dQw4w9WgXcQ
-```
-
-#### Video Tags
-```bash
-# Old (v1.2.x)
-staqan-yt get-video-tags dQw4w9WgXcQ
-staqan-yt update-video-tags dQw4w9WgXcQ --tags "tag1,tag2"
-
-# New (v1.3.0+)
-staqan-yt get-video-tags --video-id dQw4w9WgXcQ
-staqan-yt update-video-tags --video-id dQw4w9WgXcQ --tags "tag1,tag2"
-```
-
-#### Thumbnail
-```bash
-# Old (v1.2.x)
-staqan-yt get-thumbnail dQw4w9WgXcQ
-
-# New (v1.3.0+)
-staqan-yt get-thumbnail --video-id dQw4w9WgXcQ
-```
-
-### Channel Operations
-
-#### List Videos
-```bash
-# Old (v1.2.x)
-staqan-yt list-videos @mkbhd
-
-# New (v1.3.0+)
-staqan-yt list-videos --channel @mkbhd
-```
-
-#### Get Channel
-```bash
-# Old (v1.2.x)
-staqan-yt get-channel @mkbhd
-
-# New (v1.3.0+)
-staqan-yt get-channel --channel @mkbhd
-```
-
-### Playlist Operations
-
-#### Get Playlist(s)
-```bash
-# Old (v1.2.x)
-staqan-yt get-playlist PLxxx
-staqan-yt get-playlists id1 id2
-
-# New (v1.3.0+)
-staqan-yt get-playlist --playlist-id PLxxx
-staqan-yt get-playlists --playlist-ids id1 id2
-```
-
-### Search
-
-#### Search Videos
-```bash
-# Old (v1.2.x)
-staqan-yt search-videos "iPhone review"
-staqan-yt search-videos "iPhone review" --channel @mkbhd
-
-# New (v1.3.0+)
-staqan-yt search-videos --query "iPhone review"
-staqan-yt search-videos --query "iPhone review" --channel @mkbhd
-```
-
-### Localizations
-
-#### Get Video Localizations
-```bash
-# Old (v1.2.x)
-staqan-yt get-video-localizations id1 id2 id3
-
-# New (v1.3.0+)
-staqan-yt get-video-localizations --video-ids id1 id2 id3
-```
-
-#### Get/Update Video Localization
-```bash
-# Old (v1.2.x)
-staqan-yt get-video-localization dQw4w9WgXcQ --language ja
-staqan-yt put-video-localization dQw4w9WgXcQ ja "Japanese Title" "Description"
-staqan-yt update-video-localization dQw4w9WgXcQ --language ja --title "New Title"
-
-# New (v1.3.0+)
-staqan-yt get-video-localization --video-id dQw4w9WgXcQ --language ja
-staqan-yt put-video-localization --video-id dQw4w9WgXcQ --language ja --title "Japanese Title" --description "Description"
-staqan-yt update-video-localization --video-id dQw4w9WgXcQ --language ja --title "New Title"
-```
-
-### Captions
-
-#### List Captions
-```bash
-# Old (v1.2.x)
-staqan-yt list-captions dQw4w9WgXcQ
-
-# New (v1.3.0+)
-staqan-yt list-captions --video-id dQw4w9WgXcQ
-```
-
-#### Get Caption
-```bash
-# Old (v1.2.x)
-staqan-yt get-caption en.dQw4w9WgXcQ
-
-# New (v1.3.0+)
-staqan-yt get-caption --caption-id en.dQw4w9WgXcQ
-```
-
-### Comments
-
-#### List Comments
-```bash
-# Old (v1.2.x)
-staqan-yt list-comments dQw4w9WgXcQ
-
-# New (v1.3.0+)
-staqan-yt list-comments --video-id dQw4w9WgXcQ
-```
-
-## Script Updates
-
-### Batch Operations
-
-When scripting with batch operations, update your commands to use named flags:
+Replace positional arguments with named flags:
 
 ```bash
-# Old
+# Old (v1.x)
 cat video_ids.txt | xargs -I {} staqan-yt update-video {} --title "New Title" --yes
 
-# New
+# New (v2.0.0)
 cat video_ids.txt | xargs -I {} staqan-yt update-video --video-id {} --title "New Title" --yes
 ```
 
-### For Loops
-
 ```bash
-# Old
+# Old (v1.x)
 for video_id in id1 id2 id3; do
   staqan-yt get-video "$video_id"
 done
 
-# New
+# New (v2.0.0)
 for video_id in id1 id2 id3; do
   staqan-yt get-video --video-id "$video_id"
 done
 ```
 
-## Benefits of the New Syntax
+**2. Update your shell aliases**
+
+```bash
+# Old (v1.x)
+alias getvid='staqan-yt get-video'
+
+# New (v2.0.0)
+alias getvid='staqan-yt get-video --video-id'
+```
+
+### Command migration reference
+
+**Video operations:**
+```bash
+# Get single video
+staqan-yt get-video --video-id dQw4w9WgXcQ
+
+# Get multiple videos
+staqan-yt get-videos --video-ids id1 id2 id3
+
+# Update video
+staqan-yt update-video --video-id dQw4w9WgXcQ --title "New Title"
+
+# Get analytics
+staqan-yt get-video-analytics --video-id dQw4w9WgXcQ
+
+# Get/update tags
+staqan-yt get-video-tags --video-id dQw4w9WgXcQ
+staqan-yt update-video-tags --video-id dQw4w9WgXcQ --tags "tag1,tag2"
+
+# Get thumbnail
+staqan-yt get-thumbnail --video-id dQw4w9WgXcQ
+```
+
+**Channel operations:**
+```bash
+# List videos
+staqan-yt list-videos --channel @mkbhd
+
+# Get channel info
+staqan-yt get-channel --channel @mkbhd
+```
+
+**Playlist operations:**
+```bash
+# Get single playlist
+staqan-yt get-playlist --playlist-id PLxxx
+
+# Get multiple playlists
+staqan-yt get-playlists --playlist-ids id1 id2
+```
+
+**Search operations:**
+```bash
+# Search videos
+staqan-yt search-videos --query "iPhone review"
+staqan-yt search-videos --query "iPhone review" --channel @mkbhd
+```
+
+**Localization operations:**
+```bash
+# Get all localizations
+staqan-yt get-video-localizations --video-ids id1 id2 id3
+
+# Get single localization
+staqan-yt get-video-localization --video-id dQw4w9WgXcQ --language ja
+
+# Create localization
+staqan-yt put-video-localization --video-id dQw4w9WgXcQ --language ja --title "Japanese Title" --description "Description"
+
+# Update localization
+staqan-yt update-video-localization --video-id dQw4w9WgXcQ --language ja --title "New Title"
+```
+
+**Caption operations:**
+```bash
+# List captions
+staqan-yt list-captions --video-id dQw4w9WgXcQ
+
+# Get caption
+staqan-yt get-caption --caption-id en.dQw4w9WgXcQ
+```
+
+**Comment operations:**
+```bash
+# List comments
+staqan-yt list-comments --video-id dQw4w9WgXcQ
+```
+
+### Benefits of the new syntax
 
 - **Self-documenting**: Command intent is clearer with named flags
 - **Flexible ordering**: Flags can be in any order
 - **Better completion**: Tab completion suggests live YouTube data
-- **AWS CLI consistency**: Matches industry-standard CLI conventions
 
-## Configuration Shortcuts
+### Configuration shortcuts
 
 You can set default values in your config to avoid repeating common flags:
 
@@ -362,7 +309,7 @@ staqan-yt config set default.channel @mkbhd
 staqan-yt list-videos --limit 10
 ```
 
-## Need Help?
+### Need help?
 
 Run `staqan-yt <command> --help` for usage information.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,10 @@
 
 ## ⚠️ CRITICAL RULES
 
-**🚨 NEVER COMMIT DIRECTLY TO MAIN BRANCH 🚨**
+### 🚨 NEVER COMMIT DIRECTLY TO MAIN BRANCH 🚨
 
 **EVERY commit MUST be on a feature branch:**
+
 ```bash
 # BEFORE making any changes, create a feature branch
 git checkout -b feature/your-feature-name
@@ -19,6 +20,7 @@ gh pr create --title "Feature: Your Feature" --body "Description"
 ```
 
 **If you accidentally commit to main:**
+
 ```bash
 # Undo the commit (keep changes)
 git reset --soft HEAD~1
@@ -37,58 +39,117 @@ gh pr create
 - Maintains clean git history
 - Team workflow best practice
 
+### Verify Branch Before Committing
+
+```bash
+# This MUST NOT be "main"
+git branch --show-current
+
+# If it shows "main", STOP and create feature branch:
+git checkout -b feature/your-feature-name
+```
+
+---
+
+## Quick Reference
+
+### Install & Test Globally
+
+```bash
+npm link              # Test globally
+staqan-yt --help      # Verify installation
+```
+
+### Common Commands
+
+```bash
+# Authentication
+staqan-yt auth
+
+# Configuration
+staqan-yt config list
+staqan-yt config set default.channel @staqan
+staqan-yt config set default.output csv
+
+# Video operations
+staqan-yt get-video dQw4w9WgXcQ
+staqan-yt get-videos ID1 ID2
+staqan-yt list-videos @channel --limit 5
+
+# All output formats
+staqan-yt get-video ID --output json|table|text|csv|pretty
+```
+
+### File Locations
+
+**Credentials**: `~/.staqan-yt-cli/`
+- `credentials.json` - OAuth 2.0 client credentials
+- `token.json` - User access/refresh tokens
+- `config.json` - User configuration
+
+**Project Structure**:
+```
+staqan-yt-cli/
+├── bin/staqan-yt.ts          # Main CLI entry point
+├── lib/                      # Core utilities
+├── commands/                 # All command implementations
+├── types/index.ts            # Shared TypeScript types
+└── docs/                     # Documentation
+```
+
+### Key Patterns
+
+```typescript
+// Load output format
+const outputFormat = await getOutputFormat(options.output);
+
+// Get authenticated client
+const auth = await getAuthenticatedClient();
+const youtube = google.youtube({ version: 'v3', auth });
+
+// Load config value
+const channel = await getConfigValue('default.channel');
+
+// Spinner pattern
+const spinner = ora('Processing...').start();
+spinner.succeed('Done!');
+
+// Error pattern
+error((err as Error).message);
+process.exit(1);
+```
+
 ---
 
 ## Project Overview
 
 A command-line interface for managing YouTube videos and metadata using the YouTube Data API v3. Built with Node.js and designed for programmatic YouTube channel management.
 
-## Documentation Structure
+**For detailed documentation**, see:
+- User guide: [README.md](README.md)
+- Command reference: [docs/](docs/README.md)
+- Development guides: [docs/development/](docs/development/README.md)
 
-This project uses a structured documentation system to serve different audiences:
+---
+
+## Documentation Structure
 
 ```
 staqan-yt-cli/
-├── README.md                 # User-facing (concise, Homebrew-focused)
-├── CONTRIBUTING.md           # Contributor guide for humans
-├── CLAUDE.md                 # This file - AI/robot development instructions
-└── docs/                     # Comprehensive command reference
-    ├── README.md             # Documentation hub
-    ├── setup.md              # Installation & OAuth setup
-    ├── troubleshooting.md    # Common issues & solutions
-    ├── output-formats.md     # Output format guide (JSON, CSV, etc.)
-    └── commands/             # Command reference grouped by intent
-        ├── video-discovery.md        # get-video, search-videos
-        ├── channel-operations.md     # list-videos, get-channel
-        ├── metadata-management.md    # update-video, localizations
-        ├── analytics.md              # video/channel analytics
-        ├── reporting-api.md          # thumbnail CTR, reports
-        ├── engagement.md             # comments, captions
-        ├── content-management.md     # tags, thumbnails, playlists
-        └── configuration.md          # auth, config, MCP
+├── README.md                 # User-facing
+├── CONTRIBUTING.md           # Contributor guide
+├── CLAUDE.md                 # This file - AI development instructions
+└── docs/
+    ├── development/          # Development guides (11 guides)
+    ├── commands/             # Command reference
+    └── *.md                  # Setup, troubleshooting, etc.
 ```
 
-**Key Points for AI Assistants:**
+**When adding commands**: Update `docs/commands/<category>.md` + `lib/customHelp.ts`
 
-1. **When adding commands:**
-   - Document in appropriate `docs/commands/<category>.md` file
-   - Update `lib/customHelp.ts` to match documentation grouping
-   - Follow existing documentation patterns in that file
+**→ See [docs/development/README.md](docs/development/README.md) for guide listings**
 
-2. **When modifying commands:**
-   - Update the corresponding `docs/commands/<category>.md` file
-   - Update examples if behavior changes
-   - Add new error cases to `docs/troubleshooting.md`
-
-3. **Documentation serves different purposes:**
-   - README.md - Quick start for users (keep concise)
-   - CONTRIBUTING.md - Human contributor conventions
-   - CLAUDE.md - AI development instructions (this file)
-   - docs/ - Comprehensive reference (detailed examples)
-
-4. **Help command grouping:**
-   - Groups in `lib/customHelp.ts` MUST match documentation structure
-   - Update both files together to stay in sync
+---
 
 ## 🤖 Subagent Development Workflow
 
@@ -123,7 +184,7 @@ staqan-yt-cli/
 - ❌ Push to main without a PR
 - ❌ Return with uncommitted changes
 
-**Remember:** Even for "small" changes, ALWAYS use a feature branch.
+---
 
 ## Architecture Principles
 
@@ -142,82 +203,37 @@ staqan-yt-cli/
 - Metadata generation logic
 - Language-specific tone guidance
 
-### 2. File Operation Concurrency
+**→ See [Architecture Guide](docs/development/architecture.md#clean-separation-of-concerns)**
 
-### Lock Strategy
+### 2. Lock Strategy
 
 The CLI uses file-based locks with PID checking to prevent concurrent writes:
-
-**Lock files:**
-- `data/{channelId}/completion_cache.json.lock` - Completion cache
-- `data/handle-to-channel-id.json.lock` - Handle→channelId cache
-- `data/{channelId}/reports/.lock` - Per-channel reports directory
-
-**Lock behavior:**
+- Lock files: `data/{channelId}/completion_cache.json.lock`, `data/handle-to-channel-id.json.lock`
 - Locks contain PID + timestamp
 - Automatic stale lock detection (PID doesn't exist OR age > 30min)
-- Acquire with timeout: `acquireLock(lockPath, { timeout })`
-- Always release in `finally` block
+- Always use try/finally to ensure cleanup
 
-**When adding new file writes:**
-1. Identify if lock is needed (concurrent access possible?)
-2. Use appropriate lock file (file.lock or .lock for dir)
-3. Always use try/finally to ensure cleanup
-4. Test with concurrent operations
-
-**Example pattern:**
-```typescript
-import { acquireLock, getLockPath } from './lock';
-
-async function writeSomething(): Promise<void> {
-  const lockPath = getLockPath('your-type', channelId);
-  let release: (() => Promise<void>) | null = null;
-
-  try {
-    release = await acquireLock(lockPath, { timeout: 5000 });
-    // ... write operations ...
-  } finally {
-    if (release) await release();
-  }
-}
-```
+**→ See [Architecture Guide](docs/development/architecture.md#lock-strategy)**
 
 ### 3. AWS API Naming Conventions
 
-**CRITICAL**: All commands must follow AWS API naming conventions and use **NO positional arguments**.
-
 **🚨 RULE: Everything is a named flag. No positional arguments at all.**
 
-**Singular = Single-item operations**
+**Singular = Single-item operations:**
 ```bash
 get-video --video-id <id>        # Get ONE video
 update-video --video-id <id>     # Update ONE video
-delete-video --video-id <id>     # Delete ONE video (if added)
 ```
 
-**Plural = Batch/list operations**
+**Plural = Batch/list operations:**
 ```bash
 get-videos --video-ids <id1> <id2>     # Get MULTIPLE videos (batch)
 list-videos --channel <handle>         # List videos in channel
-search-videos --query <text>            # Search multiple videos
 ```
 
-**Required flags pattern:**
-- Single ID: Use `--resource-id <id>` (singular flag name, singular ID)
-- Multiple IDs: Use `--resource-ids <id...>` (plural flag name, variadic IDs)
-- Other required params: Use descriptive flag names (e.g., `--query <text>`)
+**→ See [Architecture Guide](docs/development/architecture.md#aws-api-naming-conventions)**
 
-**Naming pattern:**
-- Use `get-` for retrieving resources
-- Use `list-` for listing collections
-- Use `update-` for modifying resources
-- Use `delete-` for removing resources
-- Use `search-` for querying resources
-- Use singular nouns for single-item operations
-- Use plural nouns for batch/list operations
-- **ALL parameters use flags** (no positional arguments)
-
-### 3. Credential Management
+### 4. Credential Management
 
 **All credentials stored in**: `~/.staqan-yt-cli/`
 
@@ -228,725 +244,101 @@ search-videos --query <text>            # Search multiple videos
 **Never store credentials:**
 - In the repo
 - In project directories
-- In environment variables (use the centralized location)
+- In environment variables
 
-### 4. Configuration Management
+### 5. Configuration Management
 
 **Configuration file location**: `~/.staqan-yt-cli/config.json`
 
-**Available configuration options:**
+**Available options:**
 - `default.channel` - Default channel handle/ID for list-videos and search-videos
-- `default.output` - Default output format: `json`, `table`, `text`, `pretty`, or `csv` (defaults to `pretty`)
+- `default.output` - Default output format: `json`, `table`, `text`, `pretty`, or `csv`
 
-**How configuration works:**
-- Config values are loaded when commands execute
-- CLI flags always override config defaults
-- Optional parameters use config values when not provided
-- Configuration is managed via the `config` command
+**CLI flags always override config defaults.**
 
-**Example workflow:**
-```bash
-# Set defaults
-staqan-yt config set default.channel @staqan
-staqan-yt config set default.output csv
-
-# Commands now use these defaults
-staqan-yt list-videos --limit 5        # Uses @staqan, outputs CSV
-staqan-yt search-videos "craft beer"   # Uses @staqan, outputs CSV
-
-# Override when needed
-staqan-yt list-videos @otherChannel --output json    # Explicit format overrides config
-```
-
-**Implementation pattern:**
-```typescript
-// In command files
-import { getConfigValue, getOutputFormat } from '../lib/config';
-
-// Load default channel if not provided
-let channel = channelHandle || await getConfigValue('default.channel');
-
-// Determine output format (flag takes precedence over config)
-const outputFormat = await getOutputFormat(options.output);
-```
+---
 
 ## Code Structure
 
 ```
 staqan-yt-cli/
-├── bin/
-│   └── staqan-yt.ts          # Main CLI entry point, command routing
-├── lib/
-│   ├── auth.ts               # OAuth 2.0 authentication logic
-│   ├── youtube.ts            # YouTube Data API wrapper
-│   ├── language.ts           # Language mapping utilities
-│   ├── config.ts             # Configuration management utilities
-│   └── utils.ts              # Helper utilities (chalk, ora, paths)
-├── commands/
-│   ├── auth.ts               # Authentication command
-│   ├── config.ts             # Configuration management command
-│   ├── channel-videos.ts     # List videos command
-│   ├── video-info.ts         # Get video(s) command
-│   ├── update-metadata.ts    # Update video command
-│   ├── search-channel.ts     # Search videos command
-│   ├── get-video-localizations.ts   # Get all localizations
-│   ├── get-video-localization.ts    # Get single localization
-│   ├── put-video-localization.ts    # Create localization
-│   └── update-video-localization.ts # Update localization
-├── types/
-│   └── index.ts              # Shared TypeScript type definitions
-├── dist/                     # Compiled JavaScript output (gitignored)
-├── tsconfig.json             # TypeScript configuration
-├── eslint.config.mjs         # ESLint configuration
-├── package.json
-├── README.md                 # User-facing documentation
-└── CLAUDE.md                 # This file - development guide
+├── bin/staqan-yt.ts          # Main CLI entry point
+├── lib/                      # Core utilities (auth, youtube, config, etc.)
+├── commands/                 # All command implementations (31 total)
+├── types/index.ts            # Shared TypeScript types
+├── dist/                     # Compiled output (gitignored)
+└── package.json
 ```
 
-## TypeScript Development
+**→ See [Architecture Guide](docs/development/architecture.md#code-structure) for details**
 
-### TypeScript Configuration
+---
 
-This project uses TypeScript with strict type checking enabled. Key configuration:
+## Development Guides
 
-**tsconfig.json:**
-- Target: ES2020 (Node.js appropriate)
-- Module: CommonJS (for CLI compatibility)
-- Strict mode: enabled
-- Output directory: `dist/`
-- Source maps and declaration files enabled
+**For detailed implementation guides, see:**
 
-**Build Process:**
-```bash
-npm run build         # Compile TypeScript to dist/
-npm run type-check    # Type checking without emit
-npm run lint          # Run ESLint
-npm run dev           # Development mode with tsx
-```
+### Core Development
+- **[TypeScript Guide](docs/development/typescript-guide.md)** - TypeScript configuration, type safety, ESLint, and common patterns
+- **[Adding Commands Guide](docs/development/adding-commands.md)** - Step-by-step command creation with templates
+- **[Testing Guide](docs/development/testing-guide.md)** - Manual testing strategies and local development
+- **[Error Handling Guide](docs/development/error-handling.md)** - User-friendly error patterns
 
-### Type Safety Guidelines
+### Implementation Details
+- **[Output Formats Guide](docs/development/output-formats.md)** - Implementing JSON, table, CSV, and pretty output
+- **[YouTube API Guide](docs/development/youtube-api-guide.md)** - YouTube Data API v3 patterns and quotas
+- **[Security Guide](docs/development/security-guide.md)** - OAuth security and input validation
+- **[Architecture Guide](docs/development/architecture.md)** - Lock strategy, hidden commands, scope boundaries
 
-**⚠️ ZERO `any` TOLERANCE**
+### Maintenance & Operations
+- **[Git Workflow Guide](docs/development/git-workflow.md)** - Branch strategy, commits, releases, and protection
+- **[Maintenance Guide](docs/development/maintenance-guide.md)** - Dependency updates and Dependabot vulnerability management
+- **[Troubleshooting Guide](docs/development/troubleshooting.md)** - TypeScript and build error resolution
 
-**Never use `any` type.** It defeats TypeScript's entire purpose. This is a hard rule:
+### Quick Start Paths
 
-```typescript
-// ❌ NEVER
-function handler(...args: any[]): any { ... }
-const data: any = response;
+- **I want to add a new command**: [Adding Commands Guide](docs/development/adding-commands.md)
+- **I'm new to the project**: [Architecture Guide](docs/development/architecture.md)
+- **I found a security vulnerability**: [Security Guide](docs/development/security-guide.md) + [Maintenance Guide](docs/development/maintenance-guide.md)
+- **I need to update dependencies**: [Maintenance Guide](docs/development/maintenance-guide.md)
 
-// ✅ Use specific types
-function handler(videoId: string, options: VideoOptions): Promise<void> { ... }
-const data: VideoInfo = response;
+---
 
-// ✅ If type is truly unknown, use `unknown` + type guard
-function handler(input: unknown): void {
-  if (typeof input === 'string') { ... }
-}
+## Adding New Commands (Quick Checklist)
 
-// ✅ For external/untyped data, use a specific interface even if partial
-interface ApiResponse { items?: Item[] }
-```
+1. **Choose AWS-style name**: `get-video` (singular) or `get-videos` (plural)
+2. **Create command file**: `commands/your-command.ts` with proper types
+3. **Register in bin/staqan-yt.ts**: Add command with description
+4. **Add types** (if needed): Update `types/index.ts`
+5. **Build and test**: `npm run type-check && npm run lint && npm run build`
+6. **Update documentation**:
+   - Add to `docs/commands/<category>.md`
+   - Update `lib/customHelp.ts` help grouping
+   - Test examples
 
-If you find yourself reaching for `any`, use `unknown` with a type guard, or define a proper interface.
+**→ See [Adding Commands Guide](docs/development/adding-commands.md) for detailed steps and templates.**
 
-**1. Use strict types everywhere:**
-```typescript
-// Good - explicit types
-async function getVideoInfo(videoIds: string[]): Promise<VideoInfo[]> {
-  // ...
-}
+---
 
-// Avoid - implicit any
-async function getVideoInfo(videoIds) {
-  // ...
-}
-```
+## Pre-Commit Checklist
 
-**2. Leverage shared types from `types/index.ts`:**
-```typescript
-import { VideoInfo, VideoLocalization, JsonOption } from '../types';
+**MANDATORY checks before committing:**
 
-async function videoInfoCommand(videoIds: string[], options: JsonOption): Promise<void> {
-  const videos: VideoInfo[] = await getVideoInfo(videoIds);
-  // ...
-}
-```
+- [ ] **On a feature branch?** (NOT main!)
+- [ ] **Tested all affected commands?**
+- [ ] **Updated documentation?**
+  - [ ] README.md (if user-facing changes)
+  - [ ] docs/commands/<category>.md (command reference)
+  - [ ] lib/customHelp.ts (help grouping)
+- [ ] **Following AWS naming conventions?**
+- [ ] **Credentials never committed?**
 
-**3. Use non-null assertions sparingly:**
-```typescript
-// Prefer optional chaining and nullish coalescing
-const title = video.snippet?.title || 'Untitled';
+**Verify branch**: `git branch --show-current` (MUST NOT be "main")
+**Verify staged files**: `git diff --staged --name-only`
 
-// Only use ! when you're absolutely certain
-const channelId = response.data.items![0].id!;
-```
+---
 
-**4. Type API responses properly:**
-```typescript
-import { youtube_v3 } from 'googleapis';
-
-async function getVideoWithLocalizations(videoId: string): Promise<youtube_v3.Schema$Video> {
-  // Uses googleapis type definitions
-}
-```
-
-### ESLint Configuration
-
-ESLint is configured with TypeScript support (flat config format):
-- Parser: `@typescript-eslint/parser`
-- Plugin: `@typescript-eslint/eslint-plugin`
-- Rules optimized for Node.js CLI development
-
-**Running linter:**
-```bash
-npm run lint          # Check all files
-```
-
-### Common TypeScript Patterns for CLI
-
-**Command modules use `export =` for CommonJS:**
-```typescript
-import ora from 'ora';
-import { getVideoInfo } from '../lib/youtube';
-import { JsonOption } from '../types';
-
-async function videoInfoCommand(videoIds: string[], options: JsonOption): Promise<void> {
-  // Command logic
-}
-
-export = videoInfoCommand;
-```
-
-**Type error handling:**
-```typescript
-try {
-  // ...
-} catch (err) {
-  error((err as Error).message);
-  process.exit(1);
-}
-```
-
-**Type Commander.js options:**
-```typescript
-interface UpdateVideoOptions {
-  title?: string;
-  description?: string;
-  dryRun?: boolean;
-  yes?: boolean;
-}
-
-async function updateMetadataCommand(videoId: string, options: UpdateVideoOptions): Promise<void> {
-  // ...
-}
-```
-
-### Non-Null Assertion Usage
-
-**ESLint Rule:** `@typescript-eslint/no-non-null-assertion` is set to `'off'`
-
-**Rationale:**
-Non-null assertions (`!`) are used intentionally throughout the codebase, particularly in `lib/youtube.ts`, when working with YouTube API responses from the `googleapis` library.
-
-**Why this is safe:**
-1. **Explicit validation precedes all assertions**: Properties are validated before using `!`
-   - Example: `if (response.data.items && response.data.items.length > 0)` followed by `item.snippet!.title!`
-
-2. **YouTube API contract**: The YouTube Data API v3 guarantees certain properties exist when specific conditions are met
-   - Example: If `items` array has elements, each `item.snippet` is guaranteed to exist
-
-3. **googleapis type definitions**: The official TypeScript definitions use optional types extensively (`property?: type`), even for required fields
-
-4. **Readability**: Using `!` after validation is more concise than repeated null checks
-
-**Pattern to follow:**
-```typescript
-// Good: Validate first, then assert
-if (response.data.items && response.data.items.length > 0) {
-  const title = response.data.items[0].snippet!.title!;  // Safe!
-}
-
-// Bad: Assert without validation
-const title = response.data.items![0].snippet!.title!;  // Unsafe!
-```
-
-**When adding new code:**
-- Always validate before asserting
-- If you're unsure whether a property can be null, use optional chaining (`?.`) instead
-- Prefer explicit checks over assertions for user input or external data
-
-## Adding New Commands
-
-### Step 1: Choose the Correct Name
-
-Follow AWS conventions:
-- **Single-item operation?** Use singular noun: `get-playlist`, `update-comment`
-- **Batch/list operation?** Use plural noun: `get-playlists`, `list-comments`
-
-### Step 2: Create Command File
-
-Create `commands/your-command.ts`:
-
-```typescript
-import ora from 'ora';
-import { success, error, info } from '../lib/utils';
-import { getAuthenticatedClient } from '../lib/auth';
-import { google } from 'googleapis';
-import { JsonOption } from '../types';
-
-interface YourCommandOptions extends JsonOption {
-  // Add your option types here
-}
-
-async function yourCommand(args: string, options: YourCommandOptions): Promise<void> {
-  const spinner = ora('Processing...').start();
-
-  try {
-    const auth = await getAuthenticatedClient();
-    const youtube = google.youtube({ version: 'v3', auth });
-
-    // Your logic here
-
-    spinner.succeed('Operation completed!');
-    success('Done!');
-  } catch (err) {
-    spinner.fail('Operation failed');
-    error((err as Error).message);
-    process.exit(1);
-  }
-}
-
-export = yourCommand;
-```
-
-### Step 3: Register in bin/staqan-yt.ts
-
-```typescript
-import yourCommand = require('../commands/your-command');
-
-program
-  .command('your-command <arg>')
-  .description('Description following AWS style')
-  .option('-j, --output json', 'Output in JSON format')
-  .action(yourCommand);
-```
-
-### Step 4: Add Types (if needed)
-
-Update `types/index.ts` if you have new shared types:
-
-```typescript
-export interface YourNewType {
-  field: string;
-  // ...
-}
-```
-
-### Step 5: Build and Test
-
-```bash
-npm run type-check    # Ensure no type errors
-npm run lint          # Ensure no linting errors
-npm run build         # Compile to dist/
-npm link              # Test globally
-```
-
-### Step 6: Update Documentation
-
-**IMPORTANT:** This project uses a structured documentation system. You MUST update documentation when adding or modifying commands.
-
-**Documentation Structure:**
-```
-README.md                 # User-facing (concise, examples only)
-CONTRIBUTING.md           # Contributor guide
-CLAUDE.md                 # This file - AI development guide
-docs/                     # Comprehensive command reference
-├── README.md             # Documentation hub
-├── commands/             # Command reference by intent
-│   ├── video-discovery.md
-│   ├── channel-operations.md
-│   ├── metadata-management.md
-│   ├── analytics.md
-│   ├── reporting-api.md
-│   ├── engagement.md
-│   ├── content-management.md
-│   └── configuration.md
-├── setup.md
-├── troubleshooting.md
-└── output-formats.md
-```
-
-**What to Update:**
-
-1. **Command Documentation** (REQUIRED for new commands):
-   - Add to appropriate `docs/commands/<category>.md` file
-   - Include: usage, arguments, options, examples, output fields
-   - Follow existing documentation patterns in that file
-
-2. **Help Command Grouping** (REQUIRED):
-   - Update `lib/customHelp.ts` to include new command in appropriate group
-   - Groups must match documentation structure
-
-3. **Documentation Hub** (if new category):
-   - Update `docs/README.md` to reference new command/category
-
-4. **README.md** (OPTIONAL):
-   - Only update for significant user-facing features
-   - Keep concise, link to docs/ for details
-
-5. **Troubleshooting** (if new error cases):
-   - Update `docs/troubleshooting.md` with new error scenarios
-
-**Documentation Template for Commands:**
-```markdown
-## command-name
-
-Brief description.
-
-### Usage
-\`\`\`bash
-staqan-yt command-name <args>
-\`\`\`
-
-### Arguments
-- `arg` - Description
-
-### Options
-- `--flag` - Description
-- `-v, --verbose` - Enable verbose output
-
-### Examples
-\`\`\`bash
-# Basic usage
-staqan-yt command-name value
-\`\`\`
-
-### Output Fields
-- Field descriptions
-
-### Related Commands
-- Links to related commands
-```
-
-**Verification:**
-- [ ] Command documented in `docs/commands/<category>.md`
-- [ ] Help grouping updated in `lib/customHelp.ts`
-- [ ] Examples tested and work correctly
-- [ ] Related commands cross-referenced
-
-### Troubleshooting TypeScript Errors
-
-**"Cannot find module" errors:**
-```bash
-# Solution: Check imports use correct paths
-import { getVideoInfo } from '../lib/youtube';  # Correct
-import { getVideoInfo } from '../lib/youtube.ts';  # Wrong - no .ts extension
-```
-
-**Type errors with googleapis:**
-```typescript
-// Use optional chaining and non-null assertions carefully
-const channelId = response.data.items?.[0]?.snippet?.channelId;
-if (!channelId) {
-  throw new Error('Channel not found');
-}
-```
-
-**ESLint errors:**
-```bash
-npm run lint          # See all errors
-# Fix common issues:
-# - Unused imports: Remove them
-# - Unused variables: Prefix with _ if intentional
-# - any type: Add proper types
-```
-
-**Build errors:**
-```bash
-# Clean build and try again
-rm -rf dist/
-npm run build
-
-# Check for syntax errors in .ts files
-npm run type-check
-```
-
-## YouTube Data API v3 Guidelines
-
-### Required Scopes
-
-```javascript
-const SCOPES = [
-  'https://www.googleapis.com/auth/youtube.readonly',      // Read operations
-  'https://www.googleapis.com/auth/youtube.force-ssl',     // Write operations
-];
-```
-
-### Common Operations
-
-**Get video details:**
-```javascript
-const response = await youtube.videos.list({
-  part: 'snippet,statistics,contentDetails',
-  id: videoIds.join(',')
-});
-```
-
-**List channel videos:**
-```javascript
-// First get uploads playlist ID
-const channelResponse = await youtube.channels.list({
-  part: 'contentDetails',
-  forUsername: username
-});
-
-// Then get videos from playlist
-const playlistResponse = await youtube.playlistItems.list({
-  part: 'snippet',
-  playlistId: uploadsPlaylistId,
-  maxResults: 50
-});
-```
-
-**Update video metadata:**
-```javascript
-await youtube.videos.update({
-  part: 'snippet',
-  requestBody: {
-    id: videoId,
-    snippet: {
-      title: newTitle,
-      description: newDescription,
-      categoryId: '24' // Keep existing category
-    }
-  }
-});
-```
-
-### API Quotas
-
-**Default quota:** 10,000 units/day
-
-**Cost per operation:**
-- Read operations: 1 unit
-- Write operations: 50 units
-- List operations: 1-100 units (depends on parts)
-
-**Be mindful of quota usage** - batch operations when possible.
-
-## Error Handling
-
-### User-Friendly Errors
-
-```javascript
-try {
-  // operation
-} catch (err) {
-  if (err.code === 403) {
-    error('API quota exceeded. Try again tomorrow.');
-  } else if (err.code === 404) {
-    error('Video not found. Check the video ID.');
-  } else {
-    error(`Failed: ${err.message}`);
-  }
-  process.exit(1);
-}
-```
-
-### Authentication Errors
-
-```javascript
-if (!token) {
-  throw new Error('No authentication token found. Please run: staqan-yt auth');
-}
-```
-
-## Output Formatting
-
-### Output Format System
-
-The CLI supports 5 output formats via `--output <format>`:
-
-- **json** - Machine-readable JSON (2-space indentation)
-- **table** - ASCII table format with borders and column alignment
-- **text** - Tab-delimited output for Unix pipelines (awk, cut)
-- **pretty** - Colorful, human-friendly output (default)
-- **csv** - RFC 4180 CSV format for Excel and data analysis
-
-### Implementing Output Formats in Commands
-
-```typescript
-import { getOutputFormat } from '../lib/config';
-import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-
-const outputFormat = await getOutputFormat(options.output);
-
-switch (outputFormat) {
-  case 'json':
-    console.log(formatJson(data));
-    break;
-  case 'table':
-    console.log(formatTable(data));
-    break;
-  case 'text':
-    data.forEach(item => console.log(Object.values(item).join('\t')));
-    break;
-  case 'csv':
-    console.log(formatCsv(data));
-    break;
-  case 'pretty':
-  default:
-    // Colorful output using chalk
-    break;
-}
-```
-
-### CSV Format Details
-
-The CSV formatter (`formatCsv`) follows RFC 4180 standards:
-- Escapes fields containing commas, quotes, or newlines
-- Doubles internal quotes for proper escaping
-- Handles nested objects by JSON-encoding them
-- Always includes a header row with field names
-
-**Example usage:**
-```bash
-# Export to Excel
-staqan-yt list-videos @channel --output csv > videos.csv
-
-# Analytics to CSV
-staqan-yt get-video-analytics VIDEO_ID --output csv > analytics.csv
-
-# Pipe to other tools
-staqan-yt get-video-tags VIDEO_ID --output csv | csvkit
-```
-
-### Pretty Output (default)
-
-Use chalk for colors:
-```javascript
-const chalk = require('chalk');
-
-console.log(chalk.cyan('Video ID:'), videoId);
-console.log(chalk.green('✓'), 'Title:', title);
-console.log(chalk.yellow('Views:'), viewCount);
-```
-
-Use ora for spinners:
-```javascript
-const ora = require('ora');
-
-const spinner = ora('Fetching videos...').start();
-// ... operation ...
-spinner.succeed('Videos fetched!');
-```
-
-## Testing
-
-### Manual Testing
-
-```bash
-# Test authentication
-staqan-yt auth
-
-# Test configuration
-staqan-yt config list
-staqan-yt config set default.channel @staqan
-staqan-yt config set default.output csv
-staqan-yt config get default.channel
-
-# Test all output formats for get-video
-staqan-yt get-video dQw4w9WgXcQ --output json
-staqan-yt get-video dQw4w9WgXcQ --output table
-staqan-yt get-video dQw4w9WgXcQ --output text
-staqan-yt get-video dQw4w9WgXcQ --output csv
-staqan-yt get-video dQw4w9WgXcQ --output pretty
-
-# Test get multiple videos
-staqan-yt get-videos dQw4w9WgXcQ abc123xyz --output csv
-
-# Test list videos (with and without channel argument)
-staqan-yt list-videos @mkbhd --limit 5 --output csv
-staqan-yt list-videos --limit 5  # Uses default channel from config
-
-# Test update (dry run)
-staqan-yt update-video dQw4w9WgXcQ --title "Test" --dry-run
-```
-
-### Local Development
-
-```bash
-# Install dependencies
-npm install
-
-# Link for global testing
-npm link
-
-# Test commands
-staqan-yt --help
-```
-
-## Git Workflow
-
-### ⚠️ BRANCH STRATEGY - MOST CRITICAL RULE
-
-**🚨 NEVER, EVER commit directly to main branch! 🚨**
-
-**Before making ANY changes:**
-```bash
-# Check current branch - MUST NOT be main
-git branch --show-current
-
-# If on main, create feature branch FIRST
-git checkout -b feature/your-feature-name
-```
-
-**Branch naming convention:**
-- `feature/feature-name` - New features
-- `fix/bug-name` - Bug fixes
-- `refactor/name` - Code refactoring
-
-**Correct Workflow:**
-```bash
-# 1. Create a feature branch (DO THIS FIRST)
-git checkout -b feature/your-feature-name
-
-# 2. Make changes and commit on feature branch
-git add -A
-git commit -m "Description"
-
-# 3. Push feature branch (NOT main)
-git push -u origin feature/your-feature-name
-
-# 4. Create PR via GitHub or gh CLI
-gh pr create --title "Feature: Your Feature" --body "Description"
-
-# 5. After PR merge, delete the branch
-git checkout main
-git pull
-git branch -d feature/your-feature-name
-```
-
-**Recovery if you mess up:**
-```bash
-# If you accidentally committed to main:
-git reset --soft HEAD~1              # Undo commit, keep changes
-git checkout -b feature/your-feature  # Create proper branch
-git add -A                           # Stage changes
-git commit -m "Description"           # Commit on feature branch
-git push -u origin feature/your-feature  # Push feature branch
-gh pr create                          # Create PR
-
-# Never push the commit to main!
-```
-
-**Protecting main branch:**
-Consider enabling branch protection rules on GitHub to prevent direct commits to main.
-
-### Commit Message Format
-
-Follow the established pattern:
+## Commit Message Format
 
 ```
 Brief description of change
@@ -958,355 +350,15 @@ Detailed explanation if needed
 Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
 ```
 
-### Before Committing
-
-**MANDATORY PRE-COMMIT CHECKLIST:**
-- [ ] **On a feature branch?** (NOT main!)
-- [ ] **Tested all affected commands?**
-- [ ] **Updated documentation?**
-  - [ ] README.md (if user-facing changes)
-  - [ ] docs/commands/<category>.md (command reference)
-  - [ ] lib/customHelp.ts (help grouping)
-- [ ] **Following AWS naming conventions?**
-- [ ] **Credentials never committed?**
-
-**Verify branch before committing:**
-```bash
-# This MUST NOT be "main"
-git branch --show-current
-
-# If it shows "main", STOP and create feature branch:
-git checkout -b feature/your-feature-name
-```
-
-**Verify what you're committing:**
-```bash
-# Check staged files
-git diff --staged --name-only
-
-# Check for unintended files (credentials, etc.)
-git status
-```
-
-- [ ] Test all affected commands
-- [ ] Update documentation:
-  - [ ] README.md (if user-facing)
-  - [ ] docs/commands/<category>.md (command reference)
-  - [ ] lib/customHelp.ts (help grouping)
-- [ ] Follow AWS naming conventions
-- [ ] Ensure credentials never committed
-
-### Release Process
-
-**This project does NOT use GitHub releases.** All releases are managed through version bumps, git tags, and Homebrew formula updates.
-
-**IMPORTANT: After completing a task in a session, always release a new patch version before ending the session.**
-
-**Single source of truth:** `package.json` is the source of truth for versioning. All other files are automatically synced from it.
-
-**Release workflow:**
-
-**Option 1: Using npm version (recommended):**
-```bash
-# Automatically bumps version, syncs all files, creates commit & tag
-npm version patch   # For bug fixes and minor changes (X.Y.Z -> X.Y.Z+1)
-npm version minor   # For new features (X.Y.Z -> X.Y+1.0)
-npm version major   # For breaking changes (X.Y.Z -> X+1.0.0) - rarely used
-
-# Push to GitHub
-git push && git push --tags
-```
-
-**Option 2: Manual version bump:**
-```bash
-# 1. Edit package.json version manually
-# 2. Sync version to other files
-npm run sync-version
-
-# 3. Commit changes
-git add -A
-git commit -m "Bump version to X.Y.Z
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
-
-# 4. Create git tag
-git tag vX.Y.Z
-
-# 5. Push to GitHub
-git push && git push --tags
-```
-
-**What gets synced automatically:**
-- `package.json` - Source of truth
-- `bin/staqan-yt.ts` - Fallback version for compiled binary
-- `Formula/staqan-yt.rb` - Homebrew formula version
-
-**Semantic versioning rules (X.Y.Z):**
-
-- **Z (patch)** - Bump for normal releases:
-  - Bug fixes
-  - Minor improvements
-  - Documentation updates
-  - Non-breaking changes
-
-- **Y (minor)** - Bump only if changes are significant:
-  - New commands added
-  - New features
-  - Significant refactoring
-  - Breaking changes to non-public APIs
-
-- **X (major)** - NEVER bump unless explicitly instructed:
-  - Reserved for major breaking changes
-  - Requires explicit approval
-  - Should be extremely rare
-
-**Default behavior:** Always bump Z (patch) unless told otherwise.
-
-**Example releases:**
-- `1.2.3` → `1.2.4` - Bug fix, documentation update
-- `1.2.4` → `1.3.0` - Added new `list-playlists` command
-- `1.3.0` → `2.0.0` - Only if explicitly instructed for major breaking change
-
-## Hidden Internal Commands
-
-Some commands are registered with Commander's `{ hidden: true }` option and never appear in `staqan-yt help` output. They are implementation details and must **not** be documented in user-facing docs (README, docs/).
-
-### `__complete`
-
-**File:** `commands/complete.ts`
-**Registered in:** `bin/staqan-yt.ts` via `program.addCommand(cmd, { hidden: true })`
-
-**Purpose:** Subprocess helper for shell tab completion scripts. Shell scripts (bash/zsh) call this command and use its stdout as completion candidates.
-
-**Usage:**
-```bash
-staqan-yt __complete --type video-id      # Video IDs + titles for default channel
-staqan-yt __complete --type playlist-id   # Playlist IDs + titles for default channel
-staqan-yt __complete --type report-type   # Report type IDs + names
-```
-
-**Output format:** One `id\ttitle` per line (tab-separated). No spinners, no chalk, no extra output.
-
-**Caching:** Results are cached in `~/.staqan-yt-cli/completion-cache.json`:
-- `video-id` / `playlist-id`: 5-minute TTL, keyed as `video-id:@channel`
-- `report-type`: 1-hour TTL, keyed as `report-type`
-
-**Error handling:** Any error (no auth, no default channel, network failure) causes silent `process.exit(0)` — completion simply shows no candidates rather than printing an error to the terminal.
-
-**Shell integration:** The generated bash/zsh scripts in `lib/completion.ts` call `__complete` as a subprocess and feed its output into `_describe` (zsh) or `compgen -W` (bash).
-
 ---
 
-## Common Pitfalls
+## Release Process
 
-### ❌ Don't Do This
+**Single source of truth**: `package.json` is the source of truth for versioning.
 
-```javascript
-// Don't hardcode credentials
-const CLIENT_ID = 'hardcoded-id'; // NEVER
-
-// Don't use inconsistent naming
-program.command('getVideo'); // Wrong casing
-program.command('video-get'); // Wrong order
-
-// Don't mix singular/plural incorrectly
-program.command('get-videos <videoId>'); // Should be get-video
-
-// Don't put semantic logic here
-async function analyzeSubtitles() { } // Belongs in project CLAUDE.md
-```
-
-### ✅ Do This
-
-```javascript
-// Load credentials from standard location
-const credentials = await loadCredentials(); // From ~/.staqan-yt-cli/
-
-// Use AWS-style naming
-program.command('get-video <videoId>');    // Singular
-program.command('get-videos <ids...>');    // Plural batch
-
-// Keep it programmatic
-async function getVideoMetadata(videoId) {
-  // Pure API operation
-}
-```
-
-## Dependencies
-
-### Core Dependencies
-
-- `googleapis` - YouTube Data API client
-- `google-auth-library` - OAuth 2.0
-- `commander` - CLI framework
-- `chalk` - Terminal colors
-- `ora` - Loading spinners
-- `open` - Open browser for OAuth
-
-### When Adding Dependencies
-
-- Prefer official Google libraries
-- Keep bundle size reasonable
-- Document in package.json
-- Test on clean install
-
-## Future Enhancements
-
-### Potential Commands (following AWS conventions)
-
-**Playlist management:**
-- `get-playlist <playlistId>` - Get single playlist
-- `get-playlists <id1> <id2>` - Get multiple playlists
-- `list-playlists <channelId>` - List channel playlists
-- `create-playlist` - Create new playlist
-- `update-playlist <playlistId>` - Update playlist
-- `delete-playlist <playlistId>` - Delete playlist
-
-**Comment management:**
-- `get-comment <commentId>` - Get single comment
-- `list-comments <videoId>` - List video comments
-- `update-comment <commentId>` - Update comment
-- `delete-comment <commentId>` - Delete comment
-
-**Channel management:**
-- `get-channel <channelId>` - Get channel info
-- `update-channel` - Update channel metadata
-
-**Captions:**
-- `list-captions <videoId>` - List available captions
-- `download-caption <captionId>` - Download caption file
-- `upload-caption <videoId>` - Upload new caption
-
-### When Adding Features
-
-1. Check if it fits the "programmatic YouTube API operations" scope
-2. Use AWS naming conventions
-3. Add appropriate OAuth scopes if needed
-4. Document in `docs/commands/<category>.md` and update `lib/customHelp.ts`
-5. Update README.md if user-facing feature
-6. Test with real YouTube data
-
-## Security Considerations
-
-### OAuth Token Security
-
-- Tokens stored in `~/.staqan-yt-cli/token.json`
-- File permissions: Read/write for user only
-- Never log tokens
-- Auto-refresh expired tokens
-
-### Input Validation
-
-```javascript
-// Validate video IDs (11 characters, alphanumeric + - _)
-if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
-  error('Invalid video ID format');
-  process.exit(1);
-}
-```
-
-## Maintenance
-
-### Updating Dependencies
+### Quick Release (After Completing Work)
 
 ```bash
-# Check for updates
-npm outdated
-
-# Update carefully
-npm update
-
-# Test after updates
-npm test  # (when tests are added)
-```
-
-### Breaking Changes
-
-If YouTube API changes:
-1. Update googleapis dependency
-2. Test all commands
-3. Update documentation
-4. Increment major version
-
-## Dependabot Vulnerability Management
-
-This project uses GitHub Dependabot for automated dependency vulnerability tracking. When Dependabot detects vulnerabilities, they appear as alerts on the repository.
-
-### Checking for Vulnerabilities
-
-**Use GitHub CLI to fetch Dependabot alerts:**
-```bash
-# List all open Dependabot alerts
-gh api '/repos/OWNER/REPO/dependabot/alerts?state=open'
-
-# Get formatted summary
-gh api '/repos/prog893/staqan-yt-cli/dependabot/alerts?state=open' \
-  --jq '.[] | "\(.security_vulnerability.severity) - \(.dependency.package.name) (vulnerable: \(.security_vulnerability.vulnerable_version_range), patched: \(.security_vulnerability.first_patched_version.identifier))"'
-```
-
-**Git push provides vulnerability feedback:**
-When you push to GitHub, the remote will alert you if there are vulnerabilities:
-```
-remote: GitHub found 7 vulnerabilities on prog893/staqan-yt-cli's default branch (3 high, 4 moderate).
-remote: To find out more about visit: https://github.com/prog893/staqan-yt-cli/security/dependabot
-```
-
-This serves as an **automatic trigger** - if you see this message, you should address the vulnerabilities before continuing.
-
-**IMPORTANT:** The vulnerability count shown during push reflects the state **before** your push. Dependabot rescans after the push completes, so even after pushing a fix, you'll still see the old warning. Don't worry - the count will update on the next push once Dependabot rescans.
-
-### Vulnerability Fix Workflow
-
-**1. Assess the vulnerabilities**
-```bash
-# Fetch and review alerts
-gh api '/repos/prog893/staqan-yt-cli/dependabot/alerts?state=open' | jq .
-
-# Check dependency chain
-npm ls <vulnerable-package>
-```
-
-**2. Update dependencies**
-```bash
-# Update specific package
-npm update <package-name>
-
-# Or update all (use with caution)
-npm update
-```
-
-**3. Test thoroughly**
-```bash
-# Build the project
-npm run build
-
-# Test all non-destructive commands:
-# - Video operations: get-video, get-videos, get-thumbnail, get-video-tags
-# - Localizations: get-video-localizations, get-video-localization
-# - Comments: list-comments
-# - Playlists: list-playlists, get-playlist, get-playlists
-# - Config: config list/get/set
-# - MCP server: staqan-yt mcp (test with timeout)
-# - Output formats: test with --output json/table/text/csv/pretty
-```
-
-**4. Commit and release**
-```bash
-# Commit the fix
-git add package-lock.json
-git commit -m "Fix: Update <package> to address security vulnerabilities
-
-- Updated <package> from X.Y.Z to A.B.C
-- Fixes N Dependabot alerts (X HIGH, Y MEDIUM severity)
-- Resolves CVE-XXXX-XXXXX
-- All non-destructive CLI commands tested and working
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
-
 # Bump patch version
 npm version patch
 
@@ -1314,96 +366,68 @@ npm version patch
 git push && git push --tags
 ```
 
-**5. Verify**
-After pushing, GitHub will rescan the repository asynchronously.
-- **Expected:** You may still see vulnerability warnings on this push (they reflect the pre-push state)
-- **Verification:** The Dependabot alerts page will update within a few minutes
-- **Confirmation:** Next time you push, the warning will be gone if the fix was successful
+### Semantic Versioning (X.Y.Z)
 
-### Vulnerability Severity Classification
+- **Z (patch)** - Bug fixes, minor improvements, documentation updates
+- **Y (minor)** - New commands, new features, significant refactoring
+- **X (major)** - NEVER bump unless explicitly instructed
 
-Based on the article [Dependabot alerts を 0 でキープしたい](https://zenn.dev/tsukulink/articles/c4a204897930a9):
+**→ See [Git Workflow Guide](docs/development/git-workflow.md#release-process) for detailed release process.**
 
-| Severity | Timeline | Examples |
-|----------|----------|----------|
-| **Critical** | Immediate | System can be stopped, personal data exposed |
-| **High** | This month | Limited attack conditions, non-critical impact |
-| **Moderate** | Within 6 months | Dev-only usage, vulnerable feature not used |
-| **None** | Skip | Not actually used |
+---
 
-### Example: Real-World Fix
+## Related Documentation
 
-**Issue:** 7 Dependabot alerts (3 HIGH, 4 MEDIUM)
-- `@modelcontextprotocol/sdk` - Cross-client data leak (HIGH)
-- `hono` - Multiple vulnerabilities (2 HIGH, 4 MEDIUM)
+- **[README.md](README.md)** - User-facing documentation (Homebrew-focused)
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contributor guide for humans
+- **[docs/](docs/README.md)** - Comprehensive command reference
+- **[docs/development/](docs/development/README.md)** - Development guides hub
 
-**Root cause analysis:**
-```bash
-npm ls hono
-# staqan-yt-cli
-# └── @modelcontextprotocol/sdk@1.25.2
-#     └── @hono/node-server@1.19.8
-#         └── hono@4.11.3
+---
+
+## Updating This Documentation
+
+### CLAUDE.md
+
+This file is the **core manifesto** - keep it concise:
+1. Critical rules (branch strategy, commit format)
+2. Quick reference (commands, patterns, locations)
+3. Architecture summaries (link to detailed guides)
+4. Links to `docs/development/` guides
+
+**DO NOT add detailed tutorials.** Keep under 400 lines.
+
+### Development Guides
+
+Each guide in `docs/development/` covers one topic. Update with:
+- Detailed content and examples
+- Cross-references to related guides
+- Tested code examples
+
+**→ See [docs/development/README.md](docs/development/README.md) for guide philosophy**
+
+---
+
+## Common Pitfalls
+
+**❌ Don't:**
+```javascript
+const CLIENT_ID = 'hardcoded-id';  // NEVER hardcode credentials
+program.command('getVideo');        // Wrong casing (use get-video)
+program.command('get-videos <id>'); // Wrong (singular ID with plural name)
+async function analyzeSubtitles() { } // Semantic logic belongs elsewhere
 ```
 
-**Solution:** Update the direct dependency
-```bash
-npm update @modelcontextprotocol/sdk
-# This automatically updates hono to 4.11.8 (patched version)
+**✅ Do:**
+```javascript
+const creds = await loadCredentials(); // From ~/.staqan-yt-cli/
+program.command('get-video <id>');     // AWS-style naming
+program.command('get-videos <ids...>'); // Plural for batch
+async function getVideo() { /* API only */ }
 ```
 
-**Result:** All 7 alerts fixed with one update, tested comprehensively, released as v1.3.6.
+---
 
-### Best Practices
+## Version
 
-1. **Keep alerts at 0** - Stay sensitive to new security warnings
-2. **Check dependency chains** - Transitive dependencies often bring vulnerabilities
-3. **Test after updates** - Especially for functionality that uses vulnerable packages
-4. **Document legitimate usage** - If a package has vulnerabilities but you don't use the affected features, document why
-5. **Update quickly for HIGH/CRITICAL** - These can have real security impact
-6. **Plan updates for MODERATE** - These can be batched with other maintenance
-
-### Automating Vulnerability Detection
-
-Consider creating a GitHub Actions workflow (similar to the Zenn article) to:
-- Check Dependabot alerts daily
-- Post to Slack when new alerts appear
-- Create issues for unaddressed vulnerabilities
-
-Example reference: https://zenn.dev/tsukulink/articles/c4a204897930a9
-
-## Support
-
-### GitHub Issues
-
-Report bugs at: https://github.com/prog893/staqan-yt-cli/issues
-
-### When Users Report Issues
-
-1. Check if it's an API quota issue
-2. Verify OAuth credentials are set up correctly
-3. Test with the reporter's exact command
-4. Check YouTube API status
-
-## Quick Reference
-
-**Install globally:**
-```bash
-npm link
-```
-
-**Test command:**
-```bash
-staqan-yt get-video dQw4w9WgXcQ
-```
-
-**AWS naming:**
-- Singular: `get-video`, `update-video`
-- Plural: `get-videos`, `list-videos`, `search-videos`
-
-**Credentials location:**
-```
-~/.staqan-yt-cli/
-├── credentials.json
-└── token.json
-```
+Current version: **1.3.18** (see `package.json` for source of truth)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,47 @@ staqan-yt-cli/
 - Metadata generation logic
 - Language-specific tone guidance
 
-### 2. AWS API Naming Conventions
+### 2. File Operation Concurrency
+
+### Lock Strategy
+
+The CLI uses file-based locks with PID checking to prevent concurrent writes:
+
+**Lock files:**
+- `data/{channelId}/completion_cache.json.lock` - Completion cache
+- `data/handle-to-channel-id.json.lock` - Handle→channelId cache
+- `data/{channelId}/reports/.lock` - Per-channel reports directory
+
+**Lock behavior:**
+- Locks contain PID + timestamp
+- Automatic stale lock detection (PID doesn't exist OR age > 30min)
+- Acquire with timeout: `acquireLock(lockPath, { timeout })`
+- Always release in `finally` block
+
+**When adding new file writes:**
+1. Identify if lock is needed (concurrent access possible?)
+2. Use appropriate lock file (file.lock or .lock for dir)
+3. Always use try/finally to ensure cleanup
+4. Test with concurrent operations
+
+**Example pattern:**
+```typescript
+import { acquireLock, getLockPath } from './lock';
+
+async function writeSomething(): Promise<void> {
+  const lockPath = getLockPath('your-type', channelId);
+  let release: (() => Promise<void>) | null = null;
+
+  try {
+    release = await acquireLock(lockPath, { timeout: 5000 });
+    // ... write operations ...
+  } finally {
+    if (release) await release();
+  }
+}
+```
+
+### 3. AWS API Naming Conventions
 
 **CRITICAL**: All commands must follow AWS API naming conventions and use **NO positional arguments**.
 

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -474,6 +474,7 @@ program
   .command('get-report-data')
   .description('Get YouTube Reporting API report data (thumbnail impressions, CTR, etc.)')
   .requiredOption('--type <id>', 'Report type ID (e.g., channel_reach_basic_a1 for thumbnail data)')
+  .option('-c, --channel <handle>', 'Channel handle or ID (overrides config default)')
   .option('--video-id <id>', 'Filter by video ID')
   .option('--start-date <date>', 'Start date (YYYY-MM-DD)')
   .option('--end-date <date>', 'End date (YYYY-MM-DD)')
@@ -484,6 +485,7 @@ program
 program
   .command('fetch-reports')
   .description('Download and cache all available report data (archival)')
+  .option('-c, --channel <handle>', 'Channel handle or ID (overrides config default)')
   .option('-t, --type <id>', 'Fetch specific report type')
   .option('-T, --types <ids>', 'Fetch multiple report types (comma-separated)')
   .option('--start-date <date>', 'Filter by start date (YYYY-MM-DD)')

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -41,7 +41,9 @@ import completeCommand = require('../commands/complete');
 // Helper function to wrap command actions to handle "help" as an argument
 // Note: Using any[] here is pragmatic - we only check for "help" string,
 // then forward args to the properly-typed command function
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function withHelpWrapper(commandName: string, actionFn: (...args: any[]) => Promise<void> | void) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return async (...args: any[]) => {
     // Check if "help" is in the command arguments (before Commander's validation)
     // This works even for commands with required options

--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -21,6 +21,9 @@ const TTL: Record<CompletionType, number> = {
   'report-type': 60 * 60 * 1000,
 };
 
+// report-type completions are credential-scoped (not channel-specific)
+const GLOBAL_CACHE_PATH = path.join(CONFIG_DIR, 'data', 'completion_cache.json');
+
 function getChannelCachePath(channelId: string): string {
   return path.join(CONFIG_DIR, 'data', channelId, 'completion_cache.json');
 }
@@ -33,14 +36,17 @@ async function loadCache(cachePath: string): Promise<CompletionCache> {
   }
 }
 
-async function saveCache(cachePath: string, cache: CompletionCache, channelId: string): Promise<void> {
-  const lockPath = getLockPath('completion', channelId);
+// channelId is optional: provided for per-channel caches (acquires lock),
+// omitted for the global report-type cache (no lock needed).
+async function saveCache(cachePath: string, cache: CompletionCache, channelId?: string): Promise<void> {
   let release: (() => Promise<void>) | null = null;
 
   try {
     await fs.mkdir(path.dirname(cachePath), { recursive: true });
-    // Acquire lock with 2 second timeout (completion is fast)
-    release = await acquireLock(lockPath, { timeout: 2000 });
+    if (channelId) {
+      // Acquire lock with 2 second timeout (completion is fast)
+      release = await acquireLock(getLockPath('completion', channelId), { timeout: 2000 });
+    }
     await fs.writeFile(cachePath, JSON.stringify(cache), { mode: 0o600 });
 
     debug('Completion cache saved');
@@ -58,15 +64,6 @@ async function completeCommand(options: { type: string }): Promise<void> {
     if (!VALID_TYPES.includes(options.type as CompletionType)) process.exit(0);
     const type = options.type as CompletionType;
 
-    // All completion types require a channel to be configured
-    const channel = await getConfigValue('default.channel');
-    if (!channel) process.exit(0);
-
-    // Resolve handle → canonical channel ID for namespacing
-    const channelId = await getChannelId(channel);
-    const cachePath = getChannelCachePath(channelId);
-    const cache = await loadCache(cachePath);
-
     let items: Array<{ id: string; title: string }> | undefined;
 
     // Spinner for cold fetch - only show when running interactively (TTY)
@@ -75,6 +72,14 @@ async function completeCommand(options: { type: string }): Promise<void> {
 
     try {
       if (type === 'video-id' || type === 'playlist-id') {
+        // Video/playlist completions are channel-specific — require configured channel
+        const channel = await getConfigValue('default.channel');
+        if (!channel) process.exit(0);
+
+        const channelId = await getChannelId(channel);
+        const cachePath = getChannelCachePath(channelId);
+        const cache = await loadCache(cachePath);
+
         const entry = cache[type];
         if (entry && Date.now() - entry.fetchedAt < TTL[type]) {
           items = entry.items;
@@ -97,6 +102,10 @@ async function completeCommand(options: { type: string }): Promise<void> {
           }
         }
       } else if (type === 'report-type') {
+        // Report types are credential-scoped (same for any channel on this account)
+        // No channel configuration required
+        const cache = await loadCache(GLOBAL_CACHE_PATH);
+
         const entry = cache[type];
         if (entry && Date.now() - entry.fetchedAt < TTL[type]) {
           items = entry.items;
@@ -115,7 +124,7 @@ async function completeCommand(options: { type: string }): Promise<void> {
           }
           if (items.length > 0) {
             cache[type] = { items, fetchedAt: Date.now() };
-            await saveCache(cachePath, cache, channelId);
+            await saveCache(GLOBAL_CACHE_PATH, cache);
           }
         }
       }

--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -38,10 +38,9 @@ async function saveCache(cachePath: string, cache: CompletionCache, channelId: s
   let release: (() => Promise<void>) | null = null;
 
   try {
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
     // Acquire lock with 2 second timeout (completion is fast)
     release = await acquireLock(lockPath, { timeout: 2000 });
-
-    await fs.mkdir(path.dirname(cachePath), { recursive: true });
     await fs.writeFile(cachePath, JSON.stringify(cache), { mode: 0o600 });
 
     debug('Completion cache saved');

--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -8,13 +8,11 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import ora from 'ora';
 import { google } from 'googleapis';
-import { getChannelVideos, listChannelPlaylists } from '../lib/youtube';
+import { getChannelVideos, listChannelPlaylists, getChannelId } from '../lib/youtube';
 import { getConfigValue } from '../lib/config';
 import { getAuthenticatedClient } from '../lib/auth';
-import { CONFIG_DIR, ensureConfigDir, debug } from '../lib/utils';
+import { CONFIG_DIR, debug } from '../lib/utils';
 import { CompletionType, CompletionCache } from '../types';
-
-const CACHE_PATH = path.join(CONFIG_DIR, 'completion-cache.json');
 
 const TTL: Record<CompletionType, number> = {
   'video-id': 5 * 60 * 1000,
@@ -22,18 +20,22 @@ const TTL: Record<CompletionType, number> = {
   'report-type': 60 * 60 * 1000,
 };
 
-async function loadCache(): Promise<CompletionCache> {
+function getChannelCachePath(channelId: string): string {
+  return path.join(CONFIG_DIR, 'data', channelId, 'completion_cache.json');
+}
+
+async function loadCache(cachePath: string): Promise<CompletionCache> {
   try {
-    return JSON.parse(await fs.readFile(CACHE_PATH, 'utf-8'));
+    return JSON.parse(await fs.readFile(cachePath, 'utf-8'));
   } catch {
     return {};
   }
 }
 
-async function saveCache(cache: CompletionCache): Promise<void> {
+async function saveCache(cachePath: string, cache: CompletionCache): Promise<void> {
   try {
-    await ensureConfigDir();
-    await fs.writeFile(CACHE_PATH, JSON.stringify(cache), { mode: 0o600 });
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, JSON.stringify(cache), { mode: 0o600 });
   } catch (err) {
     debug('Failed to save completion cache:', (err as Error).message);
   }
@@ -45,30 +47,31 @@ async function completeCommand(options: { type: string }): Promise<void> {
   try {
     if (!VALID_TYPES.includes(options.type as CompletionType)) process.exit(0);
     const type = options.type as CompletionType;
-    const cache = await loadCache();
-    let cacheKey: string = type;
+
+    // All completion types require a channel to be configured
+    const channel = await getConfigValue('default.channel');
+    if (!channel) process.exit(0);
+
+    // Resolve handle → canonical channel ID for namespacing
+    const channelId = await getChannelId(channel);
+    const cachePath = getChannelCachePath(channelId);
+    const cache = await loadCache(cachePath);
 
     let items: Array<{ id: string; title: string }> | undefined;
 
-    // Spinner for cold fetch - only show when running interactively (TTY), not from shell scripts
+    // Spinner for cold fetch - only show when running interactively (TTY)
     const isInteractive = process.stdout.isTTY;
     let spinner: ReturnType<typeof ora> | null = null;
 
     try {
       if (type === 'video-id' || type === 'playlist-id') {
-        const channel = await getConfigValue('default.channel');
-        if (!channel) process.exit(0);
-        cacheKey = `${type}:${channel}`;
-        const entry = cache[cacheKey];
+        const entry = cache[type];
         if (entry && Date.now() - entry.fetchedAt < TTL[type]) {
           items = entry.items;
         } else {
-          // Cold fetch - show spinner only in interactive mode
           if (isInteractive) {
             spinner = ora('Fetching completion candidates...').start();
           }
-          // 50 is a practical cap: enough for meaningful completion without
-          // hammering the API or making tab press noticeably slow.
           const raw = type === 'video-id'
             ? await getChannelVideos(channel, 50)
             : await listChannelPlaylists(channel, 50);
@@ -79,16 +82,15 @@ async function completeCommand(options: { type: string }): Promise<void> {
             spinner.succeed(`Fetched ${items.length} completion candidates`);
           }
           if (items.length > 0) {
-            cache[cacheKey] = { items, fetchedAt: Date.now() };
-            await saveCache(cache);
+            cache[type] = { items, fetchedAt: Date.now() };
+            await saveCache(cachePath, cache);
           }
         }
       } else if (type === 'report-type') {
-        const entry = cache[cacheKey];
+        const entry = cache[type];
         if (entry && Date.now() - entry.fetchedAt < TTL[type]) {
           items = entry.items;
         } else {
-          // Cold fetch - show spinner only in interactive mode
           if (isInteractive) {
             spinner = ora('Fetching report types...').start();
           }
@@ -102,15 +104,14 @@ async function completeCommand(options: { type: string }): Promise<void> {
             spinner.succeed(`Fetched ${items.length} report types`);
           }
           if (items.length > 0) {
-            cache[cacheKey] = { items, fetchedAt: Date.now() };
-            await saveCache(cache);
+            cache[type] = { items, fetchedAt: Date.now() };
+            await saveCache(cachePath, cache);
           }
         }
       }
 
       (items || []).forEach(item => console.log(`${item.id}\t${item.title}`));
     } finally {
-      // Ensure spinner is stopped even on error
       if (isInteractive && spinner) {
         spinner.stop();
       }

--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -11,6 +11,7 @@ import { google } from 'googleapis';
 import { getChannelVideos, listChannelPlaylists, getChannelId } from '../lib/youtube';
 import { getConfigValue } from '../lib/config';
 import { getAuthenticatedClient } from '../lib/auth';
+import { acquireLock, getLockPath } from '../lib/lock';
 import { CONFIG_DIR, debug } from '../lib/utils';
 import { CompletionType, CompletionCache } from '../types';
 
@@ -32,12 +33,22 @@ async function loadCache(cachePath: string): Promise<CompletionCache> {
   }
 }
 
-async function saveCache(cachePath: string, cache: CompletionCache): Promise<void> {
+async function saveCache(cachePath: string, cache: CompletionCache, channelId: string): Promise<void> {
+  const lockPath = getLockPath('completion', channelId);
+  let release: (() => Promise<void>) | null = null;
+
   try {
+    // Acquire lock with 2 second timeout (completion is fast)
+    release = await acquireLock(lockPath, { timeout: 2000 });
+
     await fs.mkdir(path.dirname(cachePath), { recursive: true });
     await fs.writeFile(cachePath, JSON.stringify(cache), { mode: 0o600 });
+
+    debug('Completion cache saved');
   } catch (err) {
     debug('Failed to save completion cache:', (err as Error).message);
+  } finally {
+    if (release) await release();
   }
 }
 
@@ -83,7 +94,7 @@ async function completeCommand(options: { type: string }): Promise<void> {
           }
           if (items.length > 0) {
             cache[type] = { items, fetchedAt: Date.now() };
-            await saveCache(cachePath, cache);
+            await saveCache(cachePath, cache, channelId);
           }
         }
       } else if (type === 'report-type') {
@@ -105,7 +116,7 @@ async function completeCommand(options: { type: string }): Promise<void> {
           }
           if (items.length > 0) {
             cache[type] = { items, fetchedAt: Date.now() };
-            await saveCache(cachePath, cache);
+            await saveCache(cachePath, cache, channelId);
           }
         }
       }

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -8,6 +8,8 @@ import {
   loadReportMetadata,
   parseCsvAndExtractRange,
 } from '../lib/cache';
+import { getChannelId } from '../lib/youtube';
+import { getConfigValue } from '../lib/config';
 import https from 'https';
 import { createWriteStream, unlinkSync } from 'fs';
 import { unlink } from 'fs/promises';
@@ -15,6 +17,7 @@ import path from 'path';
 import chalk from 'chalk';
 
 interface FetchReportsOptions {
+  channel?: string;
   type?: string;
   types?: string;
   startDate?: string;
@@ -99,6 +102,19 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
   initCommand(options);
 
   await withSpinner('Initializing...', 'Failed to fetch reports', async (spinner) => {
+    // Resolve channel handle → canonical channel ID for cache namespacing
+    const channelHandle = options.channel || await getConfigValue('default.channel');
+    if (!channelHandle) {
+      spinner.fail('No channel configured');
+      console.log('');
+      error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
+      process.exit(1);
+    }
+
+    spinner.text = `Resolving channel ID for ${channelHandle}...`;
+    const channelId = await getChannelId(channelHandle);
+    debug(`Using channel ID: ${channelId}`);
+
     const auth = await getAuthenticatedClient();
     const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
 
@@ -220,7 +236,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         const endTime = report.endTime!;
 
         // Check if already cached
-        const cached = await findCachedReports(reportTypeId, startTime, endTime);
+        const cached = await findCachedReports(channelId, reportTypeId, startTime, endTime);
 
         if (cached.length > 0 && !options.force) {
           debug(`Skipping cached report: ${reportId} (${startTime} to ${endTime})`);
@@ -244,9 +260,10 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
           const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
 
           // Save to cache
-          await saveReportToCache(reportId, reportTypeId, csvData, {
+          await saveReportToCache(channelId, reportId, reportTypeId, csvData, {
             reportId,
             reportTypeId,
+            channelId,
             jobId,
             startTime,
             endTime,
@@ -282,12 +299,12 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     if (options.verify) {
       spinner.text = 'Verifying cached files...';
 
-      const index = await loadCacheIndex();
+      const index = await loadCacheIndex(channelId);
       let verified = 0;
       let corrupted = 0;
 
       for (const entry of index.entries) {
-        const metadata = await loadReportMetadata(entry.reportId, entry.reportTypeId);
+        const metadata = await loadReportMetadata(channelId, entry.reportId, entry.reportTypeId);
 
         if (!metadata) {
           warning(`Missing metadata: ${entry.reportId}`);

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -117,13 +117,21 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     const channelId = await getChannelId(channelHandle);
     debug(`Using channel ID: ${channelId}`);
 
+    // Ensure cache directory exists before touching the lock
+    try {
+      await ensureCacheDir(channelId);
+    } catch (err) {
+      spinner.fail('Failed to create cache directory');
+      error((err as Error).message);
+      process.exit(1);
+    }
+
     // Acquire lock for entire fetch operation
     const lockPath = getLockPath('reports', channelId);
     let release: (() => Promise<void>) | null = null;
 
     try {
       spinner.text = 'Acquiring lock...';
-      await ensureCacheDir(channelId);
       release = await acquireLock(lockPath, { timeout: 60000 }); // 60 second timeout
 
       spinner.text = 'Initializing...';
@@ -153,6 +161,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         spinner.fail('No report types found');
         console.log('');
         error('No report types found matching your criteria.');
+        if (release) await release(); release = null;
         process.exit(1);
       }
 
@@ -347,10 +356,15 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
 
     success('Fetch complete!');
     } catch (err) {
-      spinner.fail('Failed to acquire reports lock');
-      error((err as Error).message);
-      console.log('');
-      error('Another fetch operation is in progress. Wait for it to complete or run: rm ~/.staqan-yt-cli/data/*/reports/.lock');
+      if (!release) {
+        spinner.fail('Could not acquire lock for reports');
+        console.log('');
+        error('Another fetch operation is in progress. Wait for it to complete or run: rm ~/.staqan-yt-cli/data/*/reports/.lock');
+      } else {
+        if (release) await release(); release = null;
+        spinner.fail('Failed while fetching reports');
+        error((err as Error).message);
+      }
       process.exit(1);
     } finally {
       if (release) await release();

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -310,7 +310,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     if (options.verify) {
       spinner.text = 'Verifying cached files...';
 
-      const index = await loadCacheIndex(channelId);
+      const index = await loadCacheIndex(channelId, channelHandle);
       let verified = 0;
       let corrupted = 0;
 

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -10,6 +10,7 @@ import {
 } from '../lib/cache';
 import { getChannelId } from '../lib/youtube';
 import { getConfigValue } from '../lib/config';
+import { acquireLock, getLockPath } from '../lib/lock';
 import https from 'https';
 import { createWriteStream, unlinkSync } from 'fs';
 import { unlink } from 'fs/promises';
@@ -115,17 +116,26 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     const channelId = await getChannelId(channelHandle);
     debug(`Using channel ID: ${channelId}`);
 
-    const auth = await getAuthenticatedClient();
-    const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
+    // Acquire lock for entire fetch operation
+    const lockPath = getLockPath('reports', channelId);
+    let release: (() => Promise<void>) | null = null;
 
-    // Step 1: Discover report types
-    spinner.text = 'Discovering report types...';
+    try {
+      spinner.text = 'Acquiring lock...';
+      release = await acquireLock(lockPath, { timeout: 60000 }); // 60 second timeout
 
-    const typesResponse = await youtubeReporting.reportTypes.list({
-      onBehalfOfContentOwner: undefined,
-    });
+      spinner.text = 'Initializing...';
+      const auth = await getAuthenticatedClient();
+      const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
 
-    let reportTypes = typesResponse.data.reportTypes || [];
+      // Step 1: Discover report types
+      spinner.text = 'Discovering report types...';
+
+      const typesResponse = await youtubeReporting.reportTypes.list({
+        onBehalfOfContentOwner: undefined,
+      });
+
+      let reportTypes = typesResponse.data.reportTypes || [];
 
     // Filter by --type or --types if specified
     if (options.type) {
@@ -337,6 +347,15 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     console.log('');
 
     success('Fetch complete!');
+    } catch (err) {
+      spinner.fail('Failed to acquire reports lock');
+      error((err as Error).message);
+      console.log('');
+      error('Another fetch operation is in progress. Wait for it to complete or run: rm ~/.staqan-yt-cli/data/*/reports/.lock');
+      process.exit(1);
+    } finally {
+      if (release) await release();
+    }
   });
 }
 

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -7,6 +7,7 @@ import {
   loadCacheIndex,
   loadReportMetadata,
   parseCsvAndExtractRange,
+  ensureCacheDir,
 } from '../lib/cache';
 import { getChannelId } from '../lib/youtube';
 import { getConfigValue } from '../lib/config';
@@ -34,7 +35,7 @@ interface FetchReportsOptions {
 async function downloadReport(
   report: { id?: string | null; downloadUrl?: string | null; startTime?: string | null; endTime?: string | null; createTime?: string | null },
   auth: { getAccessToken(): Promise<{ token?: string | null }> }
-): Promise<{ csvData: string; headers: string[]; data: Record<string, string>[] }> {
+): Promise<{ csvData: string; headers: string[]; data: Record<string, string>[]; minDate: string; maxDate: string }> {
   const tmpPath = path.join('/tmp', `${report.id}.csv`);
 
   // Get access token for authenticated request
@@ -93,7 +94,7 @@ async function downloadReport(
     // Ignore cleanup errors
   }
 
-  return { csvData, headers: parsed.headers, data: parsed.data };
+  return { csvData, headers: parsed.headers, data: parsed.data, minDate: parsed.minDate, maxDate: parsed.maxDate };
 }
 
 /**
@@ -122,6 +123,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
 
     try {
       spinner.text = 'Acquiring lock...';
+      await ensureCacheDir(channelId);
       release = await acquireLock(lockPath, { timeout: 60000 }); // 60 second timeout
 
       spinner.text = 'Initializing...';
@@ -137,32 +139,32 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
 
       let reportTypes = typesResponse.data.reportTypes || [];
 
-    // Filter by --type or --types if specified
-    if (options.type) {
-      reportTypes = reportTypes.filter(t => t.id === options.type);
-      debug(`Filtering by single type: ${options.type}`);
-    } else if (options.types) {
-      const requestedIds = options.types.split(',');
-      reportTypes = reportTypes.filter(t => requestedIds.includes(t.id!));
-      debug(`Filtering by multiple types: ${requestedIds.join(', ')}`);
-    }
+      // Filter by --type or --types if specified
+      if (options.type) {
+        reportTypes = reportTypes.filter(t => t.id === options.type);
+        debug(`Filtering by single type: ${options.type}`);
+      } else if (options.types) {
+        const requestedIds = options.types.split(',');
+        reportTypes = reportTypes.filter(t => requestedIds.includes(t.id!));
+        debug(`Filtering by multiple types: ${requestedIds.join(', ')}`);
+      }
 
-    if (reportTypes.length === 0) {
-      spinner.fail('No report types found');
+      if (reportTypes.length === 0) {
+        spinner.fail('No report types found');
+        console.log('');
+        error('No report types found matching your criteria.');
+        process.exit(1);
+      }
+
+      spinner.succeed(`Found ${reportTypes.length} report type(s)`);
       console.log('');
-      error('No report types found matching your criteria.');
-      process.exit(1);
-    }
 
-    spinner.succeed(`Found ${reportTypes.length} report type(s)`);
-    console.log('');
+      // Step 2: Process each report type
+      let totalDownloaded = 0;
+      let totalSkipped = 0;
+      let totalErrors = 0;
 
-    // Step 2: Process each report type
-    let totalDownloaded = 0;
-    let totalSkipped = 0;
-    let totalErrors = 0;
-
-    for (const reportType of reportTypes) {
+      for (const reportType of reportTypes) {
       const reportTypeId = reportType.id!;
       spinner.text = `Processing ${reportTypeId}...`;
 
@@ -259,10 +261,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         // Download report
         try {
           spinner.text = `Downloading ${reportTypeId}: ${startTime} to ${endTime}...`;
-          const { csvData, headers, data } = await downloadReport(report, auth);
-
-          // Parse CSV to get actual date range
-          const parsed = parseCsvAndExtractRange(csvData);
+          const { csvData, headers, data, minDate, maxDate } = await downloadReport(report, auth);
 
           // Calculate expiration date
           const jobCreated = new Date(matchingJob.createTime || '');
@@ -279,8 +278,8 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
             jobId,
             startTime,
             endTime,
-            startTimeActual: parsed.minDate || startTime,
-            endTimeActual: parsed.maxDate || endTime,
+            startTimeActual: minDate || startTime,
+            endTimeActual: maxDate || endTime,
             downloadedAt: new Date().toISOString(),
             expiresAt: expiresAt.toISOString(),
             downloadUrl: report.downloadUrl!,

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -236,8 +236,8 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       if (options.startDate || options.endDate) {
         const allMinDate = reports[reports.length - 1].startTime!.split('T')[0]; // Oldest
         const allMaxDate = reports[0].endTime!.split('T')[0]; // Newest
-        const filteredStart = options.startDate || allMinDate;
-        const filteredEnd = options.endDate || allMaxDate;
+        const filteredStart = (options.startDate || allMinDate).split('T')[0];
+        const filteredEnd = (options.endDate || allMaxDate).split('T')[0];
 
         reports = reports.filter((report: typeof reports[0]) => {
           const reportStart = report.startTime!.split('T')[0];
@@ -357,11 +357,15 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     success('Fetch complete!');
     } catch (err) {
       if (!release) {
+        // Lock acquisition failed
+        const lockPath = getLockPath('reports', channelId);
         spinner.fail('Could not acquire lock for reports');
         console.log('');
-        error('Another fetch operation is in progress. Wait for it to complete or run: rm ~/.staqan-yt-cli/data/*/reports/.lock');
+        error('Another fetch operation is in progress. Wait for it to complete, or remove the lock:');
+        error(`  rm ${lockPath}`);
       } else {
-        if (release) await release(); release = null;
+        // Lock was acquired, error occurred during operation
+        await release();  // Release lock before exiting
         spinner.fail('Failed while fetching reports');
         error((err as Error).message);
       }

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -211,15 +211,17 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         continue;
       }
 
-      // Filter by date range if specified
+      // Filter by date range if specified (compare date portions only)
       if (options.startDate || options.endDate) {
-        const allMinDate = reports[reports.length - 1].startTime; // Oldest
-        const allMaxDate = reports[0].endTime; // Newest
-        const filteredStart = options.startDate || allMinDate!;
-        const filteredEnd = options.endDate || allMaxDate!;
+        const allMinDate = reports[reports.length - 1].startTime!.split('T')[0]; // Oldest
+        const allMaxDate = reports[0].endTime!.split('T')[0]; // Newest
+        const filteredStart = options.startDate || allMinDate;
+        const filteredEnd = options.endDate || allMaxDate;
 
         reports = reports.filter((report: typeof reports[0]) => {
-          return report.startTime! >= filteredStart && report.endTime! <= filteredEnd;
+          const reportStart = report.startTime!.split('T')[0];
+          const reportEnd = report.endTime!.split('T')[0];
+          return reportStart >= filteredStart && reportEnd <= filteredEnd;
         });
 
         debug(`Filtered to ${reports.length} report(s) for date range`);

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,7 +1,7 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
 import { error, debug, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
-import { getOutputFormat } from '../lib/config';
+import { getOutputFormat, getConfigValue } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 import {
   analyzeCacheCoverage,
@@ -10,6 +10,7 @@ import {
   saveReportToCache,
   parseCsvAndExtractRange,
 } from '../lib/cache';
+import { getChannelId } from '../lib/youtube';
 import { CacheIndexEntry } from '../types';
 import https from 'https';
 import { createWriteStream, unlinkSync } from 'fs';
@@ -19,6 +20,7 @@ import chalk from 'chalk';
 
 interface ReportDataOptions {
   type: string;
+  channel?: string;
   videoId?: string;
   startDate?: string;
   endDate?: string;
@@ -95,6 +97,19 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
   initCommand(options);
 
   await withSpinner('Checking for existing reporting job...', 'Failed to fetch report data', async (spinner) => {
+    // Resolve channel handle → canonical channel ID for cache namespacing
+    const channelHandle = options.channel || await getConfigValue('default.channel');
+    if (!channelHandle) {
+      spinner.fail('No channel configured');
+      console.log('');
+      error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
+      process.exit(1);
+    }
+
+    spinner.text = `Resolving channel ID for ${channelHandle}...`;
+    const channelId = await getChannelId(channelHandle);
+    debug(`Using channel ID: ${channelId}`);
+
     const auth = await getAuthenticatedClient();
     const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
 
@@ -192,8 +207,8 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       if (requestedStart < minDate) {
         const missingDays = Math.ceil((new Date(minDate).getTime() - new Date(requestedStart).getTime()) / (24 * 60 * 60 * 1000));
         console.log(chalk.red('Missing:') + ` ${requestedStart} to ${minDate} (${missingDays} days, expired and deleted)`);
-        console.log(chalk.yellow('Tip:') + ' Download reports before expiration to avoid data loss');
-        console.log(chalk.yellow('Tip:') + ` Run 'staqan-yt fetch-reports --type=${options.type}'`);
+        console.log(chalk.yellow('Tip:') + ' Run fetch-reports regularly to keep a local archive and avoid data loss:');
+        console.log(chalk.gray('       ') + chalk.cyan(`staqan-yt fetch-reports --type=${options.type}`));
         console.log('');
       }
 
@@ -219,7 +234,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     // Step 5: Analyze cache coverage
     spinner.text = 'Analyzing cache coverage...';
-    const coverage = await analyzeCacheCoverage(options.type, requestedStart, requestedEnd);
+    const coverage = await analyzeCacheCoverage(channelId, options.type, requestedStart, requestedEnd);
     debug('Cache coverage:', coverage);
 
     // Step 6: Load cached data
@@ -228,10 +243,10 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     for (const range of coverage.fullyCovered) {
       const [start, end] = range.split('/');
-      const cached = await findCachedReports(options.type, start, end);
+      const cached = await findCachedReports(channelId, options.type, start, end);
 
       for (const cachedReport of cached) {
-        const reportData = await readCachedReport(cachedReport.reportId, options.type);
+        const reportData = await readCachedReport(channelId, cachedReport.reportId, options.type);
         if (reportData) {
           allData.push(...reportData.data);
           cachedReports.push(cachedReport);
@@ -261,7 +276,6 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       const reportStart = report.startTime!;
       const reportEnd = report.endTime!;
 
-      // Check if this report covers any missing range
       const coversMissing = missingRanges.some(range => {
         return reportStart <= range.end && reportEnd >= range.start;
       });
@@ -297,9 +311,10 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       const parsed = parseCsvAndExtractRange(csvData);
 
       // Save to cache
-      await saveReportToCache(report.id || '', options.type, csvData, {
+      await saveReportToCache(channelId, report.id || '', options.type, csvData, {
         reportId: report.id || '',
         reportTypeId: options.type,
+        channelId,
         jobId,
         startTime: report.startTime || '',
         endTime: report.endTime || '',
@@ -395,7 +410,6 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     const jobCreated = new Date(matchingJob!.createTime || '');
 
     for (const report of cachedReports) {
-      // For cached reports, check expiration based on metadata
       const expiresAt = new Date(report.expiresAt);
       const daysUntilExpiration = Math.ceil((expiresAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
 
@@ -420,7 +434,8 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
         console.log(chalk.yellow('⚠️  Expiration Notice:'));
         console.log(chalk.gray('  Report:') + ` ${report.startTime} to ${report.endTime} (new)`);
         console.log(chalk.gray('  Expires:') + ' ' + chalk.red(`${expiresAt.toISOString().split('T')[0]} (${daysUntilExpiration} days remaining)`));
-        console.log(chalk.yellow('  Tip:') + ` Run 'staqan-yt fetch-reports --type=${options.type}' to archive it`);
+        console.log(chalk.yellow('  Tip:') + ' Run fetch-reports regularly to keep a local archive:');
+        console.log(chalk.gray('         ') + chalk.cyan(`staqan-yt fetch-reports --type=${options.type}`));
         console.log('');
       }
     }

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -166,7 +166,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     if (reports.length === 0) {
       // Job exists but no reports yet (within 48h window)
-      const jobCreated = new Date(matchingJob!.createTime || '');
+      const jobCreated = new Date(matchingJob.createTime || '');
       const readyAt = new Date(jobCreated.getTime() + 48 * 60 * 60 * 1000);
       const now = new Date();
       const hoursUntilReady = Math.max(0, Math.ceil((readyAt.getTime() - now.getTime()) / (1000 * 60 * 60)));
@@ -174,7 +174,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
       spinner.succeed('Job exists but no reports yet');
       console.log('');
-      console.log(chalk.gray('Created:') + ' ' + matchingJob!.createTime);
+      console.log(chalk.gray('Created:') + ' ' + matchingJob.createTime);
       console.log(chalk.gray('Ready:') + ' ' + chalk.cyan(`${formatted.local} (${formatted.timezone})`));
       console.log(chalk.yellow('Wait:') + ' ' + chalk.cyan(`${hoursUntilReady} hours remaining`));
       console.log('');
@@ -313,7 +313,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
         const { csvData, headers, data } = await downloadReport(report, auth, tmpPath);
 
         // Calculate expiration date
-        const jobCreated = new Date(matchingJob!.createTime || '');
+        const jobCreated = new Date(matchingJob.createTime || '');
         const reportCreated = new Date(report.createTime || '');
         const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
         const expirationDays = isHistorical ? 30 : 60;
@@ -424,7 +424,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     // Step 10: Show expiration warning for the reports used
     const now = new Date();
-    const jobCreated = new Date(matchingJob!.createTime || '');
+    const jobCreated = new Date(matchingJob.createTime || '');
 
     for (const report of cachedReports) {
       const expiresAt = new Date(report.expiresAt);

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -181,9 +181,9 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       process.exit(0);
     }
 
-    // Step 3: Validate date range
-    const minDate = reports[reports.length - 1].startTime; // Oldest
-    const maxDate = reports[0].endTime; // Newest
+    // Step 3: Validate date range (API returns timestamps, compare date portions only)
+    const minDate = reports[reports.length - 1].startTime!.split('T')[0]; // Oldest
+    const maxDate = reports[0].endTime!.split('T')[0]; // Newest
 
     const requestedStart = options.startDate || minDate;
     const requestedEnd = options.endDate || maxDate;
@@ -220,9 +220,11 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       process.exit(1);
     }
 
-    // Step 4: Filter reports by date range
+    // Step 4: Filter reports by date range (compare date portions only)
     reports = reports.filter((report: typeof reports[0]) => {
-      return report.startTime! >= requestedStart && report.endTime! <= requestedEnd;
+      const reportStart = report.startTime!.split('T')[0];
+      const reportEnd = report.endTime!.split('T')[0];
+      return reportStart >= requestedStart && reportEnd <= requestedEnd;
     });
 
     if (reports.length === 0) {

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -11,6 +11,7 @@ import {
   parseCsvAndExtractRange,
 } from '../lib/cache';
 import { getChannelId } from '../lib/youtube';
+import { acquireLock, getLockPath } from '../lib/lock';
 import { CacheIndexEntry } from '../types';
 import https from 'https';
 import { createWriteStream, unlinkSync } from 'fs';
@@ -293,54 +294,68 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     const tmpDir = '/tmp';
 
-    for (let i = 0; i < reportsToFetch.length; i++) {
-      const report = reportsToFetch[i];
-      const tmpPath = path.join(tmpDir, `${report.id}.csv`);
+    // Acquire lock just before writes; soft-fail with warning if busy
+    let writeRelease: (() => Promise<void>) | null = null;
+    try {
+      writeRelease = await acquireLock(getLockPath('reports', channelId), { timeout: 5000 });
+    } catch {
+      console.log(chalk.gray('Info: could not acquire lock for reports, skipping cache update'));
+    }
 
-      spinner.text = `Downloading report ${i + 1}/${reportsToFetch.length}...`;
+    try {
+      for (let i = 0; i < reportsToFetch.length; i++) {
+        const report = reportsToFetch[i];
+        const tmpPath = path.join(tmpDir, `${report.id}.csv`);
 
-      // Download report
-      const { csvData, headers, data } = await downloadReport(report, auth, tmpPath);
+        spinner.text = `Downloading report ${i + 1}/${reportsToFetch.length}...`;
 
-      // Calculate expiration date
-      const jobCreated = new Date(matchingJob!.createTime || '');
-      const reportCreated = new Date(report.createTime || '');
-      const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
-      const expirationDays = isHistorical ? 30 : 60;
-      const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
+        // Download report
+        const { csvData, headers, data } = await downloadReport(report, auth, tmpPath);
 
-      // Parse CSV to get actual date range
-      const parsed = parseCsvAndExtractRange(csvData);
+        // Calculate expiration date
+        const jobCreated = new Date(matchingJob!.createTime || '');
+        const reportCreated = new Date(report.createTime || '');
+        const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
+        const expirationDays = isHistorical ? 30 : 60;
+        const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
 
-      // Save to cache
-      await saveReportToCache(channelId, report.id || '', options.type, csvData, {
-        reportId: report.id || '',
-        reportTypeId: options.type,
-        channelId,
-        jobId,
-        startTime: report.startTime || '',
-        endTime: report.endTime || '',
-        startTimeActual: parsed.minDate,
-        endTimeActual: parsed.maxDate,
-        downloadedAt: new Date().toISOString(),
-        expiresAt: expiresAt.toISOString(),
-        downloadUrl: report.downloadUrl || '',
-        columns: headers,
-        isComplete: true,
-        fileSize: csvData.length,
-        row_count: data.length,
-      });
+        // Parse CSV to get actual date range
+        const parsed = parseCsvAndExtractRange(csvData);
 
-      allData.push(...data);
+        if (writeRelease) {
+          // Save to cache
+          await saveReportToCache(channelId, report.id || '', options.type, csvData, {
+            reportId: report.id || '',
+            reportTypeId: options.type,
+            channelId,
+            jobId,
+            startTime: report.startTime || '',
+            endTime: report.endTime || '',
+            startTimeActual: parsed.minDate,
+            endTimeActual: parsed.maxDate,
+            downloadedAt: new Date().toISOString(),
+            expiresAt: expiresAt.toISOString(),
+            downloadUrl: report.downloadUrl || '',
+            columns: headers,
+            isComplete: true,
+            fileSize: csvData.length,
+            row_count: data.length,
+          });
+        }
 
-      // Cleanup
-      try {
-        unlinkSync(tmpPath);
-      } catch {
-        // Ignore cleanup errors
+        allData.push(...data);
+
+        // Cleanup
+        try {
+          unlinkSync(tmpPath);
+        } catch {
+          // Ignore cleanup errors
+        }
+
+        debug(`Downloaded: ${report.startTime} to ${report.endTime}`);
       }
-
-      debug(`Downloaded: ${report.startTime} to ${report.endTime}`);
+    } finally {
+      if (writeRelease) await writeRelease();
     }
 
     spinner.succeed(`Retrieved ${cachedReports.length} cached + ${reportsToFetch.length} new report(s)`);

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -103,7 +103,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
 
       let total = 0;
       allRows.forEach(row => {
-        const value = (row as unknown[])[index];
+        const value = row[index];
         if (typeof value === 'number') {
           total += value;
         }

--- a/commands/get-video-retention.ts
+++ b/commands/get-video-retention.ts
@@ -117,9 +117,9 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
         // Convert rows to table format with readable timestamps
         const totalSeconds = parseDuration(duration);
         const tableData = allRows.map(row => ({
-          timestamp: formatTimestamp((row as unknown[])[0] as number * totalSeconds),
-          retentionPercent: (((row as unknown[])[1] as number) * 100).toFixed(1) + '%',
-          relativePerformance: ((row as unknown[])[2] as number).toFixed(2),
+          timestamp: formatTimestamp(row[0] as number * totalSeconds),
+          retentionPercent: ((row[1] as number) * 100).toFixed(1) + '%',
+          relativePerformance: (row[2] as number).toFixed(2),
         }));
         console.log(formatTable(tableData));
         break;
@@ -130,9 +130,9 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
         const totalSeconds = parseDuration(duration);
         allRows.forEach(row => {
           console.log([
-            formatTimestamp((row as unknown[])[0] as number * totalSeconds),
-            (((row as unknown[])[1] as number) * 100).toFixed(1),
-            ((row as unknown[])[2] as number).toFixed(2)
+            formatTimestamp(row[0] as number * totalSeconds),
+            ((row[1] as number) * 100).toFixed(1),
+            (row[2] as number).toFixed(2)
           ].join('\t'));
         });
         break;
@@ -163,9 +163,9 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
         console.log(chalk.gray('─'.repeat(60)));
 
         allRows.forEach(row => {
-          const timeRatio = (row as unknown[])[0] as number; // 0.0 to 1.0
-          const watchRatio = (row as unknown[])[1] as number; // Percentage still watching
-          const relativePerformance = (row as unknown[])[2] as number; // vs similar videos
+          const timeRatio = row[0] as number; // 0.0 to 1.0
+          const watchRatio = row[1] as number; // Percentage still watching
+          const relativePerformance = row[2] as number; // vs similar videos
 
           // Convert time ratio to actual timestamp
           const elapsedSeconds = timeRatio * totalSeconds;

--- a/commands/list-report-types.ts
+++ b/commands/list-report-types.ts
@@ -61,9 +61,9 @@ async function listReportTypesCommand(options: ReportTypesOptions): Promise<void
         break;
 
       case 'text':
-        Object.entries(grouped).forEach(([category, types]) => {
+        Object.entries(grouped).forEach(([category, types]: [string, typeof reportTypes]) => {
           console.log(`\n${category.toUpperCase()}:`);
-          (types as typeof reportTypes).forEach(rt => {
+          types.forEach(rt => {
             console.log(`  ${rt.id}`);
             console.log(`    Name: ${rt.name}`);
             console.log('');

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,25 +138,7 @@ Common issues and solutions:
 - [YouTube Data API Docs](https://developers.google.com/youtube/v3)
 - [Issue Tracker](https://github.com/prog893/staqan-yt-cli/issues)
 
-## Command Patterns
-
-### AWS-Style Naming
-
-Commands follow AWS API naming conventions:
-
-**Singular = Single-item operations:**
-```bash
-get-video <videoId>        # Get ONE video
-update-video <videoId>     # Update ONE video
-```
-
-**Plural = Batch/list operations:**
-```bash
-get-videos <id1> <id2>     # Get MULTIPLE videos
-list-videos <channel>      # List videos in channel
-```
-
-### Global Options
+## Global Options
 
 All commands support these options:
 

--- a/docs/commands/reporting-api.md
+++ b/docs/commands/reporting-api.md
@@ -150,6 +150,7 @@ staqan-yt get-report-data
 ### Options
 
 - `--type <id>` - Report type ID (e.g., `channel_reach_basic_a1`)
+- `-c, --channel <handle>` - Channel handle or ID (overrides config default)
 - `--video-id <id>` - Filter by video ID
 - `--start-date <date>` - Start date (YYYY-MM-DD)
 - `--end-date <date>` - End date (YYYY-MM-DD)
@@ -229,7 +230,12 @@ staqan-yt get-report-data \
 
 **⚡ Caching:** The `get-report-data` command automatically caches downloaded reports. Subsequent requests for the same date range are instant (loaded from cache).
 
-Cache location: `~/.staqan-yt-cli/data/reports/`
+Cache location: `~/.staqan-yt-cli/data/{channelId}/reports/`
+
+**Required:** Set a default channel or pass `--channel`:
+```bash
+staqan-yt config set default.channel @yourchannel
+```
 
 ### Data Freshness
 
@@ -251,6 +257,7 @@ staqan-yt fetch-reports
 
 ### Options
 
+- `-c, --channel <handle>` - Channel handle or ID (overrides config default)
 - `-t, --type <id>` - Fetch specific report type
 - `-T, --types <ids>` - Fetch multiple report types (comma-separated)
 - `--start-date <date>` - Filter by start date (YYYY-MM-DD)
@@ -291,8 +298,13 @@ staqan-yt fetch-reports --force
 
 **Solution:** Use `fetch-reports` periodically to:
 - Download all available reports before they expire
-- Store them locally in `~/.staqan-yt-cli/data/reports/`
+- Store them locally in `~/.staqan-yt-cli/data/{channelId}/reports/`
 - Access historical data anytime via `get-report-data`
+
+**Required:** Set a default channel first:
+```bash
+staqan-yt config set default.channel @yourchannel
+```
 
 ### Recommended Workflow
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,72 @@
+# Development Guides
+
+This directory contains comprehensive guides for developing and maintaining the staqan-yt-cli project. These guides are designed for progressive disclosure—read what you need, when you need it.
+
+## 🚀 Quick Start Paths
+
+### I want to add a new command
+1. Read [Adding Commands Guide](adding-commands.md) - Step-by-step process
+2. Reference [TypeScript Guide](typescript-guide.md) - Type safety patterns
+3. Check [Testing Guide](testing-guide.md) - How to test your changes
+4. Follow [Git Workflow](git-workflow.md) - Branch, commit, and release
+
+### I'm new to the project
+1. Read [CLAUDE.md](../../CLAUDE.md) - Critical rules and quick reference
+2. Review [Architecture Guide](architecture.md) - Understand the codebase
+3. Explore [YouTube API Guide](youtube-api-guide.md) - Domain-specific patterns
+4. Read [Error Handling Guide](error-handling.md) - Error patterns
+
+### I found a security vulnerability
+1. Read [Security Guide](security-guide.md) - Security best practices
+2. Check [Maintenance Guide](maintenance-guide.md) - Dependabot workflow
+3. Follow [Git Workflow](git-workflow.md) - Patch release process
+
+### I need to update dependencies
+1. Read [Maintenance Guide](maintenance-guide.md) - Dependabot and updates
+2. Follow [Testing Guide](testing-guide.md) - Test after updates
+3. Use [Git Workflow](git-workflow.md) - Release process
+
+## 📚 All Guides
+
+### Core Development
+- **[TypeScript Guide](typescript-guide.md)** - TypeScript configuration, type safety, ESLint, and common patterns
+- **[Adding Commands Guide](adding-commands.md)** - Step-by-step command creation with templates
+- **[Testing Guide](testing-guide.md)** - Manual testing strategies and local development
+- **[Error Handling Guide](error-handling.md)** - User-friendly error patterns
+
+### Implementation Details
+- **[Output Formats Guide](output-formats.md)** - Implementing JSON, table, CSV, and pretty output
+- **[YouTube API Guide](youtube-api-guide.md)** - YouTube Data API v3 patterns and quotas
+- **[Security Guide](security-guide.md)** - OAuth security and input validation
+- **[Architecture Guide](architecture.md)** - Lock strategy, hidden commands, scope boundaries
+
+### Maintenance & Operations
+- **[Git Workflow Guide](git-workflow.md)** - Branch strategy, commits, releases, and protection
+- **[Maintenance Guide](maintenance-guide.md)** - Dependency updates and Dependabot vulnerability management
+- **[Troubleshooting Guide](troubleshooting.md)** - TypeScript and build error resolution
+
+## 📖 Related Documentation
+
+- **[CLAUDE.md](../../CLAUDE.md)** - Critical rules and quick reference (start here!)
+- **[README.md](../../README.md)** - User-facing documentation
+- **[CONTRIBUTING.md](../../CONTRIBUTING.md)** - Contributor guide for humans
+- **[docs/](../README.md)** - Comprehensive command reference
+
+## 🎯 Guide Philosophy
+
+These guides follow progressive disclosure principles:
+
+1. **Quick reference first** - CLAUDE.md has the essentials
+2. **Deep dive when needed** - Each guide focuses on one topic
+3. **Cross-references** - Guides link to related content
+4. **Examples over theory** - Real code patterns from the codebase
+5. **Why and how** - Rationale followed by implementation
+
+## 🔄 Contributing to Guides
+
+When updating these guides:
+- Keep each guide focused on a single topic
+- Use real examples from the codebase
+- Cross-reference related guides
+- Update CLAUDE.md if the change affects critical rules
+- Test examples against actual code behavior

--- a/docs/development/adding-commands.md
+++ b/docs/development/adding-commands.md
@@ -1,0 +1,339 @@
+# Adding Commands Guide
+
+This guide provides a step-by-step process for adding new commands to the staqan-yt-cli, following AWS API naming conventions and project patterns.
+
+## Step 1: Choose the Correct Name
+
+Follow AWS conventions:
+- **Single-item operation?** Use singular noun: `get-playlist`, `update-comment`
+- **Batch/list operation?** Use plural noun: `get-playlists`, `list-comments`
+
+### Naming Pattern Examples
+
+**Singular = Single-item operations:**
+```bash
+get-video --video-id <id>        # Get ONE video
+update-video --video-id <id>     # Update ONE video
+delete-video --video-id <id>     # Delete ONE video (if added)
+```
+
+**Plural = Batch/list operations:**
+```bash
+get-videos --video-ids <id1> <id2>     # Get MULTIPLE videos (batch)
+list-videos --channel <handle>         # List videos in channel
+search-videos --query <text>           # Search multiple videos
+```
+
+### Required Flags Pattern
+
+- Single ID: Use `--resource-id <id>` (singular flag name, singular ID)
+- Multiple IDs: Use `--resource-ids <id...>` (plural flag name, variadic IDs)
+- Other required params: Use descriptive flag names (e.g., `--query <text>`)
+
+**🚨 RULE: Everything is a named flag. No positional arguments at all.**
+
+## Step 2: Create Command File
+
+Create `commands/your-command.ts`:
+
+```typescript
+import ora from 'ora';
+import { success, error, info } from '../lib/utils';
+import { getAuthenticatedClient } from '../lib/auth';
+import { google } from 'googleapis';
+import { JsonOption } from '../types';
+
+interface YourCommandOptions extends JsonOption {
+  // Add your option types here
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+async function yourCommand(args: string, options: YourCommandOptions): Promise<void> {
+  const spinner = ora('Processing...').start();
+
+  try {
+    const auth = await getAuthenticatedClient();
+    const youtube = google.youtube({ version: 'v3', auth });
+
+    // Your logic here
+
+    spinner.succeed('Operation completed!');
+    success('Done!');
+  } catch (err) {
+    spinner.fail('Operation failed');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = yourCommand;
+```
+
+## Step 3: Register in bin/staqan-yt.ts
+
+```typescript
+import yourCommand = require('../commands/your-command');
+
+program
+  .command('your-command <arg>')
+  .description('Description following AWS style')
+  .option('-j, --output json', 'Output in JSON format')
+  .action(yourCommand);
+```
+
+**Important**: Use `{ hidden: true }` for internal commands that shouldn't appear in help output.
+
+## Step 4: Add Types (if needed)
+
+Update `types/index.ts` if you have new shared types:
+
+```typescript
+export interface YourNewType {
+  field: string;
+  // ...
+}
+```
+
+## Step 5: Build and Test
+
+```bash
+npm run type-check    # Ensure no type errors
+npm run lint          # Ensure no linting errors
+npm run build         # Compile to dist/
+npm link              # Test globally
+```
+
+## Step 6: Update Documentation
+
+### Command Documentation (REQUIRED)
+
+Add to the appropriate `docs/commands/<category>.md` file:
+
+```markdown
+## command-name
+
+Brief description.
+
+### Usage
+\`\`\`bash
+staqan-yt command-name <args>
+\`\`\`
+
+### Arguments
+- `arg` - Description
+
+### Options
+- `--flag` - Description
+- `-v, --verbose` - Enable verbose output
+
+### Examples
+\`\`\`bash
+# Basic usage
+staqan-yt command-name value
+\`\`\`
+
+### Output Fields
+- Field descriptions
+
+### Related Commands
+- Links to related commands
+```
+
+### Help Command Grouping (REQUIRED)
+
+Update `lib/customHelp.ts` to include new command in appropriate group.
+
+### Documentation Verification
+
+- [ ] Command documented in `docs/commands/<category>.md`
+- [ ] Help grouping updated in `lib/customHelp.ts`
+- [ ] Examples tested and work correctly
+- [ ] Related commands cross-referenced
+
+## Command Templates
+
+### Simple Get Command
+
+```typescript
+import ora from 'ora';
+import { success, error } from '../lib/utils';
+import { getAuthenticatedClient } from '../lib/auth';
+import { google } from 'googleapis';
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatPretty } from '../lib/formatters';
+
+interface GetVideoOptions {
+  output?: string;
+}
+
+async function getVideoCommand(videoId: string, options: GetVideoOptions): Promise<void> {
+  const spinner = ora('Fetching video...').start();
+
+  try {
+    const auth = await getAuthenticatedClient();
+    const youtube = google.youtube({ version: 'v3', auth });
+
+    const response = await youtube.videos.list({
+      part: 'snippet,statistics',
+      id: videoId
+    });
+
+    if (!response.data.items || response.data.items.length === 0) {
+      spinner.fail('Video not found');
+      process.exit(1);
+    }
+
+    const video = response.data.items[0];
+    spinner.succeed('Video retrieved!');
+
+    const outputFormat = await getOutputFormat(options.output);
+
+    if (outputFormat === 'json') {
+      console.log(formatJson(video));
+    } else {
+      formatPretty(video);
+    }
+
+    success('Done!');
+  } catch (err) {
+    spinner.fail('Failed to fetch video');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = getVideoCommand;
+```
+
+### Update Command with Dry Run
+
+```typescript
+import ora from 'ora';
+import { success, error, info } from '../lib/utils';
+import { getAuthenticatedClient } from '../lib/auth';
+import { google } from 'googleapis';
+
+interface UpdateVideoOptions {
+  title?: string;
+  description?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+async function updateVideoCommand(videoId: string, options: UpdateVideoOptions): Promise<void> {
+  if (!options.title && !options.description) {
+    error('At least one of --title or --description must be provided');
+    process.exit(1);
+  }
+
+  const spinner = ora('Updating video...').start();
+
+  try {
+    const auth = await getAuthenticatedClient();
+    const youtube = google.youtube({ version: 'v3', auth });
+
+    if (options.dryRun) {
+      spinner.info('Dry run mode - no changes made');
+      info(`Would update video ${videoId}:`);
+      if (options.title) info(`  Title: ${options.title}`);
+      if (options.description) info(`  Description: ${options.description}`);
+      return;
+    }
+
+    if (!options.yes) {
+      spinner.info(`Updating video ${videoId}`);
+      // Add confirmation prompt if needed
+    }
+
+    await youtube.videos.update({
+      part: 'snippet',
+      requestBody: {
+        id: videoId,
+        snippet: {
+          title: options.title,
+          description: options.description,
+          categoryId: '24' // Keep existing category
+        }
+      }
+    });
+
+    spinner.succeed('Video updated!');
+    success('Done!');
+  } catch (err) {
+    spinner.fail('Failed to update video');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export = updateVideoCommand;
+```
+
+## Common Patterns
+
+### Loading Default Channel from Config
+
+```typescript
+import { getConfigValue } from '../lib/config';
+
+let channel = channelHandle || await getConfigValue('default.channel');
+if (!channel) {
+  error('No channel specified. Use --channel or set default.channel in config');
+  process.exit(1);
+}
+```
+
+### Output Format Switching
+
+```typescript
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+
+const outputFormat = await getOutputFormat(options.output);
+
+switch (outputFormat) {
+  case 'json':
+    console.log(formatJson(data));
+    break;
+  case 'table':
+    console.log(formatTable(data));
+    break;
+  case 'csv':
+    console.log(formatCsv(data));
+    break;
+  case 'text':
+    data.forEach(item => console.log(Object.values(item).join('\t')));
+    break;
+  case 'pretty':
+  default:
+    // Colorful output using chalk
+    break;
+}
+```
+
+### Error Handling
+
+```typescript
+try {
+  // operation
+} catch (err) {
+  if ((err as any).code === 403) {
+    error('API quota exceeded. Try again tomorrow.');
+  } else if ((err as any).code === 404) {
+    error('Video not found. Check the video ID.');
+  } else {
+    error(`Failed: ${(err as Error).message}`);
+  }
+  process.exit(1);
+}
+```
+
+## Related Guides
+
+- [TypeScript Guide](typescript-guide.md) - Type safety and patterns
+- [Testing Guide](testing-guide.md) - How to test commands
+- [Error Handling Guide](error-handling.md) - Error patterns
+- [Output Formats Guide](output-formats.md) - Output format implementation
+- [YouTube API Guide](youtube-api-guide.md) - API patterns
+- [Git Workflow Guide](git-workflow.md) - Branch, commit, release

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,277 @@
+# Architecture Guide
+
+This guide covers architectural principles, design patterns, and implementation details of the staqan-yt-cli project.
+
+## Clean Separation of Concerns
+
+### Programmatic vs Semantic Operations
+
+**This CLI is PURELY programmatic** - it handles YouTube API operations only:
+
+**IN SCOPE** (this CLI):
+- Fetch video metadata
+- List channel videos
+- Search videos
+- Update video metadata
+- OAuth 2.0 authentication
+- Localizations management
+- Comments and playlists
+- Analytics and reports
+
+**OUT OF SCOPE** (belongs in project-specific CLAUDE.md files):
+- Subtitle analysis
+- Content strategy
+- Metadata generation logic
+- Language-specific tone guidance
+
+### Example: Proper Separation
+
+```typescript
+// ✅ IN SCOPE - Pure API operation
+async function getVideoMetadata(videoId: string): Promise<VideoInfo> {
+  const response = await youtube.videos.list({
+    part: 'snippet',
+    id: videoId
+  });
+  return response.data.items?.[0];
+}
+
+// ❌ OUT OF SCOPE - Semantic analysis
+async function analyzeVideoQuality(videoId: string): Promise<string> {
+  const metadata = await getVideoMetadata(videoId);
+  // This belongs in project-specific code, not this CLI
+  return metadata.title.includes('tutorial') ? 'educational' : 'entertainment';
+}
+```
+
+## Lock Strategy
+
+### File Operation Concurrency
+
+The CLI uses file-based locks with PID checking to prevent concurrent writes.
+
+### Lock Files
+
+- `data/{channelId}/completion_cache.json.lock` - Completion cache
+- `data/handle-to-channel-id.json.lock` - Handle→channelId cache
+- `data/{channelId}/reports/.lock` - Per-channel reports directory
+
+### Lock Behavior
+
+- Locks contain **PID + timestamp**
+- **Automatic stale lock detection**: PID doesn't exist OR age > 30min
+- Acquire with timeout: `acquireLock(lockPath, { timeout })`
+- Always release in `finally` block
+
+### Usage Pattern
+
+```typescript
+import { acquireLock, getLockPath } from '../lib/lock';
+
+async function writeSomething(): Promise<void> {
+  const lockPath = getLockPath('your-type', channelId);
+  let release: (() => Promise<void>) | null = null;
+
+  try {
+    release = await acquireLock(lockPath, { timeout: 5000 });
+    // ... write operations ...
+  } finally {
+    if (release) await release();
+  }
+}
+```
+
+### When Adding New File Writes
+
+1. Identify if lock is needed (concurrent access possible?)
+2. Use appropriate lock file:
+   - `file.lock` for single files
+   - `.lock` for directories
+3. Always use try/finally to ensure cleanup
+4. Test with concurrent operations
+
+## AWS API Naming Conventions
+
+### 🚨 RULE: Everything is a named flag
+
+**NO positional arguments at all.**
+
+### Singular vs Plural
+
+**Singular = Single-item operations:**
+```bash
+get-video --video-id <id>        # Get ONE video
+update-video --video-id <id>     # Update ONE video
+delete-video --video-id <id>     # Delete ONE video
+```
+
+**Plural = Batch/list operations:**
+```bash
+get-videos --video-ids <id1> <id2>     # Get MULTIPLE videos (batch)
+list-videos --channel <handle>         # List videos in channel
+search-videos --query <text>           # Search multiple videos
+```
+
+### Required Flags Pattern
+
+- Single ID: `--resource-id <id>` (singular flag name, singular ID)
+- Multiple IDs: `--resource-ids <id...>` (plural flag name, variadic IDs)
+- Other required params: Use descriptive flag names (e.g., `--query <text>`)
+
+### Command Naming
+
+- Use `get-` for retrieving resources
+- Use `list-` for listing collections
+- Use `update-` for modifying resources
+- Use `delete-` for removing resources
+- Use `search-` for querying resources
+- Use singular nouns for single-item operations
+- Use plural nouns for batch/list operations
+
+## Hidden Internal Commands
+
+Some commands are registered with Commander's `{ hidden: true }` option and never appear in `staqan-yt help` output. They are implementation details and must **not** be documented in user-facing docs (README, docs/).
+
+### `__complete`
+
+**File**: `commands/complete.ts`
+**Registered in**: `bin/staqan-yt.ts` via `program.addCommand(cmd, { hidden: true })`
+
+**Purpose**: Subprocess helper for shell tab completion scripts. Shell scripts (bash/zsh) call this command and use its stdout as completion candidates.
+
+**Usage**:
+```bash
+staqan-yt __complete --type video-id      # Video IDs + titles for default channel
+staqan-yt __complete --type playlist-id   # Playlist IDs + titles for default channel
+staqan-yt __complete --type report-type   # Report type IDs + names
+```
+
+**Output format**: One `id\ttitle` per line (tab-separated). No spinners, no chalk, no extra output.
+
+**Caching**: Results are cached in `~/.staqan-yt-cli/completion-cache.json`:
+- `video-id` / `playlist-id`: 5-minute TTL, keyed as `video-id:@channel`
+- `report-type`: 1-hour TTL, keyed as `report-type`
+
+**Error handling**: Any error (no auth, no default channel, network failure) causes silent `process.exit(0)` — completion simply shows no candidates rather than printing an error to the terminal.
+
+**Shell integration**: The generated bash/zsh scripts in `lib/completion.ts` call `__complete` as a subprocess and feed its output into `_describe` (zsh) or `compgen -W` (bash).
+
+## Code Structure
+
+### Directory Organization
+
+```
+staqan-yt-cli/
+├── bin/
+│   └── staqan-yt.ts          # Main CLI entry point, command routing
+├── lib/
+│   ├── auth.ts               # OAuth 2.0 authentication logic
+│   ├── youtube.ts            # YouTube Data API wrapper
+│   ├── language.ts           # Language mapping utilities
+│   ├── config.ts             # Configuration management utilities
+│   ├── utils.ts              # Helper utilities (chalk, ora, paths)
+│   ├── formatters.ts         # Output format formatters
+│   ├── lock.ts               # File locking mechanism
+│   └── completion.ts         # Shell completion scripts
+├── commands/
+│   ├── auth.ts               # Authentication command
+│   ├── config.ts             # Configuration management command
+│   ├── *.ts                  # All other commands
+├── types/
+│   └── index.ts              # Shared TypeScript type definitions
+├── dist/                     # Compiled JavaScript output (gitignored)
+├── tsconfig.json             # TypeScript configuration
+├── eslint.config.mjs         # ESLint configuration
+└── package.json
+```
+
+### Key Files
+
+**`bin/staqan-yt.ts`**: CLI entry point and command router
+- Registers all commands with Commander.js
+- Sets up global options
+- Defines help format
+
+**`lib/youtube.ts`**: Main API wrapper (~903 lines)
+- Wraps YouTube Data API v3
+- Implements caching
+- Handles common operations
+
+**`lib/auth.ts`**: OAuth 2.0 authentication
+- Token management
+- Auto-refresh
+- Credential loading
+
+**`lib/config.ts`**: Configuration management
+- Load/save config
+- Default value handling
+- Output format resolution
+
+**`lib/formatters.ts`**: Output format implementations
+- JSON, table, CSV, text, pretty formatters
+- Data transformation
+
+**`lib/lock.ts`**: File locking mechanism
+- PID-based locks
+- Stale lock detection
+- Timeout handling
+
+## Configuration Management
+
+### Config File Location
+
+`~/.staqan-yt-cli/config.json`
+
+### Available Configuration Options
+
+- `default.channel` - Default channel handle/ID for list-videos and search-videos
+- `default.output` - Default output format: `json`, `table`, `text`, `pretty`, or `csv` (defaults to `pretty`)
+
+### How Configuration Works
+
+- Config values are loaded when commands execute
+- CLI flags always override config defaults
+- Optional parameters use config values when not provided
+- Configuration is managed via the `config` command
+
+### Example Workflow
+
+```bash
+# Set defaults
+staqan-yt config set default.channel @staqan
+staqan-yt config set default.output csv
+
+# Commands now use these defaults
+staqan-yt list-videos --limit 5        # Uses @staqan, outputs CSV
+staqan-yt search-videos "craft beer"   # Uses @staqan, outputs CSV
+
+# Override when needed
+staqan-yt list-videos @otherChannel --output json    # Explicit format overrides config
+```
+
+## Credential Management
+
+### All Credentials Stored In
+
+`~/.staqan-yt-cli/`
+
+```
+~/.staqan-yt-cli/
+├── credentials.json      # OAuth 2.0 client credentials
+├── token.json            # User access/refresh tokens (auto-generated)
+└── config.json           # User configuration
+```
+
+### Security Rules
+
+- Never store credentials in the repo
+- Never store in project directories
+- Never use environment variables
+- Always use the centralized location
+
+## Related Guides
+
+- [TypeScript Guide](typescript-guide.md) - Type system architecture
+- [Security Guide](security-guide.md) - Security architecture
+- [YouTube API Guide](youtube-api-guide.md) - API wrapper patterns
+- [Error Handling Guide](error-handling.md) - Error handling architecture

--- a/docs/development/error-handling.md
+++ b/docs/development/error-handling.md
@@ -1,0 +1,225 @@
+# Error Handling Guide
+
+This guide covers error handling patterns for the staqan-yt-cli project.
+
+## User-Friendly Errors
+
+Always provide clear, actionable error messages:
+
+```typescript
+try {
+  // operation
+} catch (err) {
+  if ((err as any).code === 403) {
+    error('API quota exceeded. Try again tomorrow.');
+  } else if ((err as any).code === 404) {
+    error('Video not found. Check the video ID.');
+  } else {
+    error(`Failed: ${(err as Error).message}`);
+  }
+  process.exit(1);
+}
+```
+
+## Common Error Patterns
+
+### Authentication Errors
+
+```typescript
+import { getAuthenticatedClient } from '../lib/auth';
+
+async function yourCommand() {
+  let auth;
+  try {
+    auth = await getAuthenticatedClient();
+  } catch (err) {
+    error('Authentication failed. Please run: staqan-yt auth');
+    process.exit(1);
+  }
+
+  // Use auth for API calls
+}
+```
+
+### Input Validation Errors
+
+```typescript
+// Validate video ID format
+if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+  error('Invalid video ID format. Video IDs must be 11 characters.');
+  process.exit(1);
+}
+
+// Validate required parameters
+if (!options.title && !options.description) {
+  error('At least one of --title or --description must be provided');
+  process.exit(1);
+}
+
+// Validate channel parameter
+if (!channel) {
+  error('No channel specified. Use --channel or set default.channel in config');
+  process.exit(1);
+}
+```
+
+### API Response Errors
+
+```typescript
+const response = await youtube.videos.list({
+  part: 'snippet,statistics',
+  id: videoId
+});
+
+if (!response.data.items || response.data.items.length === 0) {
+  spinner.fail('Video not found');
+  process.exit(1);
+}
+
+const video = response.data.items[0];
+// Process video
+```
+
+### File Operation Errors
+
+```typescript
+import { acquireLock } from '../lib/lock';
+
+async function writeData() {
+  let release;
+  try {
+    release = await acquireLock(lockPath, { timeout: 5000 });
+    // ... write operations ...
+  } catch (err) {
+    if ((err as Error).message.includes('timeout')) {
+      error('Could not acquire lock. Another operation may be in progress.');
+    } else {
+      error(`Failed to write data: ${(err as Error).message}`);
+    }
+    process.exit(1);
+  } finally {
+    if (release) await release();
+  }
+}
+```
+
+## Error Message Best Practices
+
+### DO ✅
+
+- Be specific about what went wrong
+- Provide actionable next steps
+- Use user-friendly language
+- Include relevant IDs/values in error messages
+- Match error type to the problem
+
+```typescript
+error('Video not found. Check the video ID: dQw4w9WgXcQ');
+error('API quota exceeded. Try again tomorrow.');
+error('No authentication token found. Please run: staqan-yt auth');
+```
+
+### DON'T ❌
+
+- Use technical jargon unnecessarily
+- Blame the user
+- Provide unhelpful error messages
+- Expose stack traces to users
+- Use generic errors for specific problems
+
+```typescript
+// Bad examples
+error('Error occurred');  // Too generic
+error('You provided wrong input');  // Blaming
+error('Error: 500 Internal Server Error');  // Too technical
+console.error(err.stack);  // Exposes implementation
+```
+
+## Error Types
+
+### YouTube API Errors
+
+| Error Code | Meaning | User Message |
+|------------|---------|--------------|
+| 400 | Bad Request | Invalid request parameters |
+| 401 | Unauthorized | Authentication required |
+| 403 | Forbidden | API quota exceeded or insufficient permissions |
+| 404 | Not Found | Resource not found |
+| 429 | Too Many Requests | Rate limit exceeded |
+
+### Configuration Errors
+
+```typescript
+// Missing configuration
+if (!configValue) {
+  error('Configuration value not found. Run: staqan-yt config set key value');
+}
+
+// Invalid configuration
+if (outputFormat && !['json', 'table', 'text', 'csv', 'pretty'].includes(outputFormat)) {
+  error('Invalid output format. Must be: json, table, text, csv, or pretty');
+}
+```
+
+### Network Errors
+
+```typescript
+try {
+  const response = await fetch(url);
+} catch (err) {
+  if ((err as Error).message.includes('ECONNREFUSED')) {
+    error('Cannot connect to YouTube. Check your internet connection.');
+  } else if ((err as Error).message.includes('ETIMEDOUT')) {
+    error('Request timed out. Please try again.');
+  } else {
+    error(`Network error: ${(err as Error).message}`);
+  }
+  process.exit(1);
+}
+```
+
+## Spinner Error Handling
+
+Use ora spinners for better UX:
+
+```typescript
+import ora from 'ora';
+
+async function yourCommand() {
+  const spinner = ora('Processing...').start();
+
+  try {
+    // Your logic here
+    spinner.succeed('Processing completed!');
+  } catch (err) {
+    spinner.fail('Processing failed');
+    error((err as Error).message);
+    process.exit(1);
+  }
+}
+```
+
+## Error Testing
+
+Always test error cases:
+
+```bash
+# Test with invalid video ID
+staqan-yt get-video invalid-id
+
+# Test without authentication
+rm ~/.staqan-yt-cli/token.json
+staqan-yt get-video dQw4w9WgXcQ
+
+# Test with missing required parameters
+staqan-yt update-video VIDEO_ID  # Missing --title or --description
+
+# Test with invalid configuration
+staqan-yt config set invalid.key value
+```
+
+## Related Guides
+
+- [Adding Commands Guide](adding-commands.md) - Command error patterns
+- [TypeScript Guide](typescript-guide.md) - Type error handling
+- [Troubleshooting Guide](troubleshooting.md) - Common error resolution

--- a/docs/development/git-workflow.md
+++ b/docs/development/git-workflow.md
@@ -1,0 +1,306 @@
+# Git Workflow Guide
+
+This guide covers the git workflow, branch strategy, and release process for the staqan-yt-cli project.
+
+## ⚠️ Branch Strategy
+
+### 🚨 NEVER Commit Directly to Main Branch
+
+**EVERY commit MUST be on a feature branch.**
+
+### Branch Naming Convention
+
+- `feature/feature-name` - New features
+- `fix/bug-name` - Bug fixes
+- `refactor/name` - Code refactoring
+
+### Correct Workflow
+
+```bash
+# 1. Create a feature branch (DO THIS FIRST)
+git checkout -b feature/your-feature-name
+
+# 2. Make changes and commit on feature branch
+git add -A
+git commit -m "Description"
+
+# 3. Push feature branch (NOT main)
+git push -u origin feature/your-feature-name
+
+# 4. Create PR via GitHub or gh CLI
+gh pr create --title "Feature: Your Feature" --body "Description"
+
+# 5. After PR merge, delete the branch
+git checkout main
+git pull
+git branch -d feature/your-feature-name
+```
+
+### Recovery If You Mess Up
+
+```bash
+# If you accidentally committed to main:
+git reset --soft HEAD~1              # Undo commit, keep changes
+git checkout -b feature/your-feature  # Create proper branch
+git add -A                           # Stage changes
+git commit -m "Description"           # Commit on feature branch
+git push -u origin feature/your-feature  # Push feature branch
+gh pr create                          # Create PR
+
+# Never push the commit to main!
+```
+
+### Verify Branch Before Committing
+
+```bash
+# This MUST NOT be "main"
+git branch --show-current
+
+# If it shows "main", STOP and create feature branch:
+git checkout -b feature/your-feature-name
+```
+
+## Commit Message Format
+
+Follow the established pattern:
+
+```
+Brief description of change
+
+Detailed explanation if needed
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+### Commit Message Examples
+
+```
+Feat: Add get-playlist command
+
+Added new command to retrieve single playlist details:
+- get-playlist <playlistId> - Get one playlist
+- Supports all output formats
+- Includes error handling for invalid IDs
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+```
+Fix: Update video category ID preservation
+
+Fixed bug where update-video was losing category ID.
+Now preserves existing category when updating metadata.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+## Pre-Commit Checklist
+
+**MANDATORY checks before committing:**
+
+- [ ] **On a feature branch?** (NOT main!)
+- [ ] **Tested all affected commands?**
+- [ ] **Updated documentation?**
+  - [ ] README.md (if user-facing changes)
+  - [ ] docs/commands/<category>.md (command reference)
+  - [ ] lib/customHelp.ts (help grouping)
+- [ ] **Following AWS naming conventions?**
+- [ ] **Credentials never committed?**
+
+### Verify What You're Committing
+
+```bash
+# Check staged files
+git diff --staged --name-only
+
+# Check for unintended files (credentials, etc.)
+git status
+
+# Ensure branch is correct
+git branch --show-current
+```
+
+## Release Process
+
+**IMPORTANT**: This project does NOT use GitHub releases. All releases are managed through version bumps, git tags, and Homebrew formula updates.
+
+### Version Management
+
+**Single source of truth**: `package.json` is the source of truth for versioning. All other files are automatically synced from it.
+
+### Release Workflow
+
+**Option 1: Using npm version (recommended):**
+
+```bash
+# Automatically bumps version, syncs all files, creates commit & tag
+npm version patch   # For bug fixes and minor changes (X.Y.Z -> X.Y.Z+1)
+npm version minor   # For new features (X.Y.Z -> X.Y+1.0)
+npm version major   # For breaking changes (X.Y.Z -> X+1.0.0) - rarely used
+
+# Push to GitHub
+git push && git push --tags
+```
+
+**Option 2: Manual version bump:**
+
+```bash
+# 1. Edit package.json version manually
+# 2. Sync version to other files
+npm run sync-version
+
+# 3. Commit changes
+git add -A
+git commit -m "Bump version to X.Y.Z
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+
+# 4. Create git tag
+git tag vX.Y.Z
+
+# 5. Push to GitHub
+git push && git push --tags
+```
+
+### What Gets Synced Automatically
+
+- `package.json` - Source of truth
+- `bin/staqan-yt.ts` - Fallback version for compiled binary
+- `Formula/staqan-yt.rb` - Homebrew formula version
+
+### Semantic Versioning Rules (X.Y.Z)
+
+- **Z (patch)** - Bump for normal releases:
+  - Bug fixes
+  - Minor improvements
+  - Documentation updates
+  - Non-breaking changes
+
+- **Y (minor)** - Bump only if changes are significant:
+  - New commands added
+  - New features
+  - Significant refactoring
+  - Breaking changes to non-public APIs
+
+- **X (major)** - NEVER bump unless explicitly instructed:
+  - Reserved for major breaking changes
+  - Requires explicit approval
+  - Should be extremely rare
+
+**Default behavior**: Always bump Z (patch) unless told otherwise.
+
+### Release Examples
+
+- `1.2.3` → `1.2.4` - Bug fix, documentation update
+- `1.2.4` → `1.3.0` - Added new `list-playlists` command
+- `1.3.0` → `2.0.0` - Only if explicitly instructed for major breaking change
+
+## Branch Protection
+
+### Recommended Branch Protection Rules
+
+Consider enabling on GitHub:
+
+1. **Require pull request reviews before merging**
+   - Required approving reviewers: 1
+
+2. **Require status checks to pass before merging**
+   - Require branches to be up to date before merging
+
+3. **Restrict who can push to main branch**
+   - Only allow: administrators (or specific users)
+
+4. **Do not allow bypassing the above settings**
+
+### Setting Up Branch Protection
+
+Via GitHub UI:
+1. Go to repository Settings
+2. Click "Branches" in left sidebar
+3. Click "Add rule" for `main` branch
+4. Configure restrictions and checks
+
+Via GitHub CLI:
+```bash
+gh api repos/OWNER/REPO/branches/main/protection \
+  --method PUT \
+  -f required_pull_request_reviews='{"required_approving_review_count":1}' \
+  -f enforce_admins=true \
+  -f required_status_checks='{"strict":true,"contexts":[]}' \
+  -f restrictions=null
+```
+
+## Pull Request Workflow
+
+### Creating a PR
+
+```bash
+# After pushing feature branch
+gh pr create \
+  --title "Feature: Your Feature Name" \
+  --body "Description of changes:
+
+- Added X feature
+- Fixed Y bug
+- Updated Z documentation
+
+Testing:
+- Tested all affected commands
+- All output formats work
+- Error handling verified"
+
+# Or open in browser to edit
+gh pr create --web
+```
+
+### PR Description Template
+
+```markdown
+## Summary
+Brief description of what this PR does.
+
+## Changes
+- Change 1
+- Change 2
+- Change 3
+
+## Testing
+- [ ] All affected commands tested
+- [ ] All output formats tested
+- [ ] Error cases tested
+- [ ] Documentation updated
+
+## Checklist
+- [ ] On feature branch (not main)
+- [ ] Follows AWS naming conventions
+- [ ] No credentials committed
+- [ ] Documentation updated
+- [ ] Ready for review
+```
+
+### Updating a PR
+
+```bash
+# Make additional changes
+git add -A
+git commit -m "Additional changes"
+
+# Push to same branch
+git push
+
+# PR automatically updates
+```
+
+## Related Guides
+
+- [CLAUDE.md](../../CLAUDE.md) - Critical rules
+- [Adding Commands Guide](adding-commands.md) - Command development workflow
+- [Maintenance Guide](maintenance-guide.md) - Dependency updates and security

--- a/docs/development/maintenance-guide.md
+++ b/docs/development/maintenance-guide.md
@@ -1,0 +1,276 @@
+# Maintenance Guide
+
+This guide covers dependency updates, breaking changes, and Dependabot vulnerability management for the staqan-yt-cli project.
+
+## Updating Dependencies
+
+### Check for Updates
+
+```bash
+npm outdated
+```
+
+### Update Dependencies
+
+```bash
+# Update specific package
+npm update <package-name>
+
+# Update all (use with caution)
+npm update
+
+# Update to latest versions (may include breaking changes)
+npx npm-check-updates -u
+npm install
+```
+
+### After Updating
+
+```bash
+# Build the project
+npm run build
+
+# Run type checking
+npm run type-check
+
+# Run linter
+npm run lint
+
+# Test all non-destructive commands:
+# - Video operations: get-video, get-videos, get-thumbnail, get-video-tags
+# - Localizations: get-video-localizations, get-video-localization
+# - Comments: list-comments
+# - Playlists: list-playlists, get-playlist, get-playlists
+# - Config: config list/get/set
+# - MCP server: staqan-yt mcp (test with timeout)
+# - Output formats: test with --output json/table/text/csv/pretty
+```
+
+## Breaking Changes
+
+If the YouTube API changes or dependencies introduce breaking changes:
+
+1. Update googleapis dependency
+2. Test all commands
+3. Update documentation
+4. Increment major version (if truly breaking to users)
+5. Document migration in BREAKING-CHANGES.md
+
+## Dependabot Vulnerability Management
+
+This project uses GitHub Dependabot for automated dependency vulnerability tracking.
+
+### Checking for Vulnerabilities
+
+**Use GitHub CLI to fetch Dependabot alerts:**
+
+```bash
+# List all open Dependabot alerts
+gh api '/repos/prog893/staqan-yt-cli/dependabot-alerts?state=open'
+
+# Get formatted summary
+gh api '/repos/prog893/staqan-yt-cli/dependabot-alerts?state=open' \
+  --jq '.[] | "\(.security_vulnerability.severity) - \(.dependency.package.name) (vulnerable: \(.security_vulnerability.vulnerable_version_range), patched: \(.security_vulnerability.first_patched_version.identifier))"'
+```
+
+### Git Push Vulnerability Feedback
+
+When you push to GitHub, the remote will alert you if there are vulnerabilities:
+
+```
+remote: GitHub found 7 vulnerabilities on prog893/staqan-yt-cli's default branch (3 high, 4 moderate).
+remote: To find out more about visit: https://github.com/prog893/staqan-yt-cli/security/dependabot
+```
+
+**IMPORTANT**: The vulnerability count shown during push reflects the state **before** your push. Dependabot rescans after the push completes, so even after pushing a fix, you'll still see the old warning. Don't worry - the count will update on the next push once Dependabot rescans.
+
+### Vulnerability Fix Workflow
+
+#### 1. Assess the Vulnerabilities
+
+```bash
+# Fetch and review alerts
+gh api '/repos/prog893/staqan-yt-cli/dependabot-alerts?state=open' | jq .
+
+# Check dependency chain
+npm ls <vulnerable-package>
+```
+
+#### 2. Update Dependencies
+
+```bash
+# Update specific package
+npm update <package-name>
+
+# Or update all (use with caution)
+npm update
+```
+
+#### 3. Test Thoroughly
+
+```bash
+# Build the project
+npm run build
+
+# Test all non-destructive commands:
+# - Video operations: get-video, get-videos, get-thumbnail, get-video-tags
+# - Localizations: get-video-localizations, get-video-localization
+# - Comments: list-comments
+# - Playlists: list-playlists, get-playlist, get-playlists
+# - Config: config list/get/set
+# - MCP server: staqan-yt mcp (test with timeout)
+# - Output formats: test with --output json/table/text/csv/pretty
+```
+
+#### 4. Commit and Release
+
+```bash
+# Commit the fix
+git add package-lock.json
+git commit -m "Fix: Update <package> to address security vulnerabilities
+
+- Updated <package> from X.Y.Z to A.B.C
+- Fixes N Dependabot alerts (X HIGH, Y MEDIUM severity)
+- Resolves CVE-XXXX-XXXXX
+- All non-destructive CLI commands tested and working
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"
+
+# Bump patch version
+npm version patch
+
+# Push to GitHub
+git push && git push --tags
+```
+
+#### 5. Verify
+
+After pushing, GitHub will rescan the repository asynchronously.
+
+- **Expected**: You may still see vulnerability warnings on this push (they reflect the pre-push state)
+- **Verification**: The Dependabot alerts page will update within a few minutes
+- **Confirmation**: Next time you push, the warning will be gone if the fix was successful
+
+### Vulnerability Severity Classification
+
+Based on security best practices:
+
+| Severity | Timeline | Examples |
+|----------|----------|----------|
+| **Critical** | Immediate | System can be stopped, personal data exposed |
+| **High** | This month | Limited attack conditions, non-critical impact |
+| **ModerATE** | Within 6 months | Dev-only usage, vulnerable feature not used |
+| **None** | Skip | Not actually used |
+
+### Real-World Example
+
+**Issue**: 7 Dependabot alerts (3 HIGH, 4 MEDIUM)
+- `@modelcontextprotocol/sdk` - Cross-client data leak (HIGH)
+- `hono` - Multiple vulnerabilities (2 HIGH, 4 MEDIUM)
+
+**Root cause analysis:**
+```bash
+npm ls hono
+# staqan-yt-cli
+# └── @modelcontextprotocol/sdk@1.25.2
+#     └── @hono/node-server@1.19.8
+#         └── hono@4.11.3
+```
+
+**Solution**: Update the direct dependency
+```bash
+npm update @modelcontextprotocol/sdk
+# This automatically updates hono to 4.11.8 (patched version)
+```
+
+**Result**: All 7 alerts fixed with one update, tested comprehensively, released as v1.3.6.
+
+## Best Practices
+
+### Keep Alerts at 0
+
+- Stay sensitive to new security warnings
+- Address HIGH/CRITICAL issues immediately
+- Plan MODERATE issues for batched updates
+- Skip NONE severity (not actually used)
+
+### Check Dependency Chains
+
+- Transitive dependencies often bring vulnerabilities
+- Use `npm ls <package>` to trace chains
+- Update direct dependencies to fix transitive issues
+
+### Test After Updates
+
+- Especially functionality that uses vulnerable packages
+- Test all output formats
+- Verify error handling still works
+
+### Document Legitimate Usage
+
+- If a package has vulnerabilities but you don't use affected features
+- Document why in code comments or SECURITY.md
+- Consider replacing with safer alternatives
+
+### Update Planning
+
+- **HIGH/CRITICAL**: Update quickly - can have real security impact
+- **MODERATE**: Can be batched with other maintenance
+- **NONE**: Skip or replace package
+
+## Automation Ideas
+
+### Daily Vulnerability Check
+
+Consider creating a GitHub Actions workflow to:
+
+- Check Dependabot alerts daily
+- Post to Slack when new alerts appear
+- Create issues for unaddressed vulnerabilities
+
+Example workflow (`.github/workflows/security.yml`):
+
+```yaml
+name: Security Scan
+
+on:
+  schedule:
+    - cron: '0 9 * * *'  # Daily at 9am
+  workflow_dispatch:
+
+jobs:
+  dependabot-alerts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Dependabot alerts
+        run: |
+          alerts=$(gh api '/repos/prog893/staqan-yt-cli/dependabot-alerts?state=open' | jq length)
+          if [ "$alerts" -gt 0 ]; then
+            echo "Found $alerts open Dependabot alerts"
+            # Create issue or post to Slack
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Automated Dependency Updates
+
+Enable Dependabot for automated PRs (`.github/dependabot.yml`):
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+```
+
+## Related Guides
+
+- [Security Guide](security-guide.md) - Security best practices
+- [Testing Guide](testing-guide.md) - Testing after updates
+- [Git Workflow Guide](git-workflow.md) - Release process

--- a/docs/development/output-formats.md
+++ b/docs/development/output-formats.md
@@ -1,0 +1,288 @@
+# Output Formats Guide
+
+This guide covers implementing output formats in commands for the staqan-yt-cli project.
+
+## Output Format System
+
+The CLI supports 5 output formats via `--output <format>`:
+
+- **json** - Machine-readable JSON (2-space indentation)
+- **table** - ASCII table format with borders and column alignment
+- **text** - Tab-delimited output for Unix pipelines (awk, cut)
+- **pretty** - Colorful, human-friendly output (default)
+- **csv** - RFC 4180 CSV format for Excel and data analysis
+
+## Implementing Output Formats
+
+### Basic Pattern
+
+```typescript
+import { getOutputFormat } from '../lib/config';
+import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+
+const outputFormat = await getOutputFormat(options.output);
+
+switch (outputFormat) {
+  case 'json':
+    console.log(formatJson(data));
+    break;
+  case 'table':
+    console.log(formatTable(data));
+    break;
+  case 'text':
+    data.forEach(item => console.log(Object.values(item).join('\t')));
+    break;
+  case 'csv':
+    console.log(formatCsv(data));
+    break;
+  case 'pretty':
+  default:
+    // Colorful output using chalk
+    break;
+}
+```
+
+### Load Output Format
+
+```typescript
+import { getOutputFormat } from '../lib/config';
+
+// Returns one of: 'json' | 'table' | 'text' | 'csv' | 'pretty'
+const outputFormat = await getOutputFormat(options.output);
+```
+
+The `getOutputFormat` function:
+1. Checks the `--output` flag (highest priority)
+2. Falls back to `config.json` default.output setting
+3. Defaults to `'pretty'` if neither is specified
+
+## Output Format Details
+
+### JSON Format
+
+**Formatter**: `formatJson(data)`
+
+```typescript
+import { formatJson } from '../lib/formatters';
+
+console.log(formatJson(data));
+```
+
+**Output**: 2-space indented JSON
+
+```json
+{
+  "videoId": "dQw4w9WgXcQ",
+  "title": "Never Gonna Give You Up",
+  "viewCount": "1400000000"
+}
+```
+
+**Use cases**:
+- APIs and programmatic access
+- Data pipelines
+- Further processing with jq
+
+### Table Format
+
+**Formatter**: `formatTable(data)`
+
+```typescript
+import { formatTable } from '../lib/formatters';
+
+console.log(formatTable(data));
+```
+
+**Output**: ASCII table with borders
+
+```
+┌─────────────┬──────────────────────────────┬──────────────┐
+│ Video ID    │ Title                        │ View Count   │
+├─────────────┼──────────────────────────────┼──────────────┤
+│ dQw4w9...   │ Never Gonna Give You Up      │ 1.4B         │
+└─────────────┴──────────────────────────────┴──────────────┘
+```
+
+**Use cases**:
+- Terminal viewing
+- Reports
+- Quick scanning
+
+### Text Format
+
+**Pattern**: Tab-delimited output
+
+```typescript
+data.forEach(item => console.log(Object.values(item).join('\t')));
+```
+
+**Output**: Tab-separated values
+
+```
+dQw4w9WgXcQ	Never Gonna Give You Up	1400000000
+```
+
+**Use cases**:
+- Unix pipelines (awk, cut, sort)
+- Log files
+- Simple parsing
+
+### CSV Format
+
+**Formatter**: `formatCsv(data)`
+
+```typescript
+import { formatCsv } from '../lib/formatters';
+
+console.log(formatCsv(data));
+```
+
+**Output**: RFC 4180 CSV format
+
+```csv
+videoId,title,viewCount
+"dQw4w9WgXcQ","Never Gonna Give You Up","1400000000"
+```
+
+**Features**:
+- Escapes fields containing commas, quotes, or newlines
+- Doubles internal quotes for proper escaping
+- Handles nested objects by JSON-encoding them
+- Always includes a header row with field names
+
+**Use cases**:
+- Excel and spreadsheet import
+- Data analysis (pandas, R)
+- Business intelligence tools
+
+### Pretty Format (Default)
+
+**Pattern**: Chalk-based colorful output
+
+```typescript
+import chalk from 'chalk';
+
+console.log(chalk.cyan('Video ID:'), videoId);
+console.log(chalk.green('✓'), 'Title:', title);
+console.log(chalk.yellow('Views:'), viewCount);
+```
+
+**Output**: Colorized terminal output
+
+```
+Video ID: dQw4w9WgXcQ
+✓ Title: Never Gonna Give You Up
+Views: 1.4B
+```
+
+**Use cases**:
+- Interactive terminal use
+- Human-readable output
+- Quick visual scanning
+
+## Data Preparation
+
+### Flatten Nested Objects
+
+For table/text/CSV formats, flatten nested objects:
+
+```typescript
+// Nested object from API
+const video = {
+  id: 'dQw4w9WgXcQ',
+  snippet: {
+    title: 'Never Gonna Give You Up',
+    description: '...'
+  },
+  statistics: {
+    viewCount: '1400000000'
+  }
+};
+
+// Flatten for output
+const flat = {
+  videoId: video.id,
+  title: video.snippet.title,
+  viewCount: video.statistics.viewCount
+};
+
+// Now use with formatters
+console.log(formatTable([flat]));
+```
+
+### Format Numbers
+
+```typescript
+// Format large numbers
+function formatNumber(num: string): string {
+  const n = parseInt(num, 10);
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return num;
+}
+
+const data = {
+  views: formatNumber(video.statistics.viewCount)
+};
+```
+
+### Format Dates
+
+```typescript
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+const data = {
+  publishedAt: formatDate(video.snippet.publishedAt)
+};
+```
+
+## Configuration Integration
+
+### Default Output Format
+
+Users can set a default in `config.json`:
+
+```bash
+staqan-yt config set default.output csv
+```
+
+Now all commands default to CSV output:
+
+```bash
+staqan-yt list-videos @channel  # Outputs CSV
+```
+
+### Override Default
+
+Users can override per-command:
+
+```bash
+staqan-yt list-videos @channel --output json  # JSON this time
+```
+
+## Output Testing
+
+Always test all output formats:
+
+```bash
+# Test all formats for a command
+staqan-yt get-video dQw4w9WgXcQ --output json
+staqan-yt get-video dQw4w9WgXcQ --output table
+staqan-yt get-video dQw4w9WgXcQ --output text
+staqan-yt get-video dQw4w9WgXcQ --output csv
+staqan-yt get-video dQw4w9WgXcQ --output pretty
+```
+
+## Related Documentation
+
+- [Output Formats (User Guide)](../output-formats.md) - User-facing documentation
+- [Adding Commands Guide](adding-commands.md) - Implementing formats in commands
+- [Testing Guide](testing-guide.md) - Testing output formats

--- a/docs/development/security-guide.md
+++ b/docs/development/security-guide.md
@@ -1,0 +1,225 @@
+# Security Guide
+
+This guide covers security best practices for the staqan-yt-cli project.
+
+## OAuth Token Security
+
+### Token Storage
+
+Tokens are stored in `~/.staqan-yt-cli/token.json`:
+
+```json
+{
+  "access_token": "...",
+  "refresh_token": "...",
+  "token_type": "Bearer",
+  "expiry_date": 1234567890
+}
+```
+
+### File Permissions
+
+Token files should have restrictive permissions (read/write for user only).
+
+### Security Rules
+
+1. **Never log tokens**: Don't output tokens to console or logs
+2. **Auto-refresh expired tokens**: Handle token expiration gracefully
+3. **Secure storage**: Use the standard `~/.staqan-yt-cli/` location
+4. **Don't commit tokens**: Never include credentials in the repository
+
+## Input Validation
+
+### Validate Video IDs
+
+```typescript
+// Video IDs are 11 characters, alphanumeric + - _
+if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+  error('Invalid video ID format. Video IDs must be 11 characters.');
+  process.exit(1);
+}
+```
+
+### Validate Channel Handles
+
+```typescript
+// Channel handles start with @
+if (!channelHandle.startsWith('@')) {
+  error('Invalid channel handle. Channel handles must start with @');
+  process.exit(1);
+}
+```
+
+### Validate Required Parameters
+
+```typescript
+if (!options.title && !options.description) {
+  error('At least one of --title or --description must be provided');
+  process.exit(1);
+}
+```
+
+### Sanitize User Input
+
+```typescript
+// Trim whitespace
+const title = options.title?.trim();
+
+// Escape HTML if outputting to web
+const escapedTitle = escapeHtml(title);
+
+// Validate ranges
+if (limit && (limit < 1 || limit > 50)) {
+  error('Limit must be between 1 and 50');
+  process.exit(1);
+}
+```
+
+## Credential Management
+
+### Credentials Location
+
+All credentials are stored in: `~/.staqan-yt-cli/`
+
+```
+~/.staqan-yt-cli/
+├── credentials.json      # OAuth 2.0 client credentials
+├── token.json            # User access/refresh tokens
+└── config.json           # User configuration
+```
+
+### Never Store Credentials In:
+
+- ❌ The repository
+- ❌ Project directories
+- ❌ Environment variables (use the centralized location)
+- ❌ Code files
+
+## API Security
+
+### Use HTTPS Only
+
+All YouTube API calls use HTTPS via the `googleapis` library.
+
+### Scope Management
+
+Only request necessary scopes:
+
+```typescript
+const SCOPES = [
+  'https://www.googleapis.com/auth/youtube.readonly',      // Read operations
+  'https://www.googleapis.com/auth/youtube.force-ssl',     // Write operations
+];
+```
+
+Don't request broader scopes than needed.
+
+### Quota Management
+
+- Respect API quota limits (10,000 units/day)
+- Implement caching to reduce API calls
+- Use batch operations when possible
+- Handle quota exceeded errors gracefully
+
+## File Operation Security
+
+### Lock Strategy
+
+Use file-based locks to prevent concurrent writes:
+
+```typescript
+import { acquireLock, getLockPath } from '../lib/lock';
+
+async function writeSomething(): Promise<void> {
+  const lockPath = getLockPath('completion_cache', channelId);
+  let release: (() => Promise<void>) | null = null;
+
+  try {
+    release = await acquireLock(lockPath, { timeout: 5000 });
+    // ... write operations ...
+  } finally {
+    if (release) await release();
+  }
+}
+```
+
+See [Architecture Guide](architecture.md#lock-strategy) for details.
+
+## Code Security
+
+### Avoid Command Injection
+
+```typescript
+// ❌ NEVER: Direct command execution
+const exec = require('child_process').exec;
+exec(`youtube-dl ${videoId}`);  // Dangerous!
+
+// ✅ Use safe alternatives
+const ytdl = require('ytdl-core');
+const stream = ytdl(videoId);  // Safe
+```
+
+### Avoid Path Traversal
+
+```typescript
+import path from 'path';
+
+// Validate file paths are within expected directory
+const safePath = path.resolve(baseDir, userPath);
+if (!safePath.startsWith(baseDir)) {
+  throw new Error('Invalid path');
+}
+```
+
+### Handle External Data Carefully
+
+```typescript
+// Validate API responses
+if (!response.data.items || response.data.items.length === 0) {
+  throw new Error('No results found');
+}
+
+// Type-check before using
+const title = video.snippet?.title;
+if (!title) {
+  throw new Error('Video title missing');
+}
+```
+
+## Dependency Security
+
+### Keep Dependencies Updated
+
+```bash
+npm update
+npm audit fix
+```
+
+### Monitor Dependabot Alerts
+
+Check for vulnerabilities regularly:
+
+```bash
+gh api '/repos/prog893/staqan-yt-cli/dependabot/alerts?state=open'
+```
+
+See [Maintenance Guide](maintenance-guide.md#dependabot-vulnerability-management) for details.
+
+## Security Checklist
+
+Before committing code:
+
+- [ ] No credentials in code
+- [ ] Input validation on all user inputs
+- [ ] Error messages don't expose sensitive data
+- [ ] File paths are validated
+- [ ] Lock strategy used for concurrent file access
+- [ ] API scopes are minimal required
+- [ ] No hardcoded secrets
+- [ ] Dependencies are up to date
+
+## Related Guides
+
+- [Maintenance Guide](maintenance-guide.md) - Vulnerability management
+- [Error Handling Guide](error-handling.md) - Security error patterns
+- [Architecture Guide](architecture.md) - Lock strategy

--- a/docs/development/testing-guide.md
+++ b/docs/development/testing-guide.md
@@ -1,0 +1,188 @@
+# Testing Guide
+
+This guide covers testing strategies and patterns for the staqan-yt-cli project.
+
+## Manual Testing
+
+### Test Authentication
+
+```bash
+staqan-yt auth
+```
+
+### Test Configuration
+
+```bash
+# List all config
+staqan-yt config list
+
+# Set default channel
+staqan-yt config set default.channel @staqan
+
+# Set default output format
+staqan-yt config set default.output csv
+
+# Get specific value
+staqan-yt config get default.channel
+```
+
+### Test All Output Formats
+
+Test with `get-video` command:
+
+```bash
+# JSON format
+staqan-yt get-video dQw4w9WgXcQ --output json
+
+# Table format
+staqan-yt get-video dQw4w9WgXcQ --output table
+
+# Text format (tab-delimited)
+staqan-yt get-video dQw4w9WgXcQ --output text
+
+# CSV format
+staqan-yt get-video dQw4w9WgXcQ --output csv
+
+# Pretty format (default, colorful)
+staqan-yt get-video dQw4w9WgXcQ --output pretty
+# or just
+staqan-yt get-video dQw4w9WgXcQ
+```
+
+### Test Multiple Video Operations
+
+```bash
+# Get multiple videos
+staqan-yt get-videos dQw4w9WgXcQ abc123xyz --output csv
+```
+
+### Test List Videos (With and Without Channel)
+
+```bash
+# With explicit channel
+staqan-yt list-videos @mkbhd --limit 5 --output csv
+
+# With default channel from config
+staqan-yt list-videos --limit 5
+```
+
+### Test Update (Dry Run)
+
+```bash
+# Dry run - no actual changes
+staqan-yt update-video dQw4w9WgXcQ --title "Test" --dry-run
+
+# Actual update (be careful!)
+staqan-yt update-video dQw4w9WgXcQ --title "New Title" --yes
+```
+
+## Local Development
+
+### Install Dependencies
+
+```bash
+npm install
+```
+
+### Link for Global Testing
+
+```bash
+npm link
+```
+
+Now you can test commands globally:
+
+```bash
+staqan-yt --help
+staqan-yt get-video dQw4w9WgXcQ
+```
+
+### Build Commands
+
+```bash
+# Type check without emitting
+npm run type-check
+
+# Run linter
+npm run lint
+
+# Build the project
+npm run build
+
+# Development mode with tsx
+npm run dev
+```
+
+## Test Patterns
+
+### Non-Destructive Commands (Safe to Test)
+
+These commands are read-only and safe to run:
+
+```bash
+# Video operations
+staqan-yt get-video VIDEO_ID
+staqan-yt get-videos ID1 ID2
+staqan-yt get-thumbnail VIDEO_ID
+staqan-yt get-video-tags VIDEO_ID
+
+# Localization operations
+staqan-yt get-video-localizations VIDEO_ID
+staqan-yt get-video-localization VIDEO_ID es
+
+# Comment operations
+staqan-yt list-comments VIDEO_ID --limit 5
+
+# Playlist operations
+staqan-yt list-playlists @channel
+staqan-yt get-playlist PLAYLIST_ID
+staqan-yt get-playlists ID1 ID2
+
+# Config operations
+staqan-yt config list
+staqan-yt config get default.channel
+
+# MCP server
+staqan-yt mcp  # (with timeout)
+```
+
+### Output Format Testing
+
+Always test new commands with all output formats:
+
+```bash
+staqan-yt your-command --output json
+staqan-yt your-command --output table
+staqan-yt your-command --output text
+staqan-yt your-command --output csv
+staqan-yt your-command --output pretty
+```
+
+### Dry Run Testing
+
+For commands that modify data, always test with `--dry-run` first:
+
+```bash
+staqan-yt update-video VIDEO_ID --title "Test" --dry-run
+staqan-yt update-video VIDEO_ID --description "New description" --dry-run
+```
+
+## Test Checklist
+
+Before committing changes:
+
+- [ ] Type check passes: `npm run type-check`
+- [ ] Linting passes: `npm run lint`
+- [ ] Build succeeds: `npm run build`
+- [ ] All non-destructive commands tested
+- [ ] All output formats work correctly
+- [ ] Error handling tested (invalid inputs, auth failures)
+- [ ] Documentation updated
+- [ ] Examples in documentation tested
+
+## Related Guides
+
+- [Adding Commands Guide](adding-commands.md) - Command creation
+- [Error Handling Guide](error-handling.md) - Error testing
+- [Output Formats Guide](output-formats.md) - Output testing
+- [Troubleshooting Guide](troubleshooting.md) - Build and type errors

--- a/docs/development/troubleshooting.md
+++ b/docs/development/troubleshooting.md
@@ -1,0 +1,307 @@
+# Troubleshooting Guide
+
+This guide covers resolving common TypeScript and build errors in the staqan-yt-cli project.
+
+## TypeScript Errors
+
+### "Cannot find module" Errors
+
+**Error**: `Cannot find module '../lib/youtube' or its corresponding type declarations`
+
+**Solution**: Check imports use correct paths:
+
+```typescript
+// ✅ Correct - no .ts extension
+import { getVideoInfo } from '../lib/youtube';
+
+// ❌ Wrong - .ts extension not needed
+import { getVideoInfo } from '../lib/youtube.ts';
+```
+
+### Type Errors with googleapis
+
+**Error**: Properties are optional and TypeScript complains
+
+**Solution**: Use optional chaining and non-null assertions carefully:
+
+```typescript
+// ✅ Use optional chaining
+const channelId = response.data.items?.[0]?.snippet?.channelId;
+if (!channelId) {
+  throw new Error('Channel not found');
+}
+
+// ✅ Validate first, then assert
+if (response.data.items && response.data.items.length > 0) {
+  const title = response.data.items[0].snippet!.title!;  // Safe!
+}
+```
+
+See [TypeScript Guide](typescript-guide.md#non-null-assertion-usage) for detailed rationale.
+
+### "Property does not exist" Errors
+
+**Error**: Property `xxx` does not exist on type `yyy`
+
+**Solution**: Add proper type definitions:
+
+```typescript
+// Define interface for external data
+interface ApiResponse {
+  items?: Item[];
+}
+
+// Use type assertion for untyped libraries
+const data = response as unknown as YourType;
+```
+
+### Implicit Any Errors
+
+**Error**: Parameter `xxx` implicitly has an `any` type
+
+**Solution**: Add explicit types:
+
+```typescript
+// ❌ Implicit any
+function handler(videoId) {
+  // ...
+}
+
+// ✅ Explicit type
+function handler(videoId: string): void {
+  // ...
+}
+```
+
+## Build Errors
+
+### "Cannot compile" Errors
+
+**Symptom**: `npm run build` fails with compilation errors
+
+**Solution**:
+
+```bash
+# Clean build artifacts
+rm -rf dist/
+
+# Check TypeScript errors
+npm run type-check
+
+# Fix errors and rebuild
+npm run build
+```
+
+### "Module not found" Errors
+
+**Error**: `Cannot find module 'xxx'` when running compiled code
+
+**Solution**:
+
+```bash
+# Check if module is installed
+npm ls xxx
+
+# Install missing module
+npm install xxx
+
+# Rebuild
+npm run build
+```
+
+### TSC Errors
+
+**Error**: `tsc` command not found
+
+**Solution**: TypeScript is installed as a dev dependency:
+
+```bash
+# Use npm scripts instead
+npm run type-check
+npm run build
+
+# Or install globally
+npm install -g typescript
+```
+
+## ESLint Errors
+
+### Common ESLint Issues
+
+```bash
+# See all errors
+npm run lint
+```
+
+### Unused Imports
+
+**Error**: `xxx` is defined but never used
+
+**Solution**: Remove unused imports:
+
+```typescript
+// ❌ Unused import
+import { unused, used } from './module';
+
+// ✅ Only import what you use
+import { used } from './module';
+```
+
+### Unused Variables
+
+**Error**: `xxx` is assigned a value but never used
+
+**Solution**: Prefix with underscore if intentional:
+
+```typescript
+// ✅ Prefix intentional unused variables
+const _unused = getSomeValue();
+```
+
+### Any Type Errors
+
+**Error**: Unsafe use of `any` type
+
+**Solution**: Add proper types (see [TypeScript Guide](typescript-guide.md)):
+
+```typescript
+// ❌ Using any
+function handler(data: any): any {
+  // ...
+}
+
+// ✅ Using specific types
+interface VideoData {
+  id: string;
+  title: string;
+}
+
+function handler(data: VideoData): Promise<void> {
+  // ...
+}
+```
+
+## Runtime Errors
+
+### "Authentication failed" Errors
+
+**Error**: `No authentication token found`
+
+**Solution**:
+
+```bash
+# Run authentication
+staqan-yt auth
+
+# Check token exists
+ls ~/.staqan-yt-cli/token.json
+```
+
+### "Channel not found" Errors
+
+**Error**: `Channel not found` or `No uploads playlist found`
+
+**Solution**: Verify channel handle:
+
+```bash
+# Must include @ symbol
+staqan-yt list-videos @staqan  # ✅ Correct
+staqan-yt list-videos staqan   # ❌ Missing @
+```
+
+### "Video not found" Errors
+
+**Error**: `Video not found`
+
+**Solution**: Check video ID format:
+
+```bash
+# Video IDs are 11 characters
+staqan-yt get-video dQw4w9WgXcQ  # ✅ Correct
+staqan-yt get-video abc          # ❌ Too short
+```
+
+## NPM Errors
+
+### "EACCES" Permission Errors
+
+**Error**: `EACCES: permission denied`
+
+**Solution**: Fix npm permissions or use sudo (not recommended):
+
+```bash
+# Fix npm permissions (recommended)
+mkdir -p ~/.npm-global
+npm config set prefix '~/.npm-global'
+export PATH=~/.npm-global/bin:$PATH
+
+# Or use sudo (not recommended)
+sudo npm install -g .
+```
+
+### "EBUSY" File Lock Errors
+
+**Error**: `EBUSY: resource busy or locked`
+
+**Solution**: Close other processes using the files:
+
+```bash
+# On Windows: Check open files
+# On macOS/Linux: Use lsof
+lsof | grep node
+
+# Kill process if needed
+kill -9 <PID>
+```
+
+## Debugging Tips
+
+### Enable Debug Logging
+
+```typescript
+// Add verbose logging
+if (options.verbose) {
+  console.log('Debug info:', debugData);
+}
+```
+
+### Check File Paths
+
+```typescript
+import path from 'path';
+
+// Always resolve paths
+const configPath = path.resolve(__dirname, '../config.json');
+console.log('Loading config from:', configPath);
+```
+
+### Verify Environment
+
+```bash
+# Check Node version
+node --version  # Should be v18 or higher
+
+# Check npm version
+npm --version
+
+# Check environment variables
+env | grep NODE
+```
+
+## Getting Help
+
+If you can't resolve the error:
+
+1. Check [Troubleshooting (User Guide)](../troubleshooting.md) for common user issues
+2. Review [Error Handling Guide](error-handling.md) for error patterns
+3. Check GitHub Issues: https://github.com/prog893/staqan-yt-cli/issues
+4. Create a new issue with:
+   - Error message
+   - Steps to reproduce
+   - Your environment (OS, Node version, CLI version)
+
+## Related Guides
+
+- [TypeScript Guide](typescript-guide.md) - Type safety and patterns
+- [Error Handling Guide](error-handling.md) - Error patterns
+- [Testing Guide](testing-guide.md) - Testing strategies

--- a/docs/development/typescript-guide.md
+++ b/docs/development/typescript-guide.md
@@ -1,0 +1,245 @@
+# TypeScript Guide
+
+This guide covers TypeScript patterns, type safety, and ESLint configuration for the staqan-yt-cli project.
+
+## TypeScript Configuration
+
+This project uses TypeScript with strict type checking enabled. Key configuration from `tsconfig.json`:
+
+- **Target**: ES2020 (Node.js appropriate)
+- **Module**: CommonJS (for CLI compatibility)
+- **Strict mode**: enabled
+- **Output directory**: `dist/`
+- **Source maps and declaration files**: enabled
+
+### Build Process
+
+```bash
+npm run build         # Compile TypeScript to dist/
+npm run type-check    # Type checking without emit
+npm run lint          # Run ESLint
+npm run dev           # Development mode with tsx
+```
+
+## Type Safety Guidelines
+
+### ⚠️ ZERO `any` TOLERANCE
+
+**Never use `any` type.** It defeats TypeScript's entire purpose. This is a hard rule.
+
+```typescript
+// ❌ NEVER
+function handler(...args: any[]): any { ... }
+const data: any = response;
+
+// ✅ Use specific types
+function handler(videoId: string, options: VideoOptions): Promise<void> { ... }
+const data: VideoInfo = response;
+
+// ✅ If type is truly unknown, use `unknown` + type guard
+function handler(input: unknown): void {
+  if (typeof input === 'string') { ... }
+}
+
+// ✅ For external/untyped data, use a specific interface even if partial
+interface ApiResponse { items?: Item[] }
+```
+
+If you find yourself reaching for `any`, use `unknown` with a type guard, or define a proper interface.
+
+### Use Strict Types Everywhere
+
+```typescript
+// Good - explicit types
+async function getVideoInfo(videoIds: string[]): Promise<VideoInfo[]> {
+  // ...
+}
+
+// Avoid - implicit any
+async function getVideoInfo(videoIds) {
+  // ...
+}
+```
+
+### Leverage Shared Types
+
+Use shared types from `types/index.ts`:
+
+```typescript
+import { VideoInfo, VideoLocalization, JsonOption } from '../types';
+
+async function videoInfoCommand(videoIds: string[], options: JsonOption): Promise<void> {
+  const videos: VideoInfo[] = await getVideoInfo(videoIds);
+  // ...
+}
+```
+
+### Use Non-Null Assertions Sparingly
+
+Prefer optional chaining and nullish coalescing:
+
+```typescript
+// Prefer optional chaining
+const title = video.snippet?.title || 'Untitled';
+
+// Only use ! when you're absolutely certain
+const channelId = response.data.items![0].id!;
+```
+
+### Type API Responses Properly
+
+```typescript
+import { youtube_v3 } from 'googleapis';
+
+async function getVideoWithLocalizations(videoId: string): Promise<youtube_v3.Schema$Video> {
+  // Uses googleapis type definitions
+}
+```
+
+## ESLint Configuration
+
+ESLint is configured with TypeScript support (flat config format):
+- **Parser**: `@typescript-eslint/parser`
+- **Plugin**: `@typescript-eslint/eslint-plugin`
+- **Rules**: Optimized for Node.js CLI development
+
+### Running Linter
+
+```bash
+npm run lint          # Check all files
+```
+
+## Common TypeScript Patterns for CLI
+
+### Command Modules Use `export =`
+
+Command modules use CommonJS export:
+
+```typescript
+import ora from 'ora';
+import { getVideoInfo } from '../lib/youtube';
+import { JsonOption } from '../types';
+
+async function videoInfoCommand(videoIds: string[], options: JsonOption): Promise<void> {
+  // Command logic
+}
+
+export = videoInfoCommand;
+```
+
+### Type Error Handling
+
+```typescript
+try {
+  // ...
+} catch (err) {
+  error((err as Error).message);
+  process.exit(1);
+}
+```
+
+### Type Commander.js Options
+
+```typescript
+interface UpdateVideoOptions {
+  title?: string;
+  description?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+async function updateMetadataCommand(videoId: string, options: UpdateVideoOptions): Promise<void> {
+  // ...
+}
+```
+
+## Non-Null Assertion Usage
+
+**ESLint Rule**: `@typescript-eslint/no-non-null-assertion` is set to `'off'`
+
+### Rationale
+
+Non-null assertions (`!`) are used intentionally throughout the codebase, particularly in `lib/youtube.ts`, when working with YouTube API responses from the `googleapis` library.
+
+### Why This Is Safe
+
+1. **Explicit validation precedes all assertions**: Properties are validated before using `!`
+   ```typescript
+   // Good: Validate first, then assert
+   if (response.data.items && response.data.items.length > 0) {
+     const title = response.data.items[0].snippet!.title!;  // Safe!
+   }
+   ```
+
+2. **YouTube API contract**: The YouTube Data API v3 guarantees certain properties exist when specific conditions are met
+   - Example: If `items` array has elements, each `item.snippet` is guaranteed to exist
+
+3. **googleapis type definitions**: The official TypeScript definitions use optional types extensively (`property?: type`), even for required fields
+
+4. **Readability**: Using `!` after validation is more concise than repeated null checks
+
+### Pattern to Follow
+
+```typescript
+// Good: Validate first, then assert
+if (response.data.items && response.data.items.length > 0) {
+  const title = response.data.items[0].snippet!.title!;  // Safe!
+}
+
+// Bad: Assert without validation
+const title = response.data.items![0].snippet!.title!;  // Unsafe!
+```
+
+### When Adding New Code
+
+- Always validate before asserting
+- If unsure whether a property can be null, use optional chaining (`?.`) instead
+- Prefer explicit checks over assertions for user input or external data
+
+## Troubleshooting TypeScript Errors
+
+### "Cannot find module" Errors
+
+```bash
+# Solution: Check imports use correct paths
+import { getVideoInfo } from '../lib/youtube';  # Correct
+import { getVideoInfo } from '../lib/youtube.ts';  # Wrong - no .ts extension
+```
+
+### Type Errors with googleapis
+
+```typescript
+// Use optional chaining and non-null assertions carefully
+const channelId = response.data.items?.[0]?.snippet?.channelId;
+if (!channelId) {
+  throw new Error('Channel not found');
+}
+```
+
+### ESLint Errors
+
+```bash
+npm run lint          # See all errors
+# Fix common issues:
+# - Unused imports: Remove them
+# - Unused variables: Prefix with _ if intentional
+# - any type: Add proper types
+```
+
+### Build Errors
+
+```bash
+# Clean build and try again
+rm -rf dist/
+npm run build
+
+# Check for syntax errors in .ts files
+npm run type-check
+```
+
+## Related Guides
+
+- [Adding Commands Guide](adding-commands.md) - Command creation patterns
+- [Error Handling Guide](error-handling.md) - Error type patterns
+- [Troubleshooting Guide](troubleshooting.md) - Build and type error resolution
+- [Architecture Guide](architecture.md) - Type system architecture

--- a/docs/development/youtube-api-guide.md
+++ b/docs/development/youtube-api-guide.md
@@ -1,0 +1,248 @@
+# YouTube API Guide
+
+This guide covers YouTube Data API v3 usage patterns for the staqan-yt-cli project.
+
+## Required Scopes
+
+```typescript
+const SCOPES = [
+  'https://www.googleapis.com/auth/youtube.readonly',      // Read operations
+  'https://www.googleapis.com/auth/youtube.force-ssl',     // Write operations
+];
+```
+
+Defined in `lib/auth.ts`.
+
+## Authentication
+
+```typescript
+import { getAuthenticatedClient } from '../lib/auth';
+
+async function yourCommand() {
+  const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
+
+  // Use youtube for API calls
+}
+```
+
+## Common Operations
+
+### Get Video Details
+
+```typescript
+const response = await youtube.videos.list({
+  part: 'snippet,statistics,contentDetails',
+  id: videoIds.join(',')
+});
+
+if (!response.data.items || response.data.items.length === 0) {
+  throw new Error('Video not found');
+}
+
+const video = response.data.items[0];
+```
+
+### List Channel Videos
+
+```typescript
+// First get uploads playlist ID
+const channelResponse = await youtube.channels.list({
+  part: 'contentDetails',
+  handle: channelHandle.replace('@', '')
+});
+
+if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
+  throw new Error('Channel not found');
+}
+
+const uploadsPlaylistId = channelResponse.data.items[0].contentDetails?.relatedPlaylists?.uploads;
+
+if (!uploadsPlaylistId) {
+  throw new Error('No uploads playlist found');
+}
+
+// Then get videos from playlist
+const playlistResponse = await youtube.playlistItems.list({
+  part: 'snippet',
+  playlistId: uploadsPlaylistId,
+  maxResults: 50
+});
+
+const videos = playlistResponse.data.items || [];
+```
+
+### Update Video Metadata
+
+```typescript
+await youtube.videos.update({
+  part: 'snippet',
+  requestBody: {
+    id: videoId,
+    snippet: {
+      title: newTitle,
+      description: newDescription,
+      categoryId: '24' // Keep existing category
+    }
+  }
+});
+```
+
+### Search Videos
+
+```typescript
+const response = await youtube.search.list({
+  part: 'snippet',
+  q: query,
+  type: 'video',
+  maxResults: 10
+});
+
+const results = response.data.items || [];
+```
+
+### Get Video Localizations
+
+```typescript
+const response = await youtube.videos.list({
+  part: 'localizations',
+  id: videoId
+});
+
+const localizations = response.data.items?.[0]?.localizations;
+```
+
+### Get Comments
+
+```typescript
+const response = await youtube.commentThreads.list({
+  part: 'snippet',
+  videoId: videoId,
+  maxResults: 100
+});
+
+const comments = response.data.items || [];
+```
+
+### Get Playlists
+
+```typescript
+const response = await youtube.playlists.list({
+  part: 'snippet,contentDetails',
+  channelId: channelId,
+  maxResults: 50
+});
+
+const playlists = response.data.items || [];
+```
+
+### Get Playlist Items
+
+```typescript
+const response = await youtube.playlistItems.list({
+  part: 'snippet',
+  playlistId: playlistId,
+  maxResults: 50
+});
+
+const items = response.data.items || [];
+```
+
+## API Parts
+
+The YouTube API uses the `part` parameter to specify which fields to return:
+
+| Part | Description |
+|------|-------------|
+| `snippet` | Basic metadata (title, description, thumbnails, etc.) |
+| `statistics` | View count, like count, comment count |
+| `contentDetails` | Duration, definition, caption availability |
+| `localizations` | Localized titles and descriptions |
+| `status` | Privacy status, license, embedding settings |
+
+**Best practice**: Only request the parts you need to save quota.
+
+## API Quotas
+
+**Default quota**: 10,000 units/day
+
+**Cost per operation**:
+- Read operations: 1-5 units
+- Write operations: 50 units
+- List operations: 1-100 units (depends on parts and maxResults)
+
+**Quota-saving tips**:
+1. Batch operations when possible (e.g., multiple video IDs in one call)
+2. Only request the parts you need
+3. Use caching for frequently accessed data
+4. Filter on the server side (use API filters, not client-side)
+
+## Pagination
+
+For large result sets, use pagination:
+
+```typescript
+let nextPageToken: string | undefined;
+const allVideos: Video[] = [];
+
+do {
+  const response = await youtube.playlistItems.list({
+    part: 'snippet',
+    playlistId: uploadsPlaylistId,
+    maxResults: 50,
+    pageToken: nextPageToken
+  });
+
+  allVideos.push(...(response.data.items || []));
+  nextPageToken = response.data.nextPageToken;
+} while (nextPageToken);
+```
+
+## Error Handling
+
+### Common API Errors
+
+```typescript
+try {
+  const response = await youtube.videos.list({ ... });
+} catch (err) {
+  if ((err as any).code === 400) {
+    throw new Error('Invalid request parameters');
+  } else if ((err as any).code === 401) {
+    throw new Error('Authentication failed. Please run: staqan-yt auth');
+  } else if ((err as any).code === 403) {
+    throw new Error('API quota exceeded or insufficient permissions');
+  } else if ((err as any).code === 404) {
+    throw new Error('Resource not found');
+  } else {
+    throw new Error(`API error: ${(err as Error).message}`);
+  }
+}
+```
+
+## Type Safety
+
+Use googleapis type definitions:
+
+```typescript
+import { youtube_v3 } from 'googleapis';
+
+async function getVideo(videoId: string): Promise<youtube_v3.Schema$Video> {
+  const response = await youtube.videos.list({
+    part: 'snippet,statistics',
+    id: videoId
+  });
+
+  if (!response.data.items || response.data.items.length === 0) {
+    throw new Error('Video not found');
+  }
+
+  return response.data.items[0];
+}
+```
+
+## Related Guides
+
+- [Adding Commands Guide](adding-commands.md) - Command patterns
+- [Error Handling Guide](error-handling.md) - API error handling
+- [Architecture Guide](architecture.md) - API wrapper architecture

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -294,6 +294,30 @@ staqan-yt config set default.channel @yourchannel
 
 ---
 
+### Lock file errors
+
+**Problem:**
+```
+Failed to acquire reports lock
+Another fetch operation is in progress. Wait for it to complete or run: rm ~/.staqan-yt-cli/data/*/reports/.lock
+```
+
+**Cause:** Another `staqan-yt fetch-reports` command is already running for this channel.
+
+**Solutions:**
+1. **Wait** for the other operation to complete (check with `ps aux | grep staqan-yt`)
+2. **Remove stale lock** if process crashed: `rm ~/.staqan-yt-cli/data/{channelId}/reports/.lock`
+3. **Verify channel** - locks are per-channel, ensure you're using the correct channel
+
+**Lock file locations:**
+- Completion cache: `data/{channelId}/completion_cache.json.lock`
+- Handle cache: `data/handle-to-channel-id.json.lock`
+- Reports directory: `data/{channelId}/reports/.lock`
+
+**Note:** Locks auto-expire after 30 minutes or if the PID no longer exists.
+
+---
+
 ## Output Issues
 
 ### CSV not opening in Excel correctly

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -130,7 +130,8 @@ async function authenticate(): Promise<OAuth2Client> {
 
   return new Promise((resolve, reject) => {
     // Create local server to receive callback
-    const server = http.createServer(async (req, res) => {
+    const server = http.createServer((req, res) => {
+      (async () => {
       try {
         const queryParams = url.parse(req.url!, true).query;
 
@@ -155,6 +156,7 @@ async function authenticate(): Promise<OAuth2Client> {
         server.close();
         reject(err);
       }
+      })();
     });
 
     // Configure server to prevent hanging

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -348,6 +348,7 @@ export async function deleteReportFromCache(
 
 /**
  * Compute overlap between two date ranges
+ * Normalizes all inputs to date-only (YYYY-MM-DD) before comparison
  * Returns null if no overlap
  */
 export function computeDateRangeOverlap(
@@ -356,10 +357,16 @@ export function computeDateRangeOverlap(
   start2: string,
   end2: string
 ): { start: string; end: string } | null {
-  const s1 = new Date(start1).getTime();
-  const e1 = new Date(end1).getTime();
-  const s2 = new Date(start2).getTime();
-  const e2 = new Date(end2).getTime();
+  // Normalize to date-only strings (handle both YYYY-MM-DD and ISO timestamps)
+  const d1 = start1.split('T')[0];
+  const d2 = end1.split('T')[0];
+  const d3 = start2.split('T')[0];
+  const d4 = end2.split('T')[0];
+
+  const s1 = new Date(d1).getTime();
+  const e1 = new Date(d2).getTime();
+  const s2 = new Date(d3).getTime();
+  const e2 = new Date(d4).getTime();
 
   const overlapStart = Math.max(s1, s2);
   const overlapEnd = Math.min(e1, e2);
@@ -477,32 +484,35 @@ export async function analyzeCacheCoverage(
   const notCovered: string[] = [];
 
   const cachedRanges = cachedReports.map(r => ({
-    start: r.startTime,
-    end: r.endTime,
+    start: r.startTime.split('T')[0],
+    end: r.endTime.split('T')[0],
   }));
 
   const gaps = findDateGaps(cachedRanges, requestedStart, requestedEnd);
 
   for (const cachedReport of cachedReports) {
+    const cachedStart = cachedReport.startTime.split('T')[0];
+    const cachedEnd = cachedReport.endTime.split('T')[0];
+
     const overlap = computeDateRangeOverlap(
-      cachedReport.startTime,
-      cachedReport.endTime,
+      cachedStart,
+      cachedEnd,
       requestedStart,
       requestedEnd
     );
 
     if (!overlap) continue;
 
-    if (overlap.start === cachedReport.startTime && overlap.end === cachedReport.endTime) {
-      fullyCovered.push(`${cachedReport.startTime}/${cachedReport.endTime}`);
+    if (overlap.start === cachedStart && overlap.end === cachedEnd) {
+      fullyCovered.push(`${cachedStart}/${cachedEnd}`);
     } else {
-      const missingStart = overlap.start < cachedReport.startTime
+      const missingStart = overlap.start < cachedStart
         ? overlap.start
-        : new Date(new Date(cachedReport.endTime).getTime() + 86400000).toISOString().split('T')[0];
+        : new Date(new Date(cachedEnd).getTime() + 86400000).toISOString().split('T')[0];
 
-      const missingEnd = overlap.end > cachedReport.endTime
+      const missingEnd = overlap.end > cachedEnd
         ? overlap.end
-        : new Date(new Date(cachedReport.startTime).getTime() - 86400000).toISOString().split('T')[0];
+        : new Date(new Date(cachedStart).getTime() - 86400000).toISOString().split('T')[0];
 
       partiallyCovered.push({
         range: { start: requestedStart, end: requestedEnd },

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -61,6 +61,17 @@ export async function loadCacheIndex(channelId: string): Promise<CacheIndex> {
       throw new Error('Invalid cache index structure');
     }
 
+    // Validate version matches expected format
+    if (index.version !== CACHE_INDEX_VERSION) {
+      debug(`Cache index version mismatch for channel ${channelId}: ${index.version} vs ${CACHE_INDEX_VERSION}`);
+      // Return fresh index to prevent schema incompatibility issues
+      return {
+        version: CACHE_INDEX_VERSION,
+        lastUpdated: new Date().toISOString(),
+        entries: [],
+      };
+    }
+
     return index;
   } catch {
     debug(`Cache index not found or invalid for channel ${channelId}, creating new one`);

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -4,63 +4,66 @@ import { CONFIG_DIR } from './utils';
 import { CacheIndex, CacheIndexEntry, ReportMetadata, CacheCoverage } from '../types';
 import { debug } from './utils';
 
-// Cache directory structure
+// Base data directory
 const DATA_DIR = path.join(CONFIG_DIR, 'data');
-const CACHE_DIR = path.join(DATA_DIR, 'reports');
-const CACHE_INDEX_PATH = path.join(DATA_DIR, 'cache-index.json');
 
-// Cache index version (for future migrations)
-const CACHE_INDEX_VERSION = '1.0';
+// Cache index version
+const CACHE_INDEX_VERSION = '2.0';
+
+// ─── Per-channel path helpers ──────────────────────────────────────────────────
+
+function getChannelDataDir(channelId: string): string {
+  return path.join(DATA_DIR, channelId);
+}
+
+function getChannelReportsDir(channelId: string): string {
+  return path.join(DATA_DIR, channelId, 'reports');
+}
+
+function getChannelCacheIndexPath(channelId: string): string {
+  return path.join(DATA_DIR, channelId, 'reports', 'cache-index.json');
+}
 
 /**
- * Ensure cache directory structure exists
+ * Ensure per-channel cache directory structure exists
  */
-export async function ensureCacheDir(): Promise<void> {
+export async function ensureCacheDir(channelId: string): Promise<void> {
+  const channelDir = getChannelDataDir(channelId);
+  const reportsDir = getChannelReportsDir(channelId);
+
+  // Check if new channel directory is being created
+  let isNew = false;
   try {
-    await fs.access(DATA_DIR);
+    await fs.access(channelDir);
   } catch {
-    await fs.mkdir(DATA_DIR, { recursive: true });
+    isNew = true;
   }
 
-  try {
-    await fs.access(CACHE_DIR);
-  } catch {
-    await fs.mkdir(CACHE_DIR, { recursive: true });
+  await fs.mkdir(reportsDir, { recursive: true });
+
+  if (isNew) {
+    debug(`Created new channel directory: ${channelDir}`);
   }
 }
 
-/**
- * Get cache directory path
- */
-export function getCacheDir(): string {
-  return CACHE_DIR;
-}
+// ─── Cache index ──────────────────────────────────────────────────────────────
 
 /**
- * Get reports subdirectory path
+ * Load per-channel cache index
  */
-export function getReportsDir(): string {
-  return CACHE_DIR;
-}
-
-/**
- * Load global cache index
- */
-export async function loadCacheIndex(): Promise<CacheIndex> {
+export async function loadCacheIndex(channelId: string): Promise<CacheIndex> {
   try {
-    await ensureCacheDir();
-    const data = await fs.readFile(CACHE_INDEX_PATH, 'utf-8');
+    await ensureCacheDir(channelId);
+    const data = await fs.readFile(getChannelCacheIndexPath(channelId), 'utf-8');
     const index = JSON.parse(data) as CacheIndex;
 
-    // Validate structure
     if (!index.version || !Array.isArray(index.entries)) {
       throw new Error('Invalid cache index structure');
     }
 
     return index;
   } catch {
-    // File doesn't exist or is invalid - return empty index
-    debug('Cache index not found or invalid, creating new one');
+    debug(`Cache index not found or invalid for channel ${channelId}, creating new one`);
     return {
       version: CACHE_INDEX_VERSION,
       lastUpdated: new Date().toISOString(),
@@ -70,60 +73,56 @@ export async function loadCacheIndex(): Promise<CacheIndex> {
 }
 
 /**
- * Save global cache index
+ * Save per-channel cache index
  */
-export async function saveCacheIndex(index: CacheIndex): Promise<void> {
-  await ensureCacheDir();
+export async function saveCacheIndex(channelId: string, index: CacheIndex): Promise<void> {
+  await ensureCacheDir(channelId);
   index.lastUpdated = new Date().toISOString();
-  await fs.writeFile(CACHE_INDEX_PATH, JSON.stringify(index, null, 2), 'utf-8');
+  await fs.writeFile(getChannelCacheIndexPath(channelId), JSON.stringify(index, null, 2), 'utf-8');
 }
 
 /**
  * Add entry to cache index
  */
-export async function addCacheEntry(entry: CacheIndexEntry): Promise<void> {
-  const index = await loadCacheIndex();
+export async function addCacheEntry(channelId: string, entry: CacheIndexEntry): Promise<void> {
+  const index = await loadCacheIndex(channelId);
 
-  // Check if entry already exists
   const existingIndex = index.entries.findIndex(e => e.reportId === entry.reportId);
   if (existingIndex >= 0) {
-    // Update existing entry
     index.entries[existingIndex] = entry;
   } else {
-    // Add new entry
     index.entries.push(entry);
   }
 
-  await saveCacheIndex(index);
+  await saveCacheIndex(channelId, index);
   debug(`Added cache entry: ${entry.reportId}`);
 }
 
 /**
  * Remove entry from cache index
  */
-export async function removeCacheEntry(reportId: string): Promise<void> {
-  const index = await loadCacheIndex();
+export async function removeCacheEntry(channelId: string, reportId: string): Promise<void> {
+  const index = await loadCacheIndex(channelId);
   index.entries = index.entries.filter(e => e.reportId !== reportId);
-  await saveCacheIndex(index);
+  await saveCacheIndex(channelId, index);
   debug(`Removed cache entry: ${reportId}`);
 }
 
 /**
- * Find cached reports for a type and date range
+ * Find cached reports for a type and date range (filtered by channelId)
  */
 export async function findCachedReports(
+  channelId: string,
   reportTypeId: string,
   startDate: string,
   endDate: string
 ): Promise<CacheIndexEntry[]> {
-  const index = await loadCacheIndex();
+  const index = await loadCacheIndex(channelId);
 
   return index.entries.filter(entry => {
-    if (entry.reportTypeId !== reportTypeId) {
-      return false;
-    }
+    if (entry.channelId !== channelId) return false;
+    if (entry.reportTypeId !== reportTypeId) return false;
 
-    // Check for overlap with requested range
     const overlap = computeDateRangeOverlap(
       entry.startTime,
       entry.endTime,
@@ -135,32 +134,31 @@ export async function findCachedReports(
   });
 }
 
-/**
- * Get report directory path
- */
-function getReportTypeDir(reportTypeId: string): string {
-  return path.join(CACHE_DIR, reportTypeId);
+// ─── Report file paths ────────────────────────────────────────────────────────
+
+function getReportTypeDir(channelId: string, reportTypeId: string): string {
+  return path.join(getChannelReportsDir(channelId), reportTypeId);
 }
 
-/**
- * Get report file paths
- */
-function getReportPaths(reportId: string, reportTypeId: string) {
-  const reportTypeDir = getReportTypeDir(reportTypeId);
+function getReportPaths(channelId: string, reportId: string, reportTypeId: string) {
+  const reportTypeDir = getReportTypeDir(channelId, reportTypeId);
   return {
     csv: path.join(reportTypeDir, `${reportId}.csv`),
     metadata: path.join(reportTypeDir, `${reportId}.metadata.json`),
   };
 }
 
+// ─── Metadata ────────────────────────────────────────────────────────────────
+
 /**
  * Load report metadata
  */
 export async function loadReportMetadata(
+  channelId: string,
   reportId: string,
   reportTypeId: string
 ): Promise<ReportMetadata | null> {
-  const { metadata: metadataPath } = getReportPaths(reportId, reportTypeId);
+  const { metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
 
   try {
     const data = await fs.readFile(metadataPath, 'utf-8');
@@ -173,14 +171,16 @@ export async function loadReportMetadata(
 /**
  * Save report metadata
  */
-export async function saveReportMetadata(metadata: ReportMetadata): Promise<void> {
-  const reportTypeDir = getReportTypeDir(metadata.reportTypeId);
+export async function saveReportMetadata(channelId: string, metadata: ReportMetadata): Promise<void> {
+  const reportTypeDir = getReportTypeDir(channelId, metadata.reportTypeId);
   await fs.mkdir(reportTypeDir, { recursive: true });
 
-  const { metadata: metadataPath } = getReportPaths(metadata.reportId, metadata.reportTypeId);
+  const { metadata: metadataPath } = getReportPaths(channelId, metadata.reportId, metadata.reportTypeId);
   await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), 'utf-8');
   debug(`Saved metadata for: ${metadata.reportId}`);
 }
+
+// ─── CSV parsing ──────────────────────────────────────────────────────────────
 
 /**
  * Parse CSV line properly handling quoted fields
@@ -196,15 +196,12 @@ function parseCsvLine(line: string): string[] {
 
     if (char === '"') {
       if (inQuotes && nextChar === '"') {
-        // Escaped quote
         current += '"';
         i++;
       } else {
-        // Toggle quote mode
         inQuotes = !inQuotes;
       }
     } else if (char === ',' && !inQuotes) {
-      // Field separator
       result.push(current);
       current = '';
     } else {
@@ -212,9 +209,7 @@ function parseCsvLine(line: string): string[] {
     }
   }
 
-  // Add last field
   result.push(current);
-
   return result;
 }
 
@@ -239,7 +234,6 @@ export function parseCsvAndExtractRange(csvData: string): {
     return obj;
   });
 
-  // Find date range (assuming 'date' column exists)
   const dates = data
     .map(row => row.date)
     .filter(date => date)
@@ -251,34 +245,33 @@ export function parseCsvAndExtractRange(csvData: string): {
   return { headers, data, minDate, maxDate };
 }
 
+// ─── Report cache operations ──────────────────────────────────────────────────
+
 /**
  * Read cached report CSV data
  */
 export async function readCachedReport(
+  channelId: string,
   reportId: string,
   reportTypeId: string
 ): Promise<{
   headers: string[];
   data: Record<string, string>[];
 } | null> {
-  const { csv: csvPath } = getReportPaths(reportId, reportTypeId);
+  const { csv: csvPath } = getReportPaths(channelId, reportId, reportTypeId);
 
   try {
-    // Read CSV data
     const csvData = await fs.readFile(csvPath, 'utf-8');
     const parsed = parseCsvAndExtractRange(csvData);
 
-    // Validate against metadata
-    const metadata = await loadReportMetadata(reportId, reportTypeId);
+    const metadata = await loadReportMetadata(channelId, reportId, reportTypeId);
 
     if (metadata) {
-      // Check column match
       if (parsed.headers.join(',') !== metadata.columns.join(',')) {
-        debug(`Column mismatch for ${reportId}, expected: ${metadata.columns.join(',')}, got: ${parsed.headers.join(',')}`);
+        debug(`Column mismatch for ${reportId}`);
         return null;
       }
 
-      // Check completeness
       if (!metadata.isComplete) {
         debug(`Report ${reportId} marked as incomplete`);
         return null;
@@ -296,26 +289,24 @@ export async function readCachedReport(
  * Save report to cache
  */
 export async function saveReportToCache(
+  channelId: string,
   reportId: string,
   reportTypeId: string,
   csvData: string,
   metadata: ReportMetadata
 ): Promise<void> {
-  const reportTypeDir = getReportTypeDir(reportTypeId);
+  const reportTypeDir = getReportTypeDir(channelId, reportTypeId);
   await fs.mkdir(reportTypeDir, { recursive: true });
 
-  const { csv: csvPath } = getReportPaths(reportId, reportTypeId);
+  const { csv: csvPath } = getReportPaths(channelId, reportId, reportTypeId);
 
-  // Save CSV file
   await fs.writeFile(csvPath, csvData, 'utf-8');
+  await saveReportMetadata(channelId, metadata);
 
-  // Save metadata
-  await saveReportMetadata(metadata);
-
-  // Add to cache index
-  await addCacheEntry({
+  await addCacheEntry(channelId, {
     reportId,
     reportTypeId,
+    channelId,
     startTime: metadata.startTime,
     endTime: metadata.endTime,
     downloadedAt: metadata.downloadedAt,
@@ -331,10 +322,11 @@ export async function saveReportToCache(
  * Delete report from cache
  */
 export async function deleteReportFromCache(
+  channelId: string,
   reportId: string,
   reportTypeId: string
 ): Promise<void> {
-  const { csv: csvPath, metadata: metadataPath } = getReportPaths(reportId, reportTypeId);
+  const { csv: csvPath, metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
 
   try {
     await fs.unlink(csvPath);
@@ -348,11 +340,11 @@ export async function deleteReportFromCache(
     // Ignore if file doesn't exist
   }
 
-  // Remove from cache index
-  await removeCacheEntry(reportId);
-
+  await removeCacheEntry(channelId, reportId);
   debug(`Deleted report from cache: ${reportId}`);
 }
+
+// ─── Date range utilities ─────────────────────────────────────────────────────
 
 /**
  * Compute overlap between two date ranges
@@ -373,7 +365,7 @@ export function computeDateRangeOverlap(
   const overlapEnd = Math.min(e1, e2);
 
   if (overlapStart > overlapEnd) {
-    return null; // No overlap
+    return null;
   }
 
   return {
@@ -388,11 +380,8 @@ export function computeDateRangeOverlap(
 export function mergeDateRanges(
   ranges: { start: string; end: string }[]
 ): { start: string; end: string }[] {
-  if (ranges.length === 0) {
-    return [];
-  }
+  if (ranges.length === 0) return [];
 
-  // Sort by start date
   const sorted = [...ranges].sort((a, b) =>
     new Date(a.start).getTime() - new Date(b.start).getTime()
   );
@@ -406,15 +395,12 @@ export function mergeDateRanges(
     const lastEnd = new Date(last.end).getTime();
     const currentStart = new Date(current.start).getTime();
 
-    // Check if ranges overlap or are adjacent (within 1 day)
     if (currentStart <= lastEnd + 86400000) {
-      // Merge ranges
       const currentEnd = new Date(current.end).getTime();
       if (currentEnd > lastEnd) {
         last.end = current.end;
       }
     } else {
-      // No overlap, add as new range
       merged.push(current);
     }
   }
@@ -430,9 +416,7 @@ export function findDateGaps(
   requestedStart: string,
   requestedEnd: string
 ): { start: string; end: string }[] {
-  // Sort and merge ranges
   const merged = mergeDateRanges(ranges);
-
   const gaps: { start: string; end: string }[] = [];
   let current = new Date(requestedStart);
 
@@ -440,7 +424,6 @@ export function findDateGaps(
     const rangeStart = new Date(range.start);
     const rangeEnd = new Date(range.end);
 
-    // Gap exists if current is before range start
     if (current < rangeStart) {
       gaps.push({
         start: current.toISOString().split('T')[0],
@@ -448,14 +431,12 @@ export function findDateGaps(
       });
     }
 
-    // Move current to after this range
     const afterRange = new Date(rangeEnd.getTime() + 86400000);
     if (afterRange > current) {
       current = afterRange;
     }
   }
 
-  // Check for gap after last range
   const requestedEndDate = new Date(requestedEnd);
   if (current <= requestedEndDate) {
     gaps.push({
@@ -471,21 +452,18 @@ export function findDateGaps(
  * Analyze cache coverage for requested date range
  */
 export async function analyzeCacheCoverage(
+  channelId: string,
   reportTypeId: string,
   requestedStart: string,
   requestedEnd: string
 ): Promise<CacheCoverage> {
   const cachedReports = await findCachedReports(
+    channelId,
     reportTypeId,
     requestedStart,
     requestedEnd
   );
 
-  const fullyCovered: string[] = [];
-  const partiallyCovered: CacheCoverage['partiallyCovered'] = [];
-  const notCovered: string[] = [];
-
-  // If no cached reports, entire range is not covered
   if (cachedReports.length === 0) {
     return {
       fullyCovered: [],
@@ -494,16 +472,17 @@ export async function analyzeCacheCoverage(
     };
   }
 
-  // Build cached ranges
+  const fullyCovered: string[] = [];
+  const partiallyCovered: CacheCoverage['partiallyCovered'] = [];
+  const notCovered: string[] = [];
+
   const cachedRanges = cachedReports.map(r => ({
     start: r.startTime,
     end: r.endTime,
   }));
 
-  // Find gaps
   const gaps = findDateGaps(cachedRanges, requestedStart, requestedEnd);
 
-  // Classify coverage
   for (const cachedReport of cachedReports) {
     const overlap = computeDateRangeOverlap(
       cachedReport.startTime,
@@ -514,12 +493,9 @@ export async function analyzeCacheCoverage(
 
     if (!overlap) continue;
 
-    // Check if fully covered
-    if (overlap.start === cachedReport.startTime &&
-        overlap.end === cachedReport.endTime) {
+    if (overlap.start === cachedReport.startTime && overlap.end === cachedReport.endTime) {
       fullyCovered.push(`${cachedReport.startTime}/${cachedReport.endTime}`);
     } else {
-      // Partial coverage
       const missingStart = overlap.start < cachedReport.startTime
         ? overlap.start
         : new Date(new Date(cachedReport.endTime).getTime() + 86400000).toISOString().split('T')[0];
@@ -536,14 +512,9 @@ export async function analyzeCacheCoverage(
     }
   }
 
-  // Add gaps to notCovered
   for (const gap of gaps) {
     notCovered.push(`${gap.start}/${gap.end}`);
   }
 
-  return {
-    fullyCovered,
-    partiallyCovered,
-    notCovered,
-  };
+  return { fullyCovered, partiallyCovered, notCovered };
 }

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -281,7 +281,7 @@ export async function readCachedReport(
 
     if (metadata) {
       if (parsed.headers.join(',') !== metadata.columns.join(',')) {
-        debug(`Column mismatch for ${reportId}`);
+        debug(`Column mismatch for ${reportId}, expected: ${metadata.columns.join(',')}, got: ${parsed.headers.join(',')}`);
         return null;
       }
 

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,8 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { CONFIG_DIR } from './utils';
+import { CONFIG_DIR, debug, warning } from './utils';
 import { CacheIndex, CacheIndexEntry, ReportMetadata, CacheCoverage } from '../types';
-import { debug } from './utils';
 
 // Base data directory
 const DATA_DIR = path.join(CONFIG_DIR, 'data');
@@ -63,8 +62,10 @@ export async function loadCacheIndex(channelId: string): Promise<CacheIndex> {
 
     // Validate version matches expected format
     if (index.version !== CACHE_INDEX_VERSION) {
-      debug(`Cache index version mismatch for channel ${channelId}: ${index.version} vs ${CACHE_INDEX_VERSION}`);
-      // Return fresh index to prevent schema incompatibility issues
+      const indexPath = getChannelCacheIndexPath(channelId);
+      warning(`Cache index is outdated (v${index.version} → v${CACHE_INDEX_VERSION}). Cached report data cleared.`);
+      warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelId}`);
+      warning(`  To delete:  ${indexPath}`);
       return {
         version: CACHE_INDEX_VERSION,
         lastUpdated: new Date().toISOString(),

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -50,7 +50,7 @@ export async function ensureCacheDir(channelId: string): Promise<void> {
 /**
  * Load per-channel cache index
  */
-export async function loadCacheIndex(channelId: string): Promise<CacheIndex> {
+export async function loadCacheIndex(channelId: string, channelHandle?: string): Promise<CacheIndex> {
   try {
     await ensureCacheDir(channelId);
     const data = await fs.readFile(getChannelCacheIndexPath(channelId), 'utf-8');
@@ -63,8 +63,9 @@ export async function loadCacheIndex(channelId: string): Promise<CacheIndex> {
     // Validate version matches expected format
     if (index.version !== CACHE_INDEX_VERSION) {
       const indexPath = getChannelCacheIndexPath(channelId);
+      const channelArg = channelHandle ?? channelId;
       warning(`Cache index is outdated (v${index.version} → v${CACHE_INDEX_VERSION}). Cached report data cleared.`);
-      warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelId}`);
+      warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelArg}`);
       warning(`  To delete:  ${indexPath}`);
       return {
         version: CACHE_INDEX_VERSION,

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -107,7 +107,7 @@ async function isLockStale(lockPath: string, staleAge: number): Promise<boolean>
     }
 
     return false;
-  } catch (err) {
+  } catch {
     // Can't read lock file - assume stale
     debug(`Failed to read lock file ${lockPath}, assuming stale`);
     return true;

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -1,0 +1,148 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import os from 'os';
+import { debug } from './utils';
+
+export interface LockOptions {
+  timeout?: number;        // Max wait time (ms) before giving up
+  interval?: number;       // Retry interval (ms)
+  staleAge?: number;       // Age to consider lock stale (ms) - default 30min
+}
+
+export interface LockInfo {
+  pid: number;
+  created: string;         // ISO 8601 timestamp
+  purpose?: string;
+  channelId?: string;
+}
+
+/**
+ * Acquire a file-based lock with PID checking
+ */
+export async function acquireLock(
+  lockPath: string,
+  options: LockOptions = {}
+): Promise<() => Promise<void>> {
+  const {
+    timeout = 30000,       // 30 second default timeout
+    interval = 100,        // 100ms retry interval
+    staleAge = 30 * 60 * 1000, // 30 minutes
+  } = options;
+
+  const startTime = Date.now();
+  const myPid = process.pid;
+  const lockInfo: LockInfo = {
+    pid: myPid,
+    created: new Date().toISOString(),
+  };
+
+  while (Date.now() - startTime < timeout) {
+    try {
+      // Try to create lock file exclusively (fails if exists)
+      const lockContent = JSON.stringify(lockInfo, null, 2);
+      await fs.writeFile(lockPath, lockContent, { flag: 'wx' });
+
+      debug(`Acquired lock: ${lockPath} (PID ${myPid})`);
+
+      // Return cleanup function
+      return async () => {
+        try {
+          await fs.unlink(lockPath);
+          debug(`Released lock: ${lockPath}`);
+        } catch (err) {
+          debug(`Failed to release lock ${lockPath}:`, (err as Error).message);
+        }
+      };
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+
+      // Lock exists - check if stale
+      if (error.code === 'EEXIST') {
+        const stale = await isLockStale(lockPath, staleAge);
+
+        if (stale) {
+          debug(`Removing stale lock: ${lockPath}`);
+          try {
+            await fs.unlink(lockPath);
+            continue; // Try to acquire again
+          } catch (unlinkErr) {
+            debug(`Failed to remove stale lock:`, (unlinkErr as Error).message);
+          }
+        }
+
+        // Lock is active - wait and retry
+        await new Promise(resolve => setTimeout(resolve, interval));
+        continue;
+      }
+
+      // Other error - give up
+      throw error;
+    }
+  }
+
+  throw new Error(`Failed to acquire lock ${lockPath} after ${timeout}ms`);
+}
+
+/**
+ * Check if lock file is stale (PID doesn't exist or file is old)
+ */
+async function isLockStale(lockPath: string, staleAge: number): Promise<boolean> {
+  try {
+    const content = await fs.readFile(lockPath, 'utf-8');
+    const lockInfo: LockInfo = JSON.parse(content);
+
+    // Check file age
+    const created = new Date(lockInfo.created).getTime();
+    const age = Date.now() - created;
+    if (age > staleAge) {
+      debug(`Lock ${lockPath} is stale (age: ${Math.round(age / 1000)}s)`);
+      return true;
+    }
+
+    // Check if PID exists
+    const pidExists = await isProcessAlive(lockInfo.pid);
+    if (!pidExists) {
+      debug(`Lock ${lockPath} is stale (PID ${lockInfo.pid} not found)`);
+      return true;
+    }
+
+    return false;
+  } catch (err) {
+    // Can't read lock file - assume stale
+    debug(`Failed to read lock file ${lockPath}, assuming stale`);
+    return true;
+  }
+}
+
+/**
+ * Check if a process is running (cross-platform)
+ */
+async function isProcessAlive(pid: number): Promise<boolean> {
+  try {
+    // POSIX: kill(pid, 0) tests if process exists without sending signal
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    // ESRCH = no such process
+    return error.code !== 'ESRCH';
+  }
+}
+
+/**
+ * Get lock file path for a given resource
+ */
+export function getLockPath(type: 'completion' | 'handles' | 'reports', channelId?: string): string {
+  const dataDir = path.join(os.homedir(), '.staqan-yt-cli', 'data');
+
+  switch (type) {
+    case 'completion':
+      if (!channelId) throw new Error('channelId required for completion lock');
+      return path.join(dataDir, channelId, 'completion_cache.json.lock');
+    case 'handles':
+      return path.join(dataDir, 'handle-to-channel-id.json.lock');
+    case 'reports':
+      if (!channelId) throw new Error('channelId required for reports lock');
+      return path.join(dataDir, channelId, 'reports', '.lock');
+  }
+}

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -40,7 +40,7 @@ export async function acquireLock(
     try {
       // Try to create lock file exclusively (fails if exists)
       const lockContent = JSON.stringify(lockInfo, null, 2);
-      await fs.writeFile(lockPath, lockContent, { flag: 'wx' });
+      await fs.writeFile(lockPath, lockContent, { flag: 'wx', mode: 0o600 });
 
       debug(`Acquired lock: ${lockPath} (PID ${myPid})`);
 

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import os from 'os';
 import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName } from './language';
+import { acquireLock, getLockPath } from './lock';
 import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PlaylistInfo, PlaylistListItem, CommentInfo, ChannelInfo, CaptionInfo, CaptionFormat } from '../types';
 import { debug, warning } from './utils';
 
@@ -20,11 +21,21 @@ async function loadHandleCache(): Promise<Record<string, string>> {
 }
 
 async function saveHandleCache(cache: Record<string, string>): Promise<void> {
+  const lockPath = getLockPath('handles');
+  let release: (() => Promise<void>) | null = null;
+
   try {
+    // Acquire lock with 5 second timeout
+    release = await acquireLock(lockPath, { timeout: 5000 });
+
     await fs.mkdir(path.dirname(HANDLE_CACHE_PATH), { recursive: true });
     await fs.writeFile(HANDLE_CACHE_PATH, JSON.stringify(cache, null, 2), 'utf-8');
+
+    debug('Handle cache saved');
   } catch (err) {
     debug('Failed to save handle cache:', (err as Error).message);
+  } finally {
+    if (release) await release();
   }
 }
 

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -25,10 +25,9 @@ async function saveHandleCache(cache: Record<string, string>): Promise<void> {
   let release: (() => Promise<void>) | null = null;
 
   try {
+    await fs.mkdir(path.dirname(HANDLE_CACHE_PATH), { recursive: true });
     // Acquire lock with 5 second timeout
     release = await acquireLock(lockPath, { timeout: 5000 });
-
-    await fs.mkdir(path.dirname(HANDLE_CACHE_PATH), { recursive: true });
     await fs.writeFile(HANDLE_CACHE_PATH, JSON.stringify(cache, null, 2), 'utf-8');
 
     debug('Handle cache saved');

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,8 +1,32 @@
 import { google, youtube_v3 } from 'googleapis';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
 import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName } from './language';
 import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PlaylistInfo, PlaylistListItem, CommentInfo, ChannelInfo, CaptionInfo, CaptionFormat } from '../types';
 import { debug, warning } from './utils';
+
+// ─── Handle → channel ID cache ────────────────────────────────────────────────
+
+const HANDLE_CACHE_PATH = path.join(os.homedir(), '.staqan-yt-cli', 'data', 'handle-to-channel-id.json');
+
+async function loadHandleCache(): Promise<Record<string, string>> {
+  try {
+    return JSON.parse(await fs.readFile(HANDLE_CACHE_PATH, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+async function saveHandleCache(cache: Record<string, string>): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(HANDLE_CACHE_PATH), { recursive: true });
+    await fs.writeFile(HANDLE_CACHE_PATH, JSON.stringify(cache, null, 2), 'utf-8');
+  } catch (err) {
+    debug('Failed to save handle cache:', (err as Error).message);
+  }
+}
 
 // ─── Client ──────────────────────────────────────────────────────────────────
 
@@ -53,16 +77,31 @@ async function getYouTubeClient(): Promise<youtube_v3.Youtube> {
 // ─── Channels ─────────────────────────────────────────────────────────────────
 
 /**
- * Get channel ID from handle or username
+ * Get channel ID from handle or username.
+ * Short-circuits if input is already a channel ID (UC + 22 chars).
+ * Caches resolved handle → ID mappings on disk to avoid repeat API calls.
  */
 async function getChannelId(handleOrId: string): Promise<string> {
-  debug(`Getting channel ID for: ${handleOrId}`);
+  // Short-circuit: already a channel ID — no API call needed
+  if (/^UC[a-zA-Z0-9_-]{22}$/.test(handleOrId)) {
+    debug(`Channel ID detected directly: ${handleOrId}`);
+    return handleOrId;
+  }
+
+  // Check FS handle cache before touching the API
+  const handleCache = await loadHandleCache();
+  if (handleCache[handleOrId]) {
+    debug(`Channel ID cache hit for: ${handleOrId} → ${handleCache[handleOrId]}`);
+    return handleCache[handleOrId];
+  }
+
+  debug(`Resolving channel ID for: ${handleOrId}`);
   const youtube = await getYouTubeClient();
+  let channelId: string | null = null;
 
   // If it starts with @, search by handle
   if (handleOrId.startsWith('@')) {
     debug('Searching by handle using search endpoint');
-    // Try searching by handle using search endpoint
     const searchResponse = await youtube.search.list({
       part: ['snippet'],
       q: handleOrId,
@@ -71,41 +110,48 @@ async function getChannelId(handleOrId: string): Promise<string> {
     });
 
     if (searchResponse.data.items && searchResponse.data.items.length > 0) {
-      const channelId = searchResponse.data.items[0].snippet!.channelId!;
+      channelId = searchResponse.data.items[0].snippet!.channelId!;
       debug(`Found channel ID: ${channelId}`);
-      return channelId;
+    }
+  } else {
+    // Try to get channel directly by ID
+    try {
+      const response = await youtube.channels.list({
+        part: ['id'],
+        id: [handleOrId],
+      });
+
+      if (response.data.items && response.data.items.length > 0) {
+        channelId = response.data.items[0].id!;
+      }
+    } catch {
+      // Continue to search
     }
 
+    // Fall back to username search
+    if (!channelId) {
+      const searchResponse = await youtube.search.list({
+        part: ['snippet'],
+        q: handleOrId,
+        type: ['channel'],
+        maxResults: 1,
+      });
+
+      if (searchResponse.data.items && searchResponse.data.items.length > 0) {
+        channelId = searchResponse.data.items[0].snippet!.channelId!;
+      }
+    }
+  }
+
+  if (!channelId) {
     throw new Error(`Channel not found: ${handleOrId}`);
   }
 
-  // Try to get channel directly
-  try {
-    const response = await youtube.channels.list({
-      part: ['id'],
-      id: [handleOrId],
-    });
+  // Persist to FS cache so future calls skip the API
+  handleCache[handleOrId] = channelId;
+  await saveHandleCache(handleCache);
 
-    if (response.data.items && response.data.items.length > 0) {
-      return response.data.items[0].id!;
-    }
-  } catch {
-    // Continue to search
-  }
-
-  // Try searching by username
-  const searchResponse = await youtube.search.list({
-    part: ['snippet'],
-    q: handleOrId,
-    type: ['channel'],
-    maxResults: 1,
-  });
-
-  if (searchResponse.data.items && searchResponse.data.items.length > 0) {
-    return searchResponse.data.items[0].snippet!.channelId!;
-  }
-
-  throw new Error(`Channel not found: ${handleOrId}`);
+  return channelId;
 }
 
 /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -346,6 +346,7 @@ export type CompletionCache = Record<string, CompletionCacheEntry>;
 export interface CacheIndexEntry {
   reportId: string;
   reportTypeId: string;
+  channelId: string;          // Channel this report belongs to
   startTime: string;          // YYYY-MM-DD
   endTime: string;            // YYYY-MM-DD
   downloadedAt: string;       // ISO 8601 timestamp
@@ -363,6 +364,7 @@ export interface CacheIndex {
 export interface ReportMetadata {
   reportId: string;
   reportTypeId: string;
+  channelId: string;          // Channel this report belongs to
   jobId: string;
   startTime: string;          // From YouTube API
   endTime: string;            // From YouTube API


### PR DESCRIPTION
## Summary

### Channel-Isolated Cache (Main Feature)
- All per-channel data now namespaced under `~/.staqan-yt-cli/data/{channelId}/`
- `completion_cache.json` → `data/{channelId}/completion_cache.json`
- `cache-index.json` → `data/{channelId}/reports/cache-index.json`
- Report files → `data/{channelId}/reports/{reportTypeId}/`
- `fetch-reports` and `get-report-data` now require channel via `--channel` flag or `default.channel` config
- `CacheIndexEntry` and `ReportMetadata` include `channelId` field (cache index version bumped to `2.0`)
- Cache keys in `complete.ts` simplified — file is already channel-scoped, no need to embed channel in key
- Renamed `MIGRATION.md` → `BREAKING-CHANGES.md` with v1.5.0 section
- **Handle→ID cache**: `data/handle-to-channel-id.json` persists resolved mappings (zero API calls on repeat use)
- **Short-circuit**: Input matching `UC[22 chars]` returns immediately with pure regex check
- **Date normalization**: Fixed timestamp vs date string comparison bug in report filtering/coverage

### Documentation Restructuring (Additional)
- **Reduced CLAUDE.md from 1409 to 433 lines** (69% reduction)
- **Created 12 focused development guides** in `docs/development/`
- Migrated detailed content to progressive-disclosure format
- Added comprehensive cross-references between guides
- Maintained all critical information in condensed CLAUDE.md

New development guides:
- `typescript-guide.md` - TypeScript patterns and type safety
- `adding-commands.md` - Step-by-step command creation
- `testing-guide.md` - Testing strategies
- `error-handling.md` - Error handling patterns
- `output-formats.md` - Output format implementation
- `youtube-api-guide.md` - YouTube Data API patterns
- `security-guide.md` - Security best practices
- `troubleshooting.md` - TypeScript/build troubleshooting
- `git-workflow.md` - Branch strategy and releases
- `maintenance-guide.md` - Dependency updates and Dependabot
- `architecture.md` - Lock strategy and architecture

Documentation benefits:
- Faster onboarding (CLAUDE.md readable in 5-10 min)
- Progressive disclosure (detail only when needed)
- Easier maintenance (update one guide without touching manifesto)
- Better organization (each guide has single, clear purpose)

## Breaking changes

Old cache data at flat paths is **not** automatically migrated. Users should set `default.channel` and re-run `fetch-reports` to repopulate. See `BREAKING-CHANGES.md` for details.

## Code Review Follow-up

### Fixed in this PR
- ✅ **Cache index version validation**: Added validation in `loadCacheIndex()` to prevent reading old v1.0 schema (missing `channelId` field). Old cache files are automatically replaced with fresh v2.0 indexes.
- ✅ **Lock ordering, double parse, indentation** (`75a6a45`): Addressed issues identified in PR review — consistent lock acquisition order, removed redundant JSON.parse calls, fixed indentation inconsistencies in `lib/lock.ts` and related files.
- ✅ **Unused catch binding** (`f16708a`): Removed unused `err` binding in `lib/lock.ts` catch block to satisfy lint.
- ✅ **Stricter lint fixes** (`93455d4`): Resolved 27 issues across 5 files — `no-misused-promises` in `lib/auth.ts` (async server callback wrapped in void IIFE), `no-unnecessary-type-assertion` in `get-report-data.ts` / `get-video-retention.ts` / `get-video-analytics.ts` / `list-report-types.ts`, and targeted `no-explicit-any` suppression in `bin/staqan-yt.ts`. `npm run lint` now reports 0 errors.
- ✅ **Lock file permissions** (`fecb3d5`): `writeFile` now passes `mode: 0o600` so lock files are owner-read/write only, preventing PID/timing info leakage to other users.
- ✅ **Cache version mismatch warning** (`fecb3d5`): Silent `debug()` log replaced with 3 visible `warning()` calls on stderr — prints the outdated version, exact index file path, and instructions to rebuild or delete.

### Tracked for future work
- #38 - Cache save failure handling + cache cleaning command
- #39 - Multi-channel support and comprehensive testing
- #40 - Cache performance metrics and telemetry

## Test plan

### Channel-Isolated Cache
- [ ] `staqan-yt config set default.channel @yourchannel`
- [ ] `staqan-yt fetch-reports --type channel_reach_basic_a1` — verifies channel resolution + new directory structure created
- [ ] `staqan-yt get-report-data --type channel_reach_basic_a1` — verifies cache read + channel flag
- [ ] `staqan-yt __complete --type video-id` — verifies per-channel completion cache path
- [ ] `ls ~/.staqan-yt-cli/data/UC*/` — should show `completion_cache.json` and `reports/`
- [ ] `cat ~/.staqan-yt-cli/data/UC*/reports/cache-index.json | jq '.version, .entries[0].channelId'` — should print `"2.0"` and a channel ID
- [ ] `staqan-yt fetch-reports` (no channel set) — should error with helpful message

### Documentation
- [ ] CLAUDE.md is under 450 lines
- [ ] All critical information preserved
- [ ] Cross-references work (links are valid)
- [ ] Quick reference section is comprehensive
- [ ] Development guides are focused and well-organized

## Performance testing

All caches verified with 0 API calls:
- Handle cache hit (`@staqan` → `UCBQQNUsrd9mgCjsrLogKW6Q`): ~1ms from FS
- Channel ID passthrough (`UC...`): 0ms (pure regex, no I/O)
- Report cache load: 1.5s total (mostly Node startup) for 16 rows from local disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)