### PR TITLE
Fix: Tab completion for flags and video IDs

### DIFF
--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -66,8 +66,8 @@ async function completeCommand(options: { type: string }): Promise<void> {
 
     let items: Array<{ id: string; title: string }> | undefined;
 
-    // Spinner for cold fetch - only show when running interactively (TTY)
-    const isInteractive = process.stdout.isTTY;
+    // Spinner for cold fetch - only show when running interactively (both stdout and stderr TTY)
+    const isInteractive = Boolean(process.stdout.isTTY) && Boolean(process.stderr.isTTY);
     let spinner: ReturnType<typeof ora> | null = null;
 
     try {
@@ -93,8 +93,12 @@ async function completeCommand(options: { type: string }): Promise<void> {
           items = raw
             .filter(v => v.id && v.title)
             .map(v => ({ id: v.id, title: v.title }));
-          if (isInteractive && spinner) {
-            spinner.succeed(`Fetched ${items.length} completion candidates`);
+          try {
+            if (isInteractive && spinner) {
+              spinner.succeed(`Fetched ${items.length} completion candidates`);
+            }
+          } catch {
+            if (spinner) spinner.stop();
           }
           if (items.length > 0) {
             cache[type] = { items, fetchedAt: Date.now() };
@@ -119,8 +123,12 @@ async function completeCommand(options: { type: string }): Promise<void> {
           items = (res.data.reportTypes || [])
             .filter(t => t.id && t.name)
             .map(t => ({ id: t.id!, title: t.name! }));
-          if (isInteractive && spinner) {
-            spinner.succeed(`Fetched ${items.length} report types`);
+          try {
+            if (isInteractive && spinner) {
+              spinner.succeed(`Fetched ${items.length} report types`);
+            }
+          } catch {
+            if (spinner) spinner.stop();
           }
           if (items.length > 0) {
             cache[type] = { items, fetchedAt: Date.now() };

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -427,114 +427,144 @@ ${commandList}
       return
       ;;
     get-video)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-videos)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-ids[Video IDs]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     update-video)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--title[Video title]' \\
-        '--description[Video description]' \\
+        '--title[Video title]:title:' \\
+        '--description[Video description]:desc:' \\
         '--dry-run[Preview changes without applying]' \\
         '--yes[Skip confirmation prompt]' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     search-videos)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
-        '--query[Search query]' \\
+        '--query[Search query]:query:' \\
         '--global[Search all of YouTube]' \\
-        '--channel[Channel handle or ID]:channel:(@)' \\
-        '--limit[Limit number of results]' \\
+        '--channel[Channel handle or ID]:channel:' \\
+        '--limit[Limit number of results]:n:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-video-localizations)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-ids[Video IDs]: :_staqan_yt_video_ids' \\
-        '--languages[Comma-separated language codes]' \\
+        '--languages[Comma-separated language codes]:langs:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-video-localization)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--language[Language code or name]' \\
+        '--language[Language code or name]:lang:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     put-video-localization)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--language[Language code or name]' \\
-        '--title[Localized title]' \\
-        '--description[Localized description]' \\
+        '--language[Language code or name]:lang:' \\
+        '--title[Localized title]:title:' \\
+        '--description[Localized description]:desc:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     update-video-localization)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--language[Language code or name]' \\
-        '--title[New localized title]' \\
-        '--description[New localized description]' \\
+        '--language[Language code or name]:lang:' \\
+        '--title[New localized title]:title:' \\
+        '--description[New localized description]:desc:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-video-analytics)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--start-date[Start date (YYYY-MM-DD)]' \\
-        '--end-date[End date (YYYY-MM-DD)]' \\
-        '--metrics[Metrics to fetch]' \\
+        '--start-date[Start date (YYYY-MM-DD)]:date:' \\
+        '--end-date[End date (YYYY-MM-DD)]:date:' \\
+        '--metrics[Metrics to fetch]:metrics:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-search-terms)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--limit[Limit number of results]' \\
+        '--limit[Limit number of results]:n:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-traffic-sources)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-video-retention)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-video-tags)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     update-video-tags)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--tags[Replace all tags]' \\
-        '--add[Add tags]' \\
-        '--remove[Remove tags]' \\
+        '--tags[Replace all tags]:tags:' \\
+        '--add[Add tags]:tags:' \\
+        '--remove[Remove tags]:tags:' \\
         '--dry-run[Preview changes]' \\
         '--yes[Skip confirmation]' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-thumbnail)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
         '--quality[Thumbnail quality]:quality:(maxres standard high medium default)' \\
@@ -542,80 +572,113 @@ ${commandList}
         '--verbose[Enable verbose output]'
       ;;
     get-playlist)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--playlist-id[Playlist ID]: :_staqan_yt_playlist_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-playlists)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--playlist-ids[Playlist IDs]: :_staqan_yt_playlist_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     list-videos|list-playlists)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
-        '--channel[Channel handle or ID]:channel:(@)' \\
-        '--limit[Limit number of results]' \\
+        '--channel[Channel handle or ID]:channel:' \\
+        '--limit[Limit number of results]:n:' \\
         '--type[Filter by type]:type:(short regular)' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     list-comments)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--limit[Limit number of results]' \\
