### PR TITLE
Fix: Add ensureCacheDir to get-report-data and simplify cache dir creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,9 @@ staqan-yt config set default.channel @staqan
 staqan-yt config set default.output csv
 
 # Video operations
-staqan-yt get-video dQw4w9WgXcQ
-staqan-yt get-videos ID1 ID2
-staqan-yt list-videos @channel --limit 5
+staqan-yt get-video --video-id dQw4w9WgXcQ
+staqan-yt get-videos --video-ids ID1 ID2
+staqan-yt list-videos --channel @channel --limit 5
 
 # All output formats
 staqan-yt get-video ID --output json|table|text|csv|pretty

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -9,6 +9,7 @@ import {
   readCachedReport,
   saveReportToCache,
   parseCsvAndExtractRange,
+  ensureCacheDir,
 } from '../lib/cache';
 import { getChannelId } from '../lib/youtube';
 import { acquireLock, getLockPath } from '../lib/lock';
@@ -110,6 +111,15 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     spinner.text = `Resolving channel ID for ${channelHandle}...`;
     const channelId = await getChannelId(channelHandle);
     debug(`Using channel ID: ${channelId}`);
+
+    // Ensure cache directory exists before attempting lock
+    try {
+      await ensureCacheDir(channelId);
+    } catch (err) {
+      spinner.fail('Failed to create cache directory');
+      error((err as Error).message);
+      process.exit(1);
+    }
 
     const auth = await getAuthenticatedClient();
     const youtubeReporting = google.youtubereporting({ version: 'v1', auth });

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -11,10 +11,6 @@ const CACHE_INDEX_VERSION = '2.0';
 
 // ─── Per-channel path helpers ──────────────────────────────────────────────────
 
-function getChannelDataDir(channelId: string): string {
-  return path.join(DATA_DIR, channelId);
-}
-
 function getChannelReportsDir(channelId: string): string {
   return path.join(DATA_DIR, channelId, 'reports');
 }
@@ -25,24 +21,15 @@ function getChannelCacheIndexPath(channelId: string): string {
 
 /**
  * Ensure per-channel cache directory structure exists
+ *
+ * Note: mkdir with { recursive: true } is idempotent — it succeeds
+ * if the directory already exists, so we call it directly without
+ * an access check. This avoids the TOCTOU window and is more efficient.
  */
 export async function ensureCacheDir(channelId: string): Promise<void> {
-  const channelDir = getChannelDataDir(channelId);
   const reportsDir = getChannelReportsDir(channelId);
-
-  // Check if new channel directory is being created
-  let isNew = false;
-  try {
-    await fs.access(channelDir);
-  } catch {
-    isNew = true;
-  }
-
   await fs.mkdir(reportsDir, { recursive: true });
-
-  if (isNew) {
-    debug(`Created new channel directory: ${channelDir}`);
-  }
+  debug(`Ensured cache directory exists: ${reportsDir}`);
 }
 
 // ─── Cache index ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR fixes a missing `ensureCacheDir()` call in `get-report-data` and simplifies the cache directory creation logic.

## Changes

### 1. Add missing ensureCacheDir() call
- `get-report-data.ts` now calls `ensureCacheDir(channelId)` before attempting to acquire the lock
- This matches the pattern already established in `fetch-reports.ts`
- Prevents lock acquisition failures when cache directory doesn't exist

### 2. Simplify ensureCacheDir() implementation
- Remove unused `getChannelDataDir()` helper function
- Remove access check before `mkdir()` (TOCTOU window + unnecessary)
- `mkdir()` with `{ recursive: true }` is idempotent - just call it directly
- Update debug log message to be clearer

### 3. Update CLAUDE.md examples
- Fix command examples to use proper `--flag` syntax (e.g., `--video-id` instead of positional)

## Testing

- [ ] `staqan-yt get-report-data --type channel_reach_basic_a1` (first run, no cache dir)
- [ ] `staqan-yt get-report-data --type channel_reach_basic_a1` (subsequent run, cache dir exists)

## Related

Follow-up to #36 (channel-isolated cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)