### PR TITLE
feat: add --privacy filter and visibility display to list-videos and list-playlists

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,7 @@ staqan-yt-cli/
 - **[YouTube API Guide](docs/development/youtube-api-guide.md)** - YouTube Data API v3 patterns and quotas
 - **[Security Guide](docs/development/security-guide.md)** - OAuth security and input validation
 - **[Architecture Guide](docs/development/architecture.md)** - Lock strategy, hidden commands, scope boundaries
+- **[Shell Completion Guide](docs/development/shell-completion-guide.md)** - Bash/zsh completion patterns, variadic flags, and adding new completions
 
 ### Maintenance & Operations
 - **[Git Workflow Guide](docs/development/git-workflow.md)** - Branch strategy, commits, releases, and protection

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -196,6 +196,7 @@ program
   .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-l, --limit <number>', 'Limit number of results', '50')
   .option('-t, --type <type>', 'Filter by video type (short or regular)')
+  .option('--privacy <status...>', 'Filter by privacy status: public, private, unlisted (multiple allowed)')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('list-videos', listVideosCommand));
 

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -388,6 +388,7 @@ program
   .option('-c, --channel <handle>', 'Channel handle or ID')
   .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-l, --limit <number>', 'Limit number of results', '50')
+  .option('--privacy <status...>', 'Filter by privacy status: public, private, unlisted (multiple allowed)')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('list-playlists', listPlaylistsCommand));
 

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -17,6 +17,7 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
     debug(`Channel handle: ${channel}, limit: ${limit}`);
 
     let playlists = await listChannelPlaylists(channel, limit);
+    const totalFetched = playlists.length;
 
     // Filter by privacy status if specified
     if (options.privacy && options.privacy.length > 0) {
@@ -25,7 +26,10 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
       playlists = playlists.filter(p => privacyFilter.includes(p.privacyStatus));
     }
 
-    spinner.succeed(`Found ${playlists.length} playlist(s)`);
+    const filterSuffix = totalFetched !== playlists.length
+      ? ` (${totalFetched - playlists.length} filtered by privacy)`
+      : '';
+    spinner.succeed(`Found ${playlists.length} playlist(s)${filterSuffix}`);
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
@@ -69,15 +73,12 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
       case 'pretty':
       default:
         playlists.forEach((playlist, index) => {
-          const privacyIndicator = playlist.privacyStatus === 'private'
-            ? chalk.red(' [Private]')
-            : playlist.privacyStatus === 'unlisted'
-              ? chalk.yellow(' [Unlisted]')
-              : '';
-          console.log(chalk.cyan(`[${index + 1}]`) + ' ' + chalk.bold(playlist.title) + privacyIndicator);
+          const privacyColor = playlist.privacyStatus === 'public' ? chalk.green : playlist.privacyStatus === 'private' ? chalk.red : chalk.yellow;
+          console.log(chalk.cyan(`[${index + 1}]`) + ' ' + chalk.bold(playlist.title));
           console.log('  ID: ' + chalk.yellow(playlist.id));
           console.log('  Videos: ' + formatNumber(playlist.itemCount));
           console.log('  Published: ' + formatDate(playlist.publishedAt));
+          console.log('  Privacy: ' + privacyColor(playlist.privacyStatus));
           console.log('  URL: ' + chalk.blue(`https://youtube.com/playlist?list=${playlist.id}`));
           console.log('');
         });

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { listChannelPlaylists } from '../lib/youtube';
 import { formatDate, formatNumber, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
-import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterOption } from '../types';
 
 async function listPlaylistsCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & PrivacyFilterOption): Promise<void> {
@@ -73,12 +73,11 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
       case 'pretty':
       default:
         playlists.forEach((playlist, index) => {
-          const privacyColor = playlist.privacyStatus === 'public' ? chalk.green : playlist.privacyStatus === 'private' ? chalk.red : chalk.yellow;
           console.log(chalk.cyan(`[${index + 1}]`) + ' ' + chalk.bold(playlist.title));
           console.log('  ID: ' + chalk.yellow(playlist.id));
           console.log('  Videos: ' + formatNumber(playlist.itemCount));
           console.log('  Published: ' + formatDate(playlist.publishedAt));
-          console.log('  Privacy: ' + privacyColor(playlist.privacyStatus));
+          console.log('  Privacy: ' + formatPrivacyStatus(playlist.privacyStatus));
           console.log('  URL: ' + chalk.blue(`https://youtube.com/playlist?list=${playlist.id}`));
           console.log('');
         });

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import { listChannelPlaylists } from '../lib/youtube';
-import { formatDate, formatNumber, debug, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, formatNumber, error, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-import { ChannelOption, OutputOption, LimitOption, VerboseOption } from '../types';
+import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterOption, PrivacyStatus } from '../types';
 
-async function listPlaylistsCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption): Promise<void> {
+async function listPlaylistsCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
 
   await withSpinner('Fetching channel playlists...', 'Failed to fetch playlists', async (spinner) => {
@@ -15,7 +15,20 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
     const limit = parseInt(options.limit || '50');
     debug(`Channel handle: ${channel}, limit: ${limit}`);
 
-    const playlists = await listChannelPlaylists(channel, limit);
+    let playlists = await listChannelPlaylists(channel, limit);
+
+    // Filter by privacy status if specified
+    if (options.privacy && options.privacy.length > 0) {
+      const validStatuses: PrivacyStatus[] = ['public', 'private', 'unlisted'];
+      const invalid = options.privacy.filter(s => !validStatuses.includes(s));
+      if (invalid.length > 0) {
+        error(`Invalid privacy value(s): ${invalid.join(', ')}. Valid values: public, private, unlisted`);
+        process.exit(1);
+      }
+      const privacyFilter = options.privacy;
+      debug(`Filtering by privacy: ${privacyFilter.join(', ')}`);
+      playlists = playlists.filter(p => privacyFilter.includes(p.privacyStatus));
+    }
 
     spinner.succeed(`Found ${playlists.length} playlist(s)`);
     console.log('');

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -1,12 +1,13 @@
 import chalk from 'chalk';
 import { listChannelPlaylists } from '../lib/youtube';
-import { formatDate, formatNumber, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, formatNumber, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterOption, PrivacyStatus } from '../types';
+import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterOption } from '../types';
 
 async function listPlaylistsCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
+  validatePrivacyFilter(options.privacy);
 
   await withSpinner('Fetching channel playlists...', 'Failed to fetch playlists', async (spinner) => {
     const channel = await requireChannel(options.channel);
@@ -19,12 +20,6 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
 
     // Filter by privacy status if specified
     if (options.privacy && options.privacy.length > 0) {
-      const validStatuses: PrivacyStatus[] = ['public', 'private', 'unlisted'];
-      const invalid = options.privacy.filter(s => !validStatuses.includes(s));
-      if (invalid.length > 0) {
-        error(`Invalid privacy value(s): ${invalid.join(', ')}. Valid values: public, private, unlisted`);
-        process.exit(1);
-      }
       const privacyFilter = options.privacy;
       debug(`Filtering by privacy: ${privacyFilter.join(', ')}`);
       playlists = playlists.filter(p => privacyFilter.includes(p.privacyStatus));

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -48,7 +48,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
           id: video.id,
           title: video.title,
           published: formatDate(video.publishedAt),
-          privacy: video.privacyStatus || '-',
+          privacy: video.privacyStatus || '-', // '-' sentinel: human-readable placeholder for unauthenticated/missing data
           type: video.videoType,
         }));
         console.log(formatTable(tableData));
@@ -56,6 +56,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
 
       case 'text':
         videos.forEach(video => {
+          // '-' sentinel: human-readable placeholder; consistent with table format for tab-delimited consumers
           console.log([video.id, video.title, formatDate(video.publishedAt), video.privacyStatus || '-', video.videoType].join('\t'));
         });
         break;
@@ -65,7 +66,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
           id: video.id,
           title: video.title,
           published: video.publishedAt,
-          privacy: video.privacyStatus || '',
+          privacy: video.privacyStatus || '', // empty string: CSV convention — absent field, not a sentinel value
           type: video.videoType,
         }));
         console.log(formatCsv(csvData));

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { getChannelVideos } from '../lib/youtube';
 import { formatDate, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
-import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption } from '../types';
 
 async function channelVideosCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & TypeFilterOption & PrivacyFilterOption): Promise<void> {
@@ -79,13 +79,10 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
       default:
         videos.forEach((video, index) => {
           const typeIndicator = video.videoType === 'short' ? chalk.magenta(' [Short]') : '';
-          const privacyColor = video.privacyStatus === 'public' ? chalk.green : video.privacyStatus === 'private' ? chalk.red : chalk.yellow;
           console.log(chalk.cyan(`[${index + 1}]`) + ' ' + chalk.bold(video.title) + typeIndicator);
           console.log('  ID: ' + chalk.yellow(video.id));
           console.log('  Published: ' + formatDate(video.publishedAt));
-          if (video.privacyStatus) {
-            console.log('  Privacy: ' + privacyColor(video.privacyStatus));
-          }
+          console.log('  Privacy: ' + formatPrivacyStatus(video.privacyStatus));
           console.log('  URL: ' + chalk.blue(`https://youtube.com/watch?v=${video.id}`));
           console.log('');
         });

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -25,6 +25,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
       debug(`Filtering by video type: ${typeFilter}`);
       videos = videos.filter(v => v.videoType === typeFilter);
     }
