### PR TITLE
fix: separate cache from archive, add cache clean command (#38)

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -36,6 +36,7 @@ import listReportTypesCommand = require('../commands/list-report-types');
 import listReportJobsCommand = require('../commands/list-report-jobs');
 import getReportDataCommand = require('../commands/get-report-data');
 import fetchReportsCommand = require('../commands/fetch-reports');
+import cacheCommand = require('../commands/cache');
 import completeCommand = require('../commands/complete');
 
 // Helper function to wrap command actions to handle "help" as an argument
@@ -498,6 +499,14 @@ program
   .option('--verify', 'Verify cached file completeness')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('fetch-reports', fetchReportsCommand));
+
+// Cache management command
+program
+  .command('cache [action]')
+  .description('Manage local cache (completions, handle map)')
+  .option('-y, --yes', 'Skip confirmation prompt')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action(withHelpWrapper('cache', cacheCommand));
 
 const completeCmd = new Command('__complete')
   .description('Internal completion helper')

--- a/commands/cache.ts
+++ b/commands/cache.ts
@@ -1,0 +1,86 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { CACHE_DIR, error, success, info, initCommand, confirm } from '../lib/utils';
+
+interface CacheOptions {
+  yes?: boolean;
+  verbose?: boolean;
+}
+
+/**
+ * Cache command handler
+ * Supports: cache clean
+ */
+async function cacheCommand(action?: string, options: CacheOptions = {}): Promise<void> {
+  initCommand(options);
+
+  if (!action || action === 'help') {
+    console.log('');
+    console.log(chalk.bold('Usage:'));
+    console.log('  staqan-yt cache clean   Remove all locally cached data (completions, handle map)');
+    console.log('');
+    console.log(chalk.bold('Options:'));
+    console.log('  -y, --yes   Skip confirmation prompt');
+    console.log('');
+    console.log(chalk.gray('Note: Report archive data is not affected. Use export-reports/import-reports'));
+    console.log(chalk.gray('      for report data management.'));
+    console.log('');
+    return;
+  }
+
+  if (action === 'clean') {
+    if (!options.yes) {
+      const confirmed = await confirm('Remove all cached data (completions, handle map)?');
+      if (!confirmed) {
+        info('Cancelled');
+        return;
+      }
+    }
+
+    // Files to delete
+    const targets = [
+      // Global completion cache (report-type completions)
+      path.join(CACHE_DIR, 'completion_cache.json'),
+      // Handle → channel ID map
+      path.join(CACHE_DIR, 'handle-to-channel-id.json'),
+    ];
+
+    // Per-channel completion caches: cache/{channelId}/completion_cache.json
+    try {
+      const entries = await fs.readdir(CACHE_DIR, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          targets.push(path.join(CACHE_DIR, entry.name, 'completion_cache.json'));
+        }
+      }
+    } catch {
+      // cache/ may not exist yet — nothing to clean
+    }
+
+    let removed = 0;
+    for (const target of targets) {
+      try {
+        await fs.unlink(target);
+        removed++;
+      } catch {
+        // File doesn't exist — skip silently
+      }
+    }
+
+    if (removed === 0) {
+      info('Nothing to clean');
+    } else {
+      success(`Cleared ${removed} cache file(s)`);
+    }
+    return;
+  }
+
+  error(`Unknown action: ${action}`);
+  console.log('');
+  console.log('Available actions:');
+  console.log('  clean   Remove all cached data');
+  process.exit(1);
+}
+
+export = cacheCommand;

--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -12,7 +12,7 @@ import { getChannelVideos, listChannelPlaylists, getChannelId } from '../lib/you
 import { getConfigValue } from '../lib/config';
 import { getAuthenticatedClient } from '../lib/auth';
 import { acquireLock, getLockPath } from '../lib/lock';