+        '--limit[Limit number of results]:n:' \\
         '--sort[Sort order]:order:(top new)' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     list-captions)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-caption)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--caption-id[Caption ID]:id:( )' \\
         '--format[Caption format]:format:(srt vtt sbv srv2 ttml json)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-channel)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
-        '--channel[Channel handle or ID]:channel:(@)' \\
+        '--channel[Channel handle or ID]:channel:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-channel-search-terms)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
-        '--channel[Channel handle or ID]:channel:(@)' \\
-        '--limit[Limit number of results]' \\
+        '--channel[Channel handle or ID]:channel:' \\
+        '--limit[Limit number of results]:n:' \\
         '--content-type[Filter by content type]:type:(all video shorts)' \\
-        '--start-date[Start date (YYYY-MM-DD)]' \\
-        '--end-date[End date (YYYY-MM-DD)]' \\
+        '--start-date[Start date (YYYY-MM-DD)]:date:' \\
+        '--end-date[End date (YYYY-MM-DD)]:date:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-channel-analytics)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
-        '--channel[Channel handle or ID]:channel:(@)' \\
+        '--channel[Channel handle or ID]:channel:' \\
         '--report[Report type]:type:(demographics devices geography traffic-sources subscription-status)' \\
-        '--start-date[Start date (YYYY-MM-DD)]' \\
-        '--end-date[End date (YYYY-MM-DD)]' \\
-        '--dimensions[Custom dimensions (comma-separated)]' \\
-        '--metrics[Custom metrics (comma-separated)]' \\
+        '--start-date[Start date (YYYY-MM-DD)]:date:' \\
+        '--end-date[End date (YYYY-MM-DD)]:date:' \\
+        '--dimensions[Custom dimensions (comma-separated)]:dims:' \\
+        '--metrics[Custom metrics (comma-separated)]:metrics:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
-    list-report-jobs|get-report-data|fetch-reports)
+    list-report-jobs|get-report-data)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--type[Report type ID]: :_staqan_yt_report_types' \\
         '--output[Output format]:format:(json table text csv)' \\
-        '--start-date[Start date (YYYY-MM-DD)]' \\
-        '--end-date[End date (YYYY-MM-DD)]' \\
-        '--force[Re-download even if cached]' \\
+        '--start-date[Start date (YYYY-MM-DD)]:date:' \\
+        '--end-date[End date (YYYY-MM-DD)]:date:' \\
         '--verbose[Enable verbose output]'
+      ;;
+    fetch-reports)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
+      _arguments \\
+        '{-c,--channel}[Channel handle or ID]:channel:' \\
+        '{-t,--type}[Report type ID]: :_staqan_yt_report_types' \\
+        '{-T,--types}[Report type IDs (comma-separated)]:ids:' \\
+        '--start-date[Start date (YYYY-MM-DD)]:date:' \\
+        '--end-date[End date (YYYY-MM-DD)]:date:' \\
+        '{-f,--force}[Re-download even if cached]' \\
+        '--verify[Verify cached file completeness]' \\
+        '--output[Output format]:format:(json table text csv)' \\
+        '{-v,--verbose}[Enable verbose output]'
       ;;
     *)
       _describe 'command' commands


### PR DESCRIPTION
## Summary

- **Bug 1 & 2 (flags + video IDs):** `_arguments` was seeing the subcommand word (e.g. `get-video`, `fetch-reports`) as an unexpected positional, causing it to fail silently. Fix: prepend `local words=($words[1] $words[3,-1])` and `local CURRENT=$(($CURRENT - 1))` in every `_arguments` case block to drop the subcommand before `_arguments` processes the line.
- **Bug 3 (spinner error on first fetch):** `ora` accessed terminal properties that are `undefined` inside a `$()` subshell (where `process.stdout.isTTY` is false but `process.stderr.isTTY` may also be false). Fix: require *both* TTY flags before starting the spinner, and wrap `spinner.succeed()` in try/catch.
- **fetch-reports split:** Separated from the `list-report-jobs|get-report-data` group into its own case with the full flag set including short flags (`-c`, `-t`, `-T`, `-f`, `-v`) and `--verify`/`--types`.
- **Value-taking flags:** Added `:desc:` suffixes to all flags that take a value (`--start-date`, `--end-date`, `--limit`, `--query`, `--language`, `--title`, `--description`, `--tags`, `--add`, `--remove`, `--metrics`, `--dimensions`, `--channel`, `--languages`, `--content-type`) so `_arguments` correctly advances past the value word.

## Test plan

After `npm run build && staqan-yt config completion zsh && exec zsh`:

- [ ] `staqan-yt get-video --video-id <TAB>` → shows video IDs with titles
- [ ] `staqan-yt fetch-reports --<TAB>` → shows `--type`, `--output`, `--channel`, etc.
- [ ] `staqan-yt fetch-reports --t<TAB>` → completes to `--type`
- [ ] `staqan-yt fetch-reports -<TAB>` → shows `-t`, `-T`, `-c`, `-f`, `-v`
- [ ] `staqan-yt <TAB>` → still shows all 31 commands
- [ ] No `✗ Cannot read properties` error on first cold-cache completion fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)