+    const afterTypeFilter = videos.length;
 
     // Filter by privacy status if specified
     if (options.privacy && options.privacy.length > 0) {
@@ -34,8 +35,12 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
     }
 
     const typeLabel = options.type ? ` ${options.type}` : '';
-    const filteredCount = totalFetched - videos.length;
-    const filterSuffix = filteredCount > 0 ? ` (${filteredCount} filtered)` : '';
+    const filterParts: string[] = [];
+    const typeFiltered = totalFetched - afterTypeFilter;
+    const privacyFiltered = afterTypeFilter - videos.length;
+    if (typeFiltered > 0) filterParts.push(`${typeFiltered} filtered by type`);
+    if (privacyFiltered > 0) filterParts.push(`${privacyFiltered} filtered by privacy`);
+    const filterSuffix = filterParts.length > 0 ? ` (${filterParts.join(', ')})` : '';
     spinner.succeed(`Found ${videos.length}${typeLabel} video(s)${filterSuffix}`);
     console.log('');
 

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -17,6 +17,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
     debug(`Channel handle: ${channel}, limit: ${limit}`);
 
     let videos = await getChannelVideos(channel, limit);
+    const totalFetched = videos.length;
 
     // Filter by video type if specified
     if (options.type) {
@@ -33,7 +34,9 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
     }
 
     const typeLabel = options.type ? ` ${options.type}` : '';
-    spinner.succeed(`Found ${videos.length}${typeLabel} video(s)`);
+    const filteredCount = totalFetched - videos.length;
+    const filterSuffix = filteredCount > 0 ? ` (${filteredCount} filtered)` : '';
+    spinner.succeed(`Found ${videos.length}${typeLabel} video(s)${filterSuffix}`);
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
 import { getChannelVideos } from '../lib/youtube';
-import { formatDate, debug, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, error, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption } from '../types';
+import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption, PrivacyStatus } from '../types';
 
 async function channelVideosCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & TypeFilterOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
@@ -26,9 +26,15 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
 
     // Filter by privacy status if specified
     if (options.privacy && options.privacy.length > 0) {
+      const validStatuses: PrivacyStatus[] = ['public', 'private', 'unlisted'];
+      const invalid = options.privacy.filter(s => !validStatuses.includes(s));
+      if (invalid.length > 0) {
+        error(`Invalid privacy value(s): ${invalid.join(', ')}. Valid values: public, private, unlisted`);
+        process.exit(1);
+      }
       const privacyFilter = options.privacy;
       debug(`Filtering by privacy: ${privacyFilter.join(', ')}`);
-      videos = videos.filter(v => v.privacyStatus && privacyFilter.includes(v.privacyStatus as never));
+      videos = videos.filter(v => v.privacyStatus && privacyFilter.includes(v.privacyStatus));
     }
 
     const typeLabel = options.type ? ` ${options.type}` : '';

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -1,12 +1,13 @@
 import chalk from 'chalk';
 import { getChannelVideos } from '../lib/youtube';
-import { formatDate, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption, PrivacyStatus } from '../types';
+import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption } from '../types';
 
 async function channelVideosCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & TypeFilterOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
+  validatePrivacyFilter(options.privacy);
 
   await withSpinner('Fetching channel videos...', 'Failed to fetch videos', async (spinner) => {
     const channel = await requireChannel(options.channel);
@@ -26,12 +27,6 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
 
     // Filter by privacy status if specified
     if (options.privacy && options.privacy.length > 0) {
-      const validStatuses: PrivacyStatus[] = ['public', 'private', 'unlisted'];
-      const invalid = options.privacy.filter(s => !validStatuses.includes(s));
-      if (invalid.length > 0) {
-        error(`Invalid privacy value(s): ${invalid.join(', ')}. Valid values: public, private, unlisted`);
-        process.exit(1);
-      }
       const privacyFilter = options.privacy;
       debug(`Filtering by privacy: ${privacyFilter.join(', ')}`);
       videos = videos.filter(v => v.privacyStatus && privacyFilter.includes(v.privacyStatus));

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -3,9 +3,9 @@ import { getChannelVideos } from '../lib/youtube';
 import { formatDate, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption } from '../types';
+import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption } from '../types';
 
-async function channelVideosCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & TypeFilterOption): Promise<void> {
+async function channelVideosCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & TypeFilterOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
 
   await withSpinner('Fetching channel videos...', 'Failed to fetch videos', async (spinner) => {
@@ -24,6 +24,13 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
       videos = videos.filter(v => v.videoType === typeFilter);
     }
 
+    // Filter by privacy status if specified
+    if (options.privacy && options.privacy.length > 0) {
+      const privacyFilter = options.privacy;
+      debug(`Filtering by privacy: ${privacyFilter.join(', ')}`);
+      videos = videos.filter(v => v.privacyStatus && privacyFilter.includes(v.privacyStatus as never));
+    }
+
     const typeLabel = options.type ? ` ${options.type}` : '';
     spinner.succeed(`Found ${videos.length}${typeLabel} video(s)`);
     console.log('');
@@ -40,6 +47,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
           id: video.id,
           title: video.title,
           published: formatDate(video.publishedAt),
+          privacy: video.privacyStatus || '-',
           type: video.videoType,
         }));
         console.log(formatTable(tableData));