-import { CONFIG_DIR, debug } from '../lib/utils';
+import { CACHE_DIR, debug } from '../lib/utils';
 import { CompletionType, CompletionCache } from '../types';
 
 const TTL: Record<CompletionType, number> = {
@@ -22,10 +22,10 @@ const TTL: Record<CompletionType, number> = {
 };
 
 // report-type completions are credential-scoped (not channel-specific)
-const GLOBAL_CACHE_PATH = path.join(CONFIG_DIR, 'data', 'completion_cache.json');
+const GLOBAL_CACHE_PATH = path.join(CACHE_DIR, 'completion_cache.json');
 
 function getChannelCachePath(channelId: string): string {
-  return path.join(CONFIG_DIR, 'data', channelId, 'completion_cache.json');
+  return path.join(CACHE_DIR, channelId, 'completion_cache.json');
 }
 
 async function loadCache(cachePath: string): Promise<CompletionCache> {

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -2,23 +2,23 @@ import chalk from 'chalk';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { getConfig, setConfigValue } from '../lib/config';
-import { success, error, info, CONFIG_DIR } from '../lib/utils';
-import { ConfigKey, CompletionCache } from '../types';
+import { success, error, info, CACHE_DIR } from '../lib/utils';
+import { ConfigKey } from '../types';
 import { installCompletion, detectShell } from '../lib/completion';
 
 async function invalidateChannelCache(): Promise<void> {
-  const cachePath = path.join(CONFIG_DIR, 'completion-cache.json');
+  // Per-channel completion caches (video-id, playlist-id) are channel-specific.
+  // When the default channel changes, wipe them all so stale IDs aren't suggested.
   try {
-    const raw = await fs.readFile(cachePath, 'utf-8');
-    const cache: CompletionCache = JSON.parse(raw);
-    for (const key of Object.keys(cache)) {
-      if (key.startsWith('video-id:') || key.startsWith('playlist-id:')) {
-        delete cache[key];
+    const entries = await fs.readdir(CACHE_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const cachePath = path.join(CACHE_DIR, entry.name, 'completion_cache.json');
+        await fs.unlink(cachePath).catch(() => {});
       }
     }
-    await fs.writeFile(cachePath, JSON.stringify(cache));
   } catch {
-    // Cache may not exist yet — ignore
+    // cache/ may not exist yet — ignore
   }
 }
 

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, debug, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
+import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
 import { getOutputFormat, getConfigValue } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 import {
@@ -357,24 +357,28 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
         const parsed = parseCsvAndExtractRange(csvData);
 
         if (writeRelease) {
-          // Save to cache
-          await saveReportToCache(channelId, report.id || '', options.type, csvData, {
-            reportId: report.id || '',
-            reportTypeId: options.type,
-            channelId,
-            jobId,
-            startTime: report.startTime || '',
-            endTime: report.endTime || '',
-            startTimeActual: parsed.minDate,
-            endTimeActual: parsed.maxDate,
-            downloadedAt: new Date().toISOString(),
-            expiresAt: expiresAt.toISOString(),
-            downloadUrl: report.downloadUrl || '',
-            columns: headers,
-            isComplete: true,
-            fileSize: csvData.length,
-            row_count: data.length,
-          });
+          // Save to cache (non-fatal: warn on failure so API data is still returned)
+          try {
+            await saveReportToCache(channelId, report.id || '', options.type, csvData, {
+              reportId: report.id || '',
+              reportTypeId: options.type,
+              channelId,
+              jobId,
+              startTime: report.startTime || '',
+              endTime: report.endTime || '',
+              startTimeActual: parsed.minDate,
+              endTimeActual: parsed.maxDate,
+              downloadedAt: new Date().toISOString(),
+              expiresAt: expiresAt.toISOString(),
+              downloadUrl: report.downloadUrl || '',
+              columns: headers,
+              isComplete: true,
+              fileSize: csvData.length,
+              row_count: data.length,
+            });
+          } catch (cacheErr) {
+            warning(`Cache save failed for ${report.id}: ${(cacheErr as Error).message} — data will be re-fetched on next run`);
+          }
         }
 
         allData.push(...data);

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -4,7 +4,7 @@ import { CONFIG_DIR, debug, warning } from './utils';
 import { CacheIndex, CacheIndexEntry, ReportMetadata, CacheCoverage } from '../types';
 
 // Base data directory
-const DATA_DIR = path.join(CONFIG_DIR, 'data');
+export const DATA_DIR = path.join(CONFIG_DIR, 'data');
 
 // Cache index version
 const CACHE_INDEX_VERSION = '2.0';

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import os from 'os';
-import { debug } from './utils';
+import { debug, CACHE_DIR } from './utils';
 
 export interface LockOptions {
   timeout?: number;        // Max wait time (ms) before giving up
@@ -138,9 +138,9 @@ export function getLockPath(type: 'completion' | 'handles' | 'reports', channelI
   switch (type) {
     case 'completion':
       if (!channelId) throw new Error('channelId required for completion lock');
-      return path.join(dataDir, channelId, 'completion_cache.json.lock');
+      return path.join(CACHE_DIR, channelId, 'completion_cache.json.lock');
     case 'handles':
-      return path.join(dataDir, 'handle-to-channel-id.json.lock');
+      return path.join(CACHE_DIR, 'handle-to-channel-id.json.lock');
     case 'reports':
       if (!channelId) throw new Error('channelId required for reports lock');
       return path.join(dataDir, channelId, 'reports', '.lock');

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -8,6 +8,7 @@ import { createInterface } from 'readline';
 import { ChannelHandle } from '../types';
 
 const CONFIG_DIR = path.join(os.homedir(), '.staqan-yt-cli');
+const CACHE_DIR = path.join(CONFIG_DIR, 'cache');
 const CREDENTIALS_PATH = path.join(CONFIG_DIR, 'credentials.json');
 const TOKEN_PATH = path.join(CONFIG_DIR, 'token.json');
 
@@ -500,6 +501,7 @@ export {
   withSpinner,
   createSpinner,
   CONFIG_DIR,
+  CACHE_DIR,
   CREDENTIALS_PATH,
   TOKEN_PATH,
   ensureConfigDir,

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,16 +1,15 @@
 import { google, youtube_v3 } from 'googleapis';
 import { promises as fs } from 'fs';
 import path from 'path';
-import os from 'os';
 import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName } from './language';
 import { acquireLock, getLockPath } from './lock';
 import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PrivacyStatus, PlaylistInfo, PlaylistListItem, CommentInfo, ChannelInfo, CaptionInfo, CaptionFormat } from '../types';
-import { debug, warning } from './utils';
+import { debug, warning, CACHE_DIR } from './utils';
 
 // ─── Handle → channel ID cache ────────────────────────────────────────────────
 
-const HANDLE_CACHE_PATH = path.join(os.homedir(), '.staqan-yt-cli', 'data', 'handle-to-channel-id.json');
+const HANDLE_CACHE_PATH = path.join(CACHE_DIR, 'handle-to-channel-id.json');
 
 async function loadHandleCache(): Promise<Record<string, string>> {
   try {
@@ -32,7 +31,7 @@ async function saveHandleCache(cache: Record<string, string>): Promise<void> {
 
     debug('Handle cache saved');
   } catch (err) {
-    debug('Failed to save handle cache:', (err as Error).message);
+    warning(`Cache save failed (handle cache): ${(err as Error).message} — data will be re-fetched on next run`);
   } finally {
     if (release) await release();
   }


### PR DESCRIPTION
Closes #38

## Summary

- **Cache/archive separation** — moves cache files (`completion_cache.json`, `handle-to-channel-id.json`) from `data/` into a dedicated `cache/` directory, making the distinction between ephemeral cache and permanent report archive explicit in the filesystem
- **`staqan-yt cache clean`** — new command that wipes all local caches; safe because they're trivially regenerated on next use
- **Warning on cache save failure** — surfaces cache write errors that were previously silently swallowed, so users know when data will be re-fetched

## Changes

### Cache vs Archive distinction
Report archive data in `data/{channelId}/reports/` is **irreplaceable** once YouTube's sliding window closes — it is not a "cache". True caches (completions, handle map) are now in `cache/`:

```
~/.staqan-yt-cli/
├── cache/                          ← NEW (was scattered in data/)
│   ├── completion_cache.json
│   ├── handle-to-channel-id.json
│   └── {channelId}/
│       └── completion_cache.json
└── data/
    └── {channelId}/reports/        ← archive only, untouched
```

- Added `CACHE_DIR` to `lib/utils.ts`; updated `lib/youtube.ts`, `lib/lock.ts`, `commands/complete.ts`, `commands/config.ts`

### `cache clean` command
```bash
staqan-yt cache clean        # prompts for confirmation
staqan-yt cache clean --yes  # skip prompt (for scripts)
```
Deletes all files under `cache/`. Does **not** touch report archive data — that is scoped to issue #37 (`export-reports` / `import-reports`).

### Warning on cache save failure
- `lib/youtube.ts`: `debug()` → `warning()` when handle cache write fails
- `commands/get-report-data.ts`: `saveReportToCache` wrapped in `try/catch` — disk write failure is now non-fatal (API data still returned, warning emitted)

### Fix stale `invalidateChannelCache` in `config.ts`
Was targeting a legacy pre-#36 flat cache file (`completion-cache.json` in config root) that no longer exists. Now correctly wipes all per-channel completion caches under `cache/` when the default channel changes.

## Test plan
- [x] `staqan-yt cache clean` — prompts, then deletes `cache/` files; `data/` untouched
- [x] `staqan-yt cache clean --yes` — skips prompt
- [x] After clean, tab completions regenerate on next command
- [x] `staqan-yt config set default.channel @other` — per-channel completion caches wiped
- [x] Simulate cache save failure — warning printed, command still returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)