@@ -47,7 +55,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
 
       case 'text':
         videos.forEach(video => {
-          console.log([video.id, video.title, formatDate(video.publishedAt), video.videoType].join('\t'));
+          console.log([video.id, video.title, formatDate(video.publishedAt), video.privacyStatus || '-', video.videoType].join('\t'));
         });
         break;
 
@@ -56,6 +64,7 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
           id: video.id,
           title: video.title,
           published: video.publishedAt,
+          privacy: video.privacyStatus || '',
           type: video.videoType,
         }));
         console.log(formatCsv(csvData));
@@ -65,9 +74,13 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
       default:
         videos.forEach((video, index) => {
           const typeIndicator = video.videoType === 'short' ? chalk.magenta(' [Short]') : '';
+          const privacyColor = video.privacyStatus === 'public' ? chalk.green : video.privacyStatus === 'private' ? chalk.red : chalk.yellow;
           console.log(chalk.cyan(`[${index + 1}]`) + ' ' + chalk.bold(video.title) + typeIndicator);
           console.log('  ID: ' + chalk.yellow(video.id));
           console.log('  Published: ' + formatDate(video.publishedAt));
+          if (video.privacyStatus) {
+            console.log('  Privacy: ' + privacyColor(video.privacyStatus));
+          }
           console.log('  URL: ' + chalk.blue(`https://youtube.com/watch?v=${video.id}`));
           console.log('');
         });

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -39,6 +39,7 @@ This directory contains comprehensive guides for developing and maintaining the 
 - **[YouTube API Guide](youtube-api-guide.md)** - YouTube Data API v3 patterns and quotas
 - **[Security Guide](security-guide.md)** - OAuth security and input validation
 - **[Architecture Guide](architecture.md)** - Lock strategy, hidden commands, scope boundaries
+- **[Shell Completion Guide](shell-completion-guide.md)** - Bash/zsh completion patterns, variadic flags, and adding new completions
 
 ### Maintenance & Operations
 - **[Git Workflow Guide](git-workflow.md)** - Branch strategy, commits, releases, and protection

--- a/docs/development/shell-completion-guide.md
+++ b/docs/development/shell-completion-guide.md
@@ -1,0 +1,312 @@
+# Shell Completion Guide
+
+This guide covers the two-layer completion architecture, key patterns used in
+`lib/completion.ts`, and a step-by-step checklist for adding completion support
+for a new flag.
+
+---
+
+## Overview: Two-Layer Architecture
+
+```
+getCommandOptions()          ← exported TypeScript function
+  Used externally (MCP, tests, etc.)
+  Source of truth for "what flags does command X have?"
+
+generateBashCompletion()     ← private, produces installed bash script
+generateZshCompletion()      ← private, produces installed zsh script
+  Both read getCommandOptions() implicitly via the same command lists,
+  but their actual completion logic is hand-written for correctness.
+```
+
+**Important**: `getCommandOptions` and the generated scripts must be kept in
+sync manually. When you add a flag to a command, update both the
+`commandOptionMap` entry *and* the corresponding `case` block in the script.
+
+---
+
+## Bash Completion Patterns
+
+### Single-value flags — `case "$prev"`
+
+For flags that take exactly one value, add a case in the `case "${prev}" in`
+block near the top of `_staqa_nyt_completion`:
+
+```bash
+--output)
+  COMPREPLY=( $(compgen -W "json table text pretty csv" -- "${cur}") )
+  return ;;
+--quality)
+  COMPREPLY=( $(compgen -W "maxres standard high medium default" -- "${cur}") )
+  return ;;
+```
+
+This fires when the user's cursor is immediately after the flag name.
+
+### Space-separated variadic flags — backwards-walk scan
+
+For flags like `--privacy public private unlisted` or `--video-ids id1 id2`,
+the user types multiple values separated by spaces after a single flag
+occurrence. `$prev` alone can't detect this (it points to the last word, which
+is one of the values, not the flag name).
+
+**Pattern**: walk backwards from `$cword-1` until you find the flag name or
+hit another flag:
+
+```bash
+if [[ "${cur}" != -* ]]; then
+  local j
+  for ((j=cword-1; j>=1; j--)); do
+    case "${words[$j]}" in
+      --privacy)
+        # Collect already-used values, offer remaining
+        local -A _used=()
+        local k
+        for (( k=j+1; k<cword; k++ )); do
+          _used["${words[$k]}"]=1
+        done
+        local _rem=()
+        for v in public private unlisted; do
+          [[ -z "${_used[$v]}" ]] && _rem+=("$v")
+        done
+        COMPREPLY=( $(compgen -W "${_rem[*]}" -- "${cur}") ); return ;;
+      public|private|unlisted)
+        continue ;;   # skip known values, keep walking
+      --video-ids)
+        _staqan_yt_complete_type video-id; return ;;
+      -*)
+        break ;;      # hit a different flag, stop
+      *)
+        continue ;;
+    esac
+  done
+fi
+```
+
+The `public|private|unlisted` arm keeps the scan moving past already-typed
+values. The `-*` arm breaks the loop when a different flag boundary is reached.
+
+### Command-level flag lists — `case "$cmd"` inside `case "$prev"`
+
+After the variadic scan, there's a `case "${prev}" in` block where one of the
+arms matches the command name itself (set as `$prev` when the user typed
+`staqan-yt <cmd> <TAB>`):
+
+```bash
+case "${prev}" in
+  list-videos)
+    COMPREPLY=( $(compgen -W "--channel --limit --type --privacy --output --verbose" -- "${cur}") )
+    ;;
+  fetch-reports)
+    COMPREPLY=( $(compgen -W "--channel --type --types --start-date --end-date --force --verify --verbose" -- "${cur}") )
+    ;;
+esac
+```
+
+Every command must have an arm here; commands without one silently fall through
+to no suggestions.
+
+---
+
+## Zsh Completion Patterns
+
+Zsh completion uses `_arguments` specs and a backwards-walk pre-check for
+variadic flags. The `_staqa_nyt` function dispatches on `$words[2]`.
+
+### `_arguments` spec format
+
+```zsh
+_arguments \
+  '--flag[description]:metavar:action'
+```
+
+- `metavar` — the label shown in the completion menu (e.g. `format`, `n`)
+- `action` — `(val1 val2)` for inline enums, `:funcname` to call a helper
+  function, empty `:` for free text
+
+Examples:
+
+```zsh
+'--output[Output format]:format:(json table text pretty csv)'
+'--video-id[Video ID]: :_staqan_yt_video_ids'
+'--limit[Limit number of results]:n:'
+```
+
+### `*` prefix semantics — flag can repeat, NOT space-separated values
+
+From `man zshcompsys`:
+
+> Specifications beginning with `*` indicate the option may be given any
+> number of times on the command line (i.e. the flag itself repeats).
+
+`*--flag` means:
+```
+staqan-yt cmd --flag val1 --flag val2   ← correct zsh interpretation
+```
+
+It does **NOT** mean:
+```
+staqan-yt cmd --flag val1 val2          ← space-separated, single occurrence
+```
+
+Commander.js processes `--video-ids id1 --video-ids id2` as two invocations,
+with the second **overwriting** the first. So `*--video-ids` actively breaks
+batch input. Never use `*` for space-separated variadic flags.
+
+### `_describe` for fixed-set enums with descriptions
+
+```zsh
+local -a _rem
+_rem=(public private unlisted)
+_describe -t privacy-status 'privacy status' _rem
+```
+
+`_describe` shows items with optional `:description` suffixes in the completion
+menu. The `-t` tag keeps the completion group labelled.
+
+### `compadd -F array` for excluding already-used dynamic values
+
+Sourced from `_docker` (`/opt/homebrew/share/zsh/site-functions/_docker`):
+
+```zsh
+local -a _vused=()
+# ... populate _vused with already-typed IDs ...
+local -a _all
+_all=(${(f)"$(staqan-yt __complete --type video-id 2>/dev/null | cut -f1)"})
+compadd -F _vused -- $_all
+```
+
+`compadd -F _vused` filters out all values in `_vused` before offering
+completions. Use this for dynamic lists (IDs fetched from cache) where
+`_describe` can't help.
+
+### Variadic pre-check pattern
+
+Walk backwards before calling `_arguments`. If we're currently completing a
+non-flag token and we find a variadic flag behind us, handle it and `return`
+before `_arguments` ever runs:
+
+```zsh
+if [[ $words[$CURRENT] != -* ]]; then
+  local j=$(($CURRENT - 1))
+  local -a _pused=()
+  while (( j >= 1 )); do
+    case $words[$j] in
+      --privacy)
+        local -a _rem=()
+        local v
+        for v in public private unlisted; do
+          [[ -z "${_pused[(r)$v]}" ]] && _rem+=($v)
+        done
+        _describe -t privacy-status 'privacy status' _rem
+        return ;;
+      public|private|unlisted) _pused+=($words[$j]); (( j-- )) ;;
+      *) break ;;
+    esac
+  done
+fi
+_arguments \
+  '--privacy[...]:status:(public private unlisted)' \
+  ...
+```
+
+The `_pused[(r)$v]` subscript uses zsh's reverse-subscript operator: it
+returns `$v` if found, empty string if not. Combined with `-z`, this filters
+already-used values.
+
+---
+
+## Decision Guide — Which Pattern to Use?
+
+| Flag type | Values | Pattern |
+|-----------|--------|---------|
+| Single fixed enum | `public private unlisted` | `case "$prev"` + `compgen -W` (bash) / `_arguments` spec inline `(val1 val2)` (zsh) |
+| Space-separated variadic, fixed enum | `--privacy public private` | Backwards-walk + `_describe` with `_pused` filter |
+| Space-separated variadic, dynamic IDs | `--video-ids id1 id2` | Backwards-walk + `compadd -F _vused` from `__complete` call |
+| Comma-separated single value | `--types "type1,type2"` | No pre-check; `_arguments` spec `:ids:` (free text) |
+| Boolean / text flags | `--dry-run`, `--title` | `case "$prev"` only for the prev-flag arm; no special action needed |
+
+---
+
+## Adding Completion for a New Flag
+
+### Step 1: Update `getCommandOptions`
+
+In `lib/completion.ts`, find your command's entry in `commandOptionMap` and
+add the flag name:
+
+```typescript
+'my-command': ['--my-flag', ...outputOptions, ...verboseOption],
+```
+
+### Step 2: Update the bash `case "$prev"` command arm
+
+Find the `case "${prev}" in` block and locate your command's arm. Add the new
+flag to the `compgen -W` list:
+
+```bash
+my-command)
+  COMPREPLY=( $(compgen -W "--my-flag --output --verbose" -- "${cur}") )
+  ;;
+```
+
+If the command has no arm yet, add one before the `config)` arm.
+
+### Step 3: Add bash value completion (if needed)
+
+If the flag takes a fixed set of values, add a case in `case "${prev}" in`:
+
+```bash
+--my-flag)
+  COMPREPLY=( $(compgen -W "val1 val2 val3" -- "${cur}") )
+  return ;;
+```
+
+If it's variadic (space-separated), add an arm to the backwards-walk block:
+
+```bash
+--my-flag)
+  COMPREPLY=( $(compgen -W "val1 val2 val3" -- "${cur}") ); return ;;
+val1|val2|val3)
+  continue ;;
+```
+
+### Step 4: Update the zsh `_arguments` spec
+
+Find the `case $words[2] in` arm for your command and add the flag:
+
+```zsh
+'--my-flag[Description]:metavar:(val1 val2 val3)'
+```
+
+For variadic flags, add a pre-check block *before* `_arguments` (see
+[Variadic pre-check pattern](#variadic-pre-check-pattern) above) and use a
+plain spec without `*` in `_arguments`.
+
+### Step 5: Build and verify
+
+```bash
+npm run type-check
+npm run build
+
+# Inspect generated bash completion for your command
+node -e "const {getCompletionScript} = require('./dist/lib/completion'); \
+  console.log(getCompletionScript('bash'))" | grep -A 3 "my-command)"
+
+# Inspect generated zsh completion
+node -e "const {getCompletionScript} = require('./dist/lib/completion'); \
+  console.log(getCompletionScript('zsh'))" | grep -A 15 "my-command)"
+
+# Reinstall and test live
+staqan-yt config completion zsh
+exec zsh
+staqan-yt my-command --my-flag <TAB>
+```
+
+---
+
+## Related Files
+
+- `lib/completion.ts` — all completion logic
+- `commands/config.ts` — `config completion` subcommand that calls `installCompletion()`
+- `commands/complete.ts` — `__complete` hidden command (returns ID lists for dynamic completions)

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -128,20 +128,20 @@ export function getCommandOptions(command: string): string[] {
     'get-traffic-sources': [...outputOptions, ...verboseOption],
     'get-video-retention': [...outputOptions, ...verboseOption],
     'get-channel-analytics': ['--report', '--start-date', '--end-date', '--dimensions', '--metrics', ...outputOptions, ...verboseOption],
-    'get-channel-search-terms': ['--limit', '-l', '--content-type', '--start-date', '--end-date', ...outputOptions, ...verboseOption],
+    'get-channel-search-terms': ['--channel', '--limit', '-l', '--content-type', '--start-date', '--end-date', ...outputOptions, ...verboseOption],
     'list-comments': ['--limit', '-l', '--sort', '-s', ...outputOptions, ...verboseOption],
     'get-video-tags': [...outputOptions, ...verboseOption],
     'update-video-tags': ['--tags', '--add', '--remove', '--dry-run', '--yes', '-y', ...outputOptions, ...verboseOption],
     'get-thumbnail': ['--quality', ...outputOptions, ...verboseOption],
     'get-playlist': [...outputOptions, ...verboseOption],
     'get-playlists': [...outputOptions, ...verboseOption],
-    'list-playlists': ['--limit', '-l', '--privacy', ...outputOptions, ...verboseOption],
+    'list-playlists': ['--channel', '--limit', '-l', '--privacy', ...outputOptions, ...verboseOption],
     'list-captions': [...outputOptions, ...verboseOption],
     'get-caption': ['--format', ...verboseOption],
     'list-report-types': ['--output', 'json', 'table', 'text', ...verboseOption],
     'list-report-jobs': ['--type', '--output', 'json', 'table', 'text', ...verboseOption],
     'get-report-data': ['--type', '--video-id', '--start-date', '--end-date', '--output', 'json', 'csv', ...verboseOption],
-    'fetch-reports': ['--type', '-t', '--types', '-T', '--start-date', '--end-date', '--force', '-f', '--verify', ...verboseOption],
+    'fetch-reports': ['--channel', '--type', '-t', '--types', '-T', '--start-date', '--end-date', '--force', '-f', '--verify', ...verboseOption],
   };
 
   return commandOptionMap[command] || [...outputOptions, ...verboseOption];
@@ -353,6 +353,21 @@ _staqa_nyt_completion() {
     get-channel)
       COMPREPLY=( \$(compgen -W "--channel --output --verbose" -- "\${cur}") )
       ;;
+    get-channel-search-terms)
+      COMPREPLY=( \$(compgen -W "--channel --limit --content-type --start-date --end-date --output --verbose" -- "\${cur}") )
+      ;;
+    list-report-types)
+      COMPREPLY=( \$(compgen -W "--output --verbose" -- "\${cur}") )
+      ;;
+    list-report-jobs)
+      COMPREPLY=( \$(compgen -W "--type --output --verbose" -- "\${cur}") )
+      ;;
+    get-report-data)
+      COMPREPLY=( \$(compgen -W "--type --video-id --start-date --end-date --output --verbose" -- "\${cur}") )
+      ;;
+    fetch-reports)
+      COMPREPLY=( \$(compgen -W "--channel --type --types --start-date --end-date --force --verify --verbose" -- "\${cur}") )
+      ;;
     config)
       COMPREPLY=( \$(compgen -W "set get list completion --show --output --verbose" -- "\${cur}") )
       ;;
@@ -475,8 +490,25 @@ ${commandList}
     get-videos)
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
+      # Space-separated variadic: walk back to detect if we're inside --video-ids'
+      # value list. Exclude already-used IDs via compadd -F.
+      if [[ \$words[\$CURRENT] != -* ]]; then
+        local j=\$((\$CURRENT - 1))
+        local -a _vused=()
+        while (( j >= 1 )); do
+          case \$words[\$j] in
+            --video-ids)
+              local -a _all
+              _all=(\${(f)"\$(staqan-yt __complete --type video-id 2>/dev/null | cut -f1)"})
+              compadd -F _vused -- \$_all
+              return ;;
+            --*) break ;;
+            *) _vused+=(\$words[\$j]); (( j-- )) ;;
+          esac
+        done
+      fi
       _arguments \\
-        '*--video-ids[Video IDs (repeatable)]: :_staqan_yt_video_ids' \\
+        '--video-ids[Video IDs (variadic)]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
@@ -506,8 +538,24 @@ ${commandList}
     get-video-localizations)
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
+      # Same variadic pre-check as get-videos
+      if [[ \$words[\$CURRENT] != -* ]]; then
+        local j=\$((\$CURRENT - 1))
+        local -a _vused=()
+        while (( j >= 1 )); do
+          case \$words[\$j] in
+            --video-ids)
+              local -a _all
+              _all=(\${(f)"\$(staqan-yt __complete --type video-id 2>/dev/null | cut -f1)"})
+              compadd -F _vused -- \$_all
+              return ;;
+            --*) break ;;
+            *) _vused+=(\$words[\$j]); (( j-- )) ;;
+          esac
+        done
+      fi
       _arguments \\
-        '*--video-ids[Video IDs (repeatable)]: :_staqan_yt_video_ids' \\
+        '--video-ids[Video IDs (variadic)]: :_staqan_yt_video_ids' \\
         '--languages[Comma-separated language codes]:langs:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -628,21 +628,63 @@ ${commandList}
     list-videos)
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
+      # Space-separated variadic: walk back to detect if we're inside --privacy's
+      # value list. Pattern from Docker/_docker: use \${words[(r)val]} to check
+      # already-used values, then offer only the remaining ones.
+      if [[ \$words[\$CURRENT] != -* ]]; then
+        local j=\$((\$CURRENT - 1))
+        local -a _pused=()
+        while (( j >= 1 )); do
+          case \$words[\$j] in
+            --privacy)
+              local -a _rem=()
+              local v
+              for v in public private unlisted; do
+                [[ -z "\${_pused[(r)\$v]}" ]] && _rem+=(\$v)
+              done
+              _describe -t privacy-status 'privacy status' _rem
+              return
+              ;;
+            public|private|unlisted) _pused+=(\$words[\$j]); (( j-- )) ;;
+            *) break ;;
+          esac
+        done
+      fi
       _arguments \\
         '--channel[Channel handle or ID]:channel:' \\
         '--limit[Limit number of results]:n:' \\
         '--type[Filter by type]:type:(short regular)' \\
-        '*--privacy[Filter by privacy status (repeatable)]:status:(public private unlisted)' \\
+        '--privacy[Filter by privacy status (variadic: public private unlisted)]:status:(public private unlisted)' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     list-playlists)
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
+      # Same space-separated variadic pre-check as list-videos
+      if [[ \$words[\$CURRENT] != -* ]]; then
+        local j=\$((\$CURRENT - 1))
+        local -a _pused=()
+        while (( j >= 1 )); do
+          case \$words[\$j] in
+            --privacy)
+              local -a _rem=()
+              local v
+              for v in public private unlisted; do
+                [[ -z "\${_pused[(r)\$v]}" ]] && _rem+=(\$v)
+              done
+              _describe -t privacy-status 'privacy status' _rem
+              return
+              ;;
+            public|private|unlisted) _pused+=(\$words[\$j]); (( j-- )) ;;
+            *) break ;;
+          esac
+        done
+      fi
       _arguments \\
         '--channel[Channel handle or ID]:channel:' \\
         '--limit[Limit number of results]:n:' \\
-        '*--privacy[Filter by privacy status (repeatable)]:status:(public private unlisted)' \\
+        '--privacy[Filter by privacy status (variadic: public private unlisted)]:status:(public private unlisted)' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -115,7 +115,7 @@ export function getCommandOptions(command: string): string[] {
     'config': ['--show', ...outputOptions, ...verboseOption],
     'get-video': [...outputOptions, ...verboseOption],
     'get-videos': [...outputOptions, ...verboseOption],
-    'list-videos': ['--limit', '-l', '--type', '-t', '--privacy', 'public', 'private', 'unlisted', ...outputOptions, ...verboseOption],
+    'list-videos': ['--limit', '-l', '--type', '-t', '--privacy', ...outputOptions, ...verboseOption],
     'search-videos': ['--global', '-g', '--channel', '-c', '--limit', '-l', ...outputOptions, ...verboseOption],
     'get-channel': [...outputOptions, ...verboseOption],
     'update-video': ['--title', '-t', '--description', '-d', '--dry-run', '--yes', '-y', ...outputOptions, ...verboseOption],
@@ -135,7 +135,7 @@ export function getCommandOptions(command: string): string[] {
     'get-thumbnail': ['--quality', ...outputOptions, ...verboseOption],
     'get-playlist': [...outputOptions, ...verboseOption],
     'get-playlists': [...outputOptions, ...verboseOption],
-    'list-playlists': ['--limit', '-l', '--privacy', 'public', 'private', 'unlisted', ...outputOptions, ...verboseOption],
+    'list-playlists': ['--limit', '-l', '--privacy', ...outputOptions, ...verboseOption],
     'list-captions': [...outputOptions, ...verboseOption],
     'get-caption': ['--format', ...verboseOption],
     'list-report-types': ['--output', 'json', 'table', 'text', ...verboseOption],
@@ -238,7 +238,18 @@ _staqa_nyt_completion() {
     for ((j=cword-1; j>=1; j--)); do
       case "\${words[$j]}" in
         --privacy)
-          COMPREPLY=( \$(compgen -W "public private unlisted" -- "\${cur}") ); return ;;
+          # Forward-scan from the flag's position to cword-1 to collect
+          # already-used values, then offer only the remaining ones.
+          local -A _used=()
+          local k
+          for (( k=j+1; k<cword; k++ )); do
+            _used["\${words[$k]}"]=1
+          done
+          local _rem=()
+          for v in public private unlisted; do
+            [[ -z "\${_used[$v]}" ]] && _rem+=("$v")
+          done
+          COMPREPLY=( \$(compgen -W "\${_rem[*]}" -- "\${cur}") ); return ;;
         public|private|unlisted)
           continue ;;
         --video-ids)

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -135,7 +135,7 @@ export function getCommandOptions(command: string): string[] {
     'get-thumbnail': ['--quality', ...outputOptions, ...verboseOption],
     'get-playlist': [...outputOptions, ...verboseOption],
     'get-playlists': [...outputOptions, ...verboseOption],
-    'list-playlists': ['--limit', '-l', ...outputOptions, ...verboseOption],
+    'list-playlists': ['--limit', '-l', '--privacy', 'public', 'private', 'unlisted', ...outputOptions, ...verboseOption],
     'list-captions': [...outputOptions, ...verboseOption],
     'get-caption': ['--format', ...verboseOption],
     'list-report-types': ['--output', 'json', 'table', 'text', ...verboseOption],
@@ -331,7 +331,7 @@ _staqa_nyt_completion() {
       COMPREPLY=( \$(compgen -W "--channel --limit --type --privacy --output --verbose" -- "\${cur}") )
       ;;
     list-playlists)
-      COMPREPLY=( \$(compgen -W "--channel --limit --output --verbose" -- "\${cur}") )
+      COMPREPLY=( \$(compgen -W "--channel --limit --privacy --output --verbose" -- "\${cur}") )
       ;;
     list-comments)
       COMPREPLY=( \$(compgen -W "--video-id --limit --sort --output --verbose" -- "\${cur}") )
@@ -631,6 +631,7 @@ ${commandList}
       _arguments \\
         '--channel[Channel handle or ID]:channel:' \\
         '--limit[Limit number of results]:n:' \\
+        '*--privacy[Filter by privacy status (repeatable)]:status:(public private unlisted)' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -231,8 +231,8 @@ _staqa_nyt_completion() {
     fi
   done
 
-  # Variadic --privacy scan: walk back to detect if we are still inside a
-  # space-separated privacy value list (e.g. --privacy public <TAB>)
+  # Variadic flag scan: walk back to detect if we are still inside a
+  # space-separated value list (e.g. --privacy public <TAB>, --video-ids abc <TAB>)
   if [[ "\${cur}" != -* ]]; then
     local j
     for ((j=cword-1; j>=1; j--)); do
@@ -241,8 +241,14 @@ _staqa_nyt_completion() {
           COMPREPLY=( \$(compgen -W "public private unlisted" -- "\${cur}") ); return ;;
         public|private|unlisted)
           continue ;;
-        *)
+        --video-ids)
+          _staqan_yt_complete_type video-id; return ;;
+        --playlist-ids)
+          _staqan_yt_complete_type playlist-id; return ;;
+        -*)
           break ;;
+        *)
+          continue ;;
       esac
     done
   fi
@@ -459,7 +465,7 @@ ${commandList}
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
-        '--video-ids[Video IDs]: :_staqan_yt_video_ids' \\
+        '*--video-ids[Video IDs (repeatable)]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
@@ -490,7 +496,7 @@ ${commandList}
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
-        '--video-ids[Video IDs]: :_staqan_yt_video_ids' \\
+        '*--video-ids[Video IDs (repeatable)]: :_staqan_yt_video_ids' \\
         '--languages[Comma-separated language codes]:langs:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -115,7 +115,7 @@ export function getCommandOptions(command: string): string[] {
     'config': ['--show', ...outputOptions, ...verboseOption],
     'get-video': [...outputOptions, ...verboseOption],
     'get-videos': [...outputOptions, ...verboseOption],
-    'list-videos': ['--limit', '-l', '--type', '-t', ...outputOptions, ...verboseOption],
+    'list-videos': ['--limit', '-l', '--type', '-t', '--privacy', 'public', 'private', 'unlisted', ...outputOptions, ...verboseOption],
     'search-videos': ['--global', '-g', '--channel', '-c', '--limit', '-l', ...outputOptions, ...verboseOption],
     'get-channel': [...outputOptions, ...verboseOption],
     'update-video': ['--title', '-t', '--description', '-d', '--dry-run', '--yes', '-y', ...outputOptions, ...verboseOption],
@@ -231,6 +231,22 @@ _staqa_nyt_completion() {
     fi
   done
 
+  # Variadic --privacy scan: walk back to detect if we are still inside a
+  # space-separated privacy value list (e.g. --privacy public <TAB>)
+  if [[ "\${cur}" != -* ]]; then
+    local j
+    for ((j=cword-1; j>=1; j--)); do
+      case "\${words[$j]}" in
+        --privacy)
+          COMPREPLY=( \$(compgen -W "public private unlisted" -- "\${cur}") ); return ;;
+        public|private|unlisted)
+          continue ;;
+        *)
+          break ;;
+      esac
+    done
+  fi
+
   # Flag-based completion - complete after --video-id, --playlist-id, etc.
   case "\${prev}" in
     --video-id)
@@ -257,6 +273,8 @@ _staqa_nyt_completion() {
           COMPREPLY=( \$(compgen -W "short regular" -- "\${cur}") ); return ;;
       esac
       ;;
+    --privacy)
+      COMPREPLY=( \$(compgen -W "public private unlisted" -- "\${cur}") ); return ;;
     --quality)
       COMPREPLY=( \$(compgen -W "maxres standard high medium default" -- "\${cur}") ); return ;;
     --sort|-s)
@@ -303,8 +321,11 @@ _staqa_nyt_completion() {
     get-playlists)
       COMPREPLY=( \$(compgen -W "--playlist-ids --output --verbose" -- "\${cur}") )
       ;;
-    list-videos|list-playlists)
-      COMPREPLY=( \$(compgen -W "--channel --limit --type --output --verbose" -- "\${cur}") )
+    list-videos)
+      COMPREPLY=( \$(compgen -W "--channel --limit --type --privacy --output --verbose" -- "\${cur}") )
+      ;;
+    list-playlists)
+      COMPREPLY=( \$(compgen -W "--channel --limit --output --verbose" -- "\${cur}") )
       ;;
     list-comments)
       COMPREPLY=( \$(compgen -W "--video-id --limit --sort --output --verbose" -- "\${cur}") )
@@ -587,13 +608,23 @@ ${commandList}
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
-    list-videos|list-playlists)
+    list-videos)
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--channel[Channel handle or ID]:channel:' \\
         '--limit[Limit number of results]:n:' \\
         '--type[Filter by type]:type:(short regular)' \\
+        '*--privacy[Filter by privacy status (repeatable)]:status:(public private unlisted)' \\
+        '--output[Output format]:format:(json table text pretty csv)' \\
+        '--verbose[Enable verbose output]'
+      ;;
+    list-playlists)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
+      _arguments \\
+        '--channel[Channel handle or ID]:channel:' \\
+        '--limit[Limit number of results]:n:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -3,6 +3,7 @@
  */
 
 import chalk from 'chalk';
+import { PrivacyStatus } from '../types';
 
 /**
  * Format data as JSON
@@ -243,4 +244,15 @@ function escapeCSV(field: string): string {
     return `"${field.replace(/"/g, '""')}"`;
   }
   return field;
+}
+
+/**
+ * Format a privacy status value with color for terminal pretty output.
+ * Returns chalk.gray('unknown') when status is undefined (e.g. unauthenticated call).
+ */
+export function formatPrivacyStatus(status: PrivacyStatus | undefined): string {
+  if (!status) return chalk.gray('unknown');
+  if (status === 'public') return chalk.green(status);
+  if (status === 'private') return chalk.red(status);
+  return chalk.yellow(status); // unlisted
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -308,6 +308,11 @@ function chunkDateRange(startDate: string, endDate: string): { start: string; en
 /**
  * Validate --privacy flag values before any API calls.
  * Exits with an error message if any value is not public/private/unlisted.
+ *
+ * Accepts string[] (not PrivacyStatus[]) because Commander.js parses option
+ * values as raw strings before this validation runs. The call site's option
+ * type is PrivacyStatus[], but at runtime the values are unvalidated strings
+ * until this function confirms them.
  */
 function validatePrivacyFilter(privacy: string[] | undefined): void {
   if (!privacy || privacy.length === 0) return;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -306,6 +306,20 @@ function chunkDateRange(startDate: string, endDate: string): { start: string; en
 }
 
 /**
+ * Validate --privacy flag values before any API calls.
+ * Exits with an error message if any value is not public/private/unlisted.
+ */
+function validatePrivacyFilter(privacy: string[] | undefined): void {
+  if (!privacy || privacy.length === 0) return;
+  const valid = ['public', 'private', 'unlisted'];
+  const invalid = privacy.filter(s => !valid.includes(s));
+  if (invalid.length > 0) {
+    error(`Invalid privacy value(s): ${invalid.join(', ')}. Valid values: public, private, unlisted`);
+    process.exit(1);
+  }
+}
+
+/**
  * Initialize a command: enable verbose mode if requested.
  * Call at the top of every command before any async work.
  */
@@ -508,4 +522,5 @@ export {
   chunkDateRange,
   sleep,
   retryWithBackoff,
+  validatePrivacyFilter,
 };

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -327,7 +327,7 @@ async function getVideoInfo(videoIds: string[]): Promise<VideoInfo[]> {
       commentCount: parseInt(item.statistics?.commentCount || '0'),
     },
     duration: item.contentDetails!.duration!,
-    privacyStatus: item.status!.privacyStatus!,
+    privacyStatus: item.status!.privacyStatus! as PrivacyStatus,
     videoType: videoTypes.get(item.id!) || 'regular',
   }));
 }
@@ -719,7 +719,7 @@ async function getPlaylistInfo(playlistId: string): Promise<PlaylistInfo> {
     channelTitle: item.snippet!.channelTitle!,
     publishedAt: item.snippet!.publishedAt!,
     itemCount: item.contentDetails!.itemCount || 0,
-    privacyStatus: item.status!.privacyStatus!,
+    privacyStatus: item.status!.privacyStatus! as PrivacyStatus,
     thumbnails: item.snippet!.thumbnails!,
   };
 }
@@ -757,7 +757,7 @@ async function getPlaylistsById(playlistIds: string[]): Promise<PlaylistInfo[]> 
       channelTitle: item.snippet!.channelTitle!,
       publishedAt: item.snippet!.publishedAt!,
       itemCount: item.contentDetails!.itemCount || 0,
-      privacyStatus: item.status!.privacyStatus!,
+      privacyStatus: item.status!.privacyStatus! as PrivacyStatus,
       thumbnails: item.snippet!.thumbnails!,
     })));
   }
@@ -799,7 +799,7 @@ async function listChannelPlaylists(channelHandle: string, maxResults = 50): Pro
       channelTitle: item.snippet!.channelTitle!,
       publishedAt: item.snippet!.publishedAt!,
       itemCount: item.contentDetails!.itemCount || 0,
-      privacyStatus: item.status!.privacyStatus!,
+      privacyStatus: item.status!.privacyStatus! as PrivacyStatus,
     })));
 
     nextPageToken = playlistResponse.nextPageToken || undefined;

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -5,7 +5,7 @@ import os from 'os';
 import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName } from './language';
 import { acquireLock, getLockPath } from './lock';
-import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PlaylistInfo, PlaylistListItem, CommentInfo, ChannelInfo, CaptionInfo, CaptionFormat } from '../types';
+import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PrivacyStatus, PlaylistInfo, PlaylistListItem, CommentInfo, ChannelInfo, CaptionInfo, CaptionFormat } from '../types';
 import { debug, warning } from './utils';
 
 // ─── Handle → channel ID cache ────────────────────────────────────────────────
@@ -218,16 +218,16 @@ async function getChannelInfo(handleOrId: string): Promise<ChannelInfo> {
 /**
  * Batch-fetch privacy statuses for a list of video IDs (50 per API call).
  */
-async function fetchPrivacyStatuses(videoIds: string[]): Promise<Map<string, string>> {
+async function fetchPrivacyStatuses(videoIds: string[]): Promise<Map<string, PrivacyStatus>> {
   if (videoIds.length === 0) return new Map();
   const youtube = await getYouTubeClient();
-  const result = new Map<string, string>();
+  const result = new Map<string, PrivacyStatus>();
   for (let i = 0; i < videoIds.length; i += 50) {
     const batch = videoIds.slice(i, i + 50);
     const response = await youtube.videos.list({ part: ['status'], id: batch });
     for (const item of response.data.items || []) {
       if (item.id && item.status?.privacyStatus) {
-        result.set(item.id, item.status.privacyStatus);
+        result.set(item.id, item.status.privacyStatus as PrivacyStatus);
       }
     }
   }

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -216,6 +216,25 @@ async function getChannelInfo(handleOrId: string): Promise<ChannelInfo> {
 }
 
 /**
+ * Batch-fetch privacy statuses for a list of video IDs (50 per API call).
+ */
+async function fetchPrivacyStatuses(videoIds: string[]): Promise<Map<string, string>> {
+  if (videoIds.length === 0) return new Map();
+  const youtube = await getYouTubeClient();
+  const result = new Map<string, string>();
+  for (let i = 0; i < videoIds.length; i += 50) {
+    const batch = videoIds.slice(i, i + 50);
+    const response = await youtube.videos.list({ part: ['status'], id: batch });
+    for (const item of response.data.items || []) {
+      if (item.id && item.status?.privacyStatus) {
+        result.set(item.id, item.status.privacyStatus);
+      }
+    }
+  }
+  return result;
+}
+
+/**
  * Get all videos from a channel
  */
 async function getChannelVideos(channelHandle: string, maxResults = 50): Promise<VideoListItem[]> {
@@ -258,13 +277,18 @@ async function getChannelVideos(channelHandle: string, maxResults = 50): Promise
     nextPageToken = playlistResponse.nextPageToken || undefined;
   } while (nextPageToken && rawVideos.length < maxResults);
 
-  // Check video types for all videos
-  const videoTypes = await checkVideoTypes(rawVideos.map(v => v.id));
+  const ids = rawVideos.map(v => v.id);
 
-  // Add videoType to each video
+  // Fetch video types and privacy statuses in parallel
+  const [videoTypes, privacyStatuses] = await Promise.all([
+    checkVideoTypes(ids),
+    fetchPrivacyStatuses(ids),
+  ]);
+
   return rawVideos.map(video => ({
     ...video,
     videoType: videoTypes.get(video.id) || 'regular',
+    privacyStatus: privacyStatuses.get(video.id),
   }));
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -28,6 +28,8 @@ export interface PlaylistListItem {
   channelTitle: string;
   publishedAt: string;
   itemCount: number;
+  // Required (not optional): playlists.list always returns status in the same
+  // API response — no extra authenticated call needed, unlike VideoListItem.
   privacyStatus: PrivacyStatus;
 }
 
@@ -78,7 +80,9 @@ export interface VideoListItem {
   videoType: VideoType;
   channelTitle?: string;  // For global search results
   channelId?: string;     // For global search results
-  privacyStatus?: PrivacyStatus; // requires authenticated API call
+  // Optional: requires a separate authenticated videos.list call (see fetchPrivacyStatuses).
+  // Contrast with PlaylistListItem where privacy is always present in the same response.
+  privacyStatus?: PrivacyStatus;
 }
 
 // Localization types

--- a/types/index.ts
+++ b/types/index.ts
@@ -78,6 +78,7 @@ export interface VideoListItem {
   videoType: VideoType;
   channelTitle?: string;  // For global search results
   channelId?: string;     // For global search results
+  privacyStatus?: string; // public | private | unlisted (requires authenticated API call)
 }
 
 // Localization types
@@ -141,6 +142,12 @@ export interface LimitOption {
 
 export interface TypeFilterOption {
   type?: 'short' | 'regular';
+}
+
+export type PrivacyStatus = 'public' | 'private' | 'unlisted';
+
+export interface PrivacyFilterOption {
+  privacy?: PrivacyStatus[];
 }
 
 export interface ChannelOption {

--- a/types/index.ts
+++ b/types/index.ts
@@ -16,7 +16,7 @@ export interface PlaylistInfo {
   channelTitle: string;
   publishedAt: string;
   itemCount: number;
-  privacyStatus: string;
+  privacyStatus: PrivacyStatus;
   thumbnails: youtube_v3.Schema$ThumbnailDetails;
 }
 
@@ -28,7 +28,7 @@ export interface PlaylistListItem {
   channelTitle: string;
   publishedAt: string;
   itemCount: number;
-  privacyStatus: string;
+  privacyStatus: PrivacyStatus;
 }
 
 // Comment-related types
@@ -59,7 +59,7 @@ export interface VideoInfo {
   thumbnails: youtube_v3.Schema$ThumbnailDetails;
   statistics: VideoStatistics;
   duration: string;
-  privacyStatus: string;
+  privacyStatus: PrivacyStatus;
   videoType: VideoType;
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -78,7 +78,7 @@ export interface VideoListItem {
   videoType: VideoType;
   channelTitle?: string;  // For global search results
   channelId?: string;     // For global search results
-  privacyStatus?: string; // public | private | unlisted (requires authenticated API call)
+  privacyStatus?: PrivacyStatus; // requires authenticated API call
 }
 
 // Localization types


### PR DESCRIPTION
## Summary

Adds `--privacy <status...>` filtering to both `list-videos` and `list-playlists`, with visibility always shown in output. Also strengthens `privacyStatus` from `string` to a proper `PrivacyStatus` union type across the codebase.

- **`--privacy public private unlisted`** — variadic flag, accepts multiple values; filters results client-side after fetch
- **Privacy always displayed** in `pretty`, `table`, `text`, and `csv` output formats (color-coded in pretty: green/red/yellow/gray)
- **`PrivacyStatus` type** (`'public' | 'private' | 'unlisted'`) added to `types/index.ts`; replaces loose `string` on `VideoInfo`, `VideoListItem`, `PlaylistInfo`, `PlaylistListItem`
- **Shell completion** updated for both bash and zsh, including backwards-walk variadic scan so `--privacy public <TAB>` offers only remaining values
- **New shell completion guide** (`docs/development/shell-completion-guide.md`) documenting the two-layer architecture, variadic flag patterns, and a step-by-step checklist for adding completions

## Test plan

- [ ] `staqan-yt list-videos --privacy public` — returns only public videos, spinner shows count + `(N filtered by privacy)`
- [ ] `staqan-yt list-videos --privacy private unlisted` — filters to private + unlisted
- [ ] `staqan-yt list-videos --type short --privacy public` — both filters active; spinner reports each separately e.g. `(2 filtered by type, 5 filtered by privacy)`
- [ ] `staqan-yt list-videos --privacy invalid` — exits with clear error before any API call
- [ ] `staqan-yt list-playlists --privacy private` — filters playlists by privacy
- [ ] Pretty output shows `Privacy: public/private/unlisted/unknown` with correct colors
- [ ] Table and CSV output include `privacy` column
- [ ] `staqan-yt list-videos --privacy <TAB>` completes `public private unlisted`
- [ ] `staqan-yt list-videos --privacy public <TAB>` offers only `private unlisted`
- [ ] Unauthenticated call: privacy shows as `unknown` (pretty) / `-` (table/text) / `` (csv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)