### PR TITLE
fix: fetch-reports overlap bug, pagination, incomplete data warning

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -2,7 +2,7 @@ import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
 import { error, debug, success, warning, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
 import {
-  findCachedReports,
+  isReportCached,
   saveReportToCache,
   loadCacheIndex,
   loadReportMetadata,
@@ -220,13 +220,21 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         continue;
       }
 
-      // Get reports for this job
-      const reportsResponse = await youtubeReporting.jobs.reports.list({
-        jobId,
-        onBehalfOfContentOwner: undefined,
-      });
-
-      let reports = reportsResponse.data.reports || [];
+      // Get reports for this job (with pagination)
+      const allFetchedReports: any[] = [];
+      let reportsPageToken: string | undefined;
+      do {
+        const reportsResponse = await youtubeReporting.jobs.reports.list({
+          jobId,
+          onBehalfOfContentOwner: undefined,
+          pageToken: reportsPageToken,
+        });
+        const pageReports = reportsResponse.data.reports || [];
+        allFetchedReports.push(...pageReports);
+        reportsPageToken = reportsResponse.data.nextPageToken || undefined;
+        debug(`Fetched ${pageReports.length} reports (total: ${allFetchedReports.length})`);
+      } while (reportsPageToken);
+      let reports = allFetchedReports;
 
       if (reports.length === 0) {
         debug(`No reports available for ${reportTypeId}`);
@@ -267,10 +275,10 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         const startTime = report.startTime!;
         const endTime = report.endTime!;
 
-        // Check if already cached
-        const cached = await findCachedReports(channelId, reportTypeId, startTime, endTime);
+        // Check if already cached (by unique report ID, not date overlap)
+        const alreadyCached = await isReportCached(channelId, reportId);
 
-        if (cached.length > 0 && !options.force) {
+        if (alreadyCached && !options.force) {
           debug(`Skipping cached report: ${reportId} (${startTime} to ${endTime})`);
           typeSkipped++;
           continue;

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -167,12 +167,21 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     // Step 2: Check if reports are available
     spinner.text = 'Fetching available reports...';
 
-    const reportsResponse = await youtubeReporting.jobs.reports.list({
-      jobId,
-      onBehalfOfContentOwner: undefined,
-    });
+    spinner.text = 'Fetching available reports...';
 
-    let reports = reportsResponse.data.reports || [];
+    const allFetchedReports: any[] = [];
+    let reportsPageToken: string | undefined;
+    do {
+      const reportsResponse = await youtubeReporting.jobs.reports.list({
+        jobId,
+        onBehalfOfContentOwner: undefined,
+        pageToken: reportsPageToken,
+      });
+      const pageReports = reportsResponse.data.reports || [];
+      allFetchedReports.push(...pageReports);
+      reportsPageToken = reportsResponse.data.nextPageToken || undefined;
+    } while (reportsPageToken);
+    let reports = allFetchedReports;
 
     if (reports.length === 0) {
       // Job exists but no reports yet (within 48h window)
@@ -217,9 +226,27 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       process.exit(1);
     }
 
-    // Adjust date range to available data if needed
-    const adjustedStart = requestedStart < minDate ? minDate : requestedStart;
-    const adjustedEnd = requestedEnd > maxDate ? maxDate : requestedEnd;
+    // Adjust date range to available data if needed.
+    // Consider both API range and local cache — cache may contain data that
+    // has expired from the API, or may be the only source if API returns nothing.
+    const cacheEntries = await findCachedReports(channelId, options.type, requestedStart, requestedEnd);
+    let effectiveMinDate = minDate;
+    let effectiveMaxDate = maxDate;
+    if (cacheEntries.length > 0) {
+      const cacheEarliest = cacheEntries.reduce((min, e) => {
+        const s = e.startTime.split('T')[0];
+        return s < min ? s : min;
+      }, '9999-99-99');
+      const cacheLatest = cacheEntries.reduce((max, e) => {
+        const s = e.endTime.split('T')[0];
+        return s > max ? s : max;
+      }, '');
+      if (cacheEarliest < effectiveMinDate) effectiveMinDate = cacheEarliest;
+      if (cacheLatest > effectiveMaxDate) effectiveMaxDate = cacheLatest;
+    }
+
+    const adjustedStart = requestedStart < effectiveMinDate ? effectiveMinDate : requestedStart;
+    const adjustedEnd = requestedEnd > effectiveMaxDate ? effectiveMaxDate : requestedEnd;
 
     // Validate that adjusted range has overlap (i.e., requested range is not entirely before/after available data)
     if (adjustedStart > adjustedEnd) {
@@ -227,7 +254,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       process.stderr.write('\n');
       process.stderr.write(chalk.red('Error:') + ' Requested date range has no overlap with available data\n');
       process.stderr.write(chalk.gray('Requested:') + ` ${requestedStart} to ${requestedEnd}\n`);
-      process.stderr.write(chalk.gray('Available:') + ` ${minDate} to ${maxDate}\n`);
+      process.stderr.write(chalk.gray('Available:') + ` ${effectiveMinDate} to ${effectiveMaxDate}\n`);
       process.stderr.write('\n');
       process.exit(1);
     }
@@ -241,28 +268,33 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       process.stderr.write(chalk.gray('Will return:') + ` ${adjustedStart} to ${adjustedEnd}\n`);
       process.stderr.write('\n');
 
-      if (requestedStart < minDate) {
-        const missingDays = Math.ceil((new Date(minDate).getTime() - new Date(requestedStart).getTime()) / (24 * 60 * 60 * 1000));
-        process.stderr.write(chalk.red('Missing:') + ` ${requestedStart} to ${minDate} (${missingDays} days, expired and deleted)\n`);
+      if (requestedStart < effectiveMinDate) {
+        const missingDays = Math.ceil((new Date(effectiveMinDate).getTime() - new Date(requestedStart).getTime()) / (24 * 60 * 60 * 1000));
+        process.stderr.write(chalk.red('Missing:') + ` ${requestedStart} to ${effectiveMinDate} (${missingDays} days, expired and deleted)
+`);
         process.stderr.write(chalk.yellow('Tip:') + ' Run fetch-reports regularly to keep a local archive and avoid data loss:\n');
         process.stderr.write(chalk.gray('       ') + chalk.cyan(`staqan-yt fetch-reports --type=${options.type}\n`));
         process.stderr.write('\n');
       }
 
-      if (requestedEnd > maxDate) {
-        process.stderr.write(chalk.red('Future dates not available:') + ` ${maxDate} to ${requestedEnd}\n`);
+      if (requestedEnd > effectiveMaxDate) {
+        process.stderr.write(chalk.red('Future dates not available:') + ` ${effectiveMaxDate} to ${requestedEnd}\n`);
         process.stderr.write('\n');
       }
     }
 
     // Step 4: Filter reports by date range (compare date portions only)
-    reports = reports.filter((report: typeof reports[0]) => {
+    // These are API reports — used for fetching data not yet in cache.
+    const filteredReports = reports.filter((report: typeof reports[0]) => {
       const reportStart = report.startTime!.split('T')[0];
       const reportEnd = report.endTime!.split('T')[0];
       return reportStart >= adjustedStart && reportEnd <= adjustedEnd;
     });
+    reports = filteredReports;
 
-    if (reports.length === 0) {
+    // It's okay if no API reports match — data may still be available from cache
+    // (e.g. expired from API but present in local archive).
+    if (reports.length === 0 && cacheEntries.length === 0) {
       spinner.fail('No reports match the specified date range');
       console.log('');
       error('No reports match the specified date range.');
@@ -460,7 +492,59 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
         break;
     }
 
-    // Step 10: Show expiration warning for the reports used
+    // Step 10: Warn about missing dates in the returned data
+    if (filteredData.length > 0) {
+      const returnedDates = new Set(filteredData.map(row => row.date));
+      // Generate expected date range
+      const rangeStart = new Date(adjustedStart);
+      const rangeEnd = new Date(adjustedEnd);
+      const expectedDates: string[] = [];
+      const current = new Date(rangeStart);
+      while (current <= rangeEnd) {
+        expectedDates.push(current.toISOString().split('T')[0].replace(/-/g, ''));
+        current.setDate(current.getDate() + 1);
+      }
+      const missingDates = expectedDates.filter(d => !returnedDates.has(d));
+      if (missingDates.length > 0) {
+        // Format missing dates for display (group consecutive only)
+        const formattedMissing = missingDates.map(d => `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`);
+        const gaps: { start: string; end: string }[] = [];
+        let gapStart = formattedMissing[0];
+        let gapEnd = formattedMissing[0];
+        for (let i = 1; i < formattedMissing.length; i++) {
+          const prev = new Date(formattedMissing[i - 1]);
+          const curr = new Date(formattedMissing[i]);
+          const diffDays = Math.round((curr.getTime() - prev.getTime()) / (24 * 60 * 60 * 1000));
+          if (diffDays === 1) {
+            gapEnd = formattedMissing[i];
+          } else {
+            gaps.push({ start: gapStart, end: gapEnd });
+            gapStart = formattedMissing[i];
+            gapEnd = formattedMissing[i];
+          }
+        }
+        gaps.push({ start: gapStart, end: gapEnd });
+
+        process.stderr.write('\n');
+        process.stderr.write(chalk.yellow('⚠️  Incomplete Data:\n'));
+        process.stderr.write(chalk.gray(`  Requested: ${adjustedStart} to ${adjustedEnd} (${expectedDates.length} days)\n`));
+        process.stderr.write(chalk.gray(`  Returned:  ${returnedDates.size} of ${expectedDates.length} days\n`));
+        process.stderr.write(chalk.gray('  Missing:\n'));
+        for (const gap of gaps) {
+          const days = Math.round((new Date(gap.end).getTime() - new Date(gap.start).getTime()) / (24 * 60 * 60 * 1000)) + 1;
+          if (gap.start === gap.end) {
+            process.stderr.write(chalk.red(`    ${gap.start}\n`));
+          } else {
+            process.stderr.write(chalk.red(`    ${gap.start} → ${gap.end} (${days} days)\n`));
+          }
+        }
+        process.stderr.write(chalk.yellow('  Tip:') + ' Data may have expired from YouTube or was never archived.\n');
+        process.stderr.write(chalk.gray('       ') + 'Run ' + chalk.cyan(`staqan-yt fetch-reports --type=${options.type}`) + ' to archive available data.\n');
+        process.stderr.write('\n');
+      }
+    }
+
+    // Step 11: Show expiration warning for the reports used
     const now = new Date();
     const jobCreated = new Date(matchingJob.createTime || '');
 

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -6,6 +6,7 @@ import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatter
 import {
   analyzeCacheCoverage,
   findCachedReports,
+  loadReportMetadata,
   readCachedReport,
   saveReportToCache,
   parseCsvAndExtractRange,
@@ -229,18 +230,29 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     // Adjust date range to available data if needed.
     // Consider both API range and local cache — cache may contain data that
     // has expired from the API, or may be the only source if API returns nothing.
+    // Use actual CSV data dates (from metadata) rather than API report windows
+    // which span 2 calendar days and would overstate coverage.
     const cacheEntries = await findCachedReports(channelId, options.type, requestedStart, requestedEnd);
     let effectiveMinDate = minDate;
     let effectiveMaxDate = maxDate;
     if (cacheEntries.length > 0) {
-      const cacheEarliest = cacheEntries.reduce((min, e) => {
-        const s = e.startTime.split('T')[0];
-        return s < min ? s : min;
-      }, '9999-99-99');
-      const cacheLatest = cacheEntries.reduce((max, e) => {
-        const s = e.endTime.split('T')[0];
-        return s > max ? s : max;
-      }, '');
+      const cacheDates = await Promise.all(
+        cacheEntries.map(async (e) => {
+          const meta = await loadReportMetadata(channelId, e.reportId, options.type);
+          if (meta?.startTimeActual) {
+            const s = meta.startTimeActual;
+            return {
+              min: `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
+              max: meta.endTimeActual
+                ? `${meta.endTimeActual.slice(0, 4)}-${meta.endTimeActual.slice(4, 6)}-${meta.endTimeActual.slice(6, 8)}`
+                : `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
+            };
+          }
+          return { min: e.startTime.split('T')[0], max: e.endTime.split('T')[0] };
+        })
+      );
+      const cacheEarliest = cacheDates.reduce((min, d) => d.min < min ? d.min : min, '9999-99-99');
+      const cacheLatest = cacheDates.reduce((max, d) => d.max > max ? d.max : max, '');
       if (cacheEarliest < effectiveMinDate) effectiveMinDate = cacheEarliest;
       if (cacheLatest > effectiveMaxDate) effectiveMaxDate = cacheLatest;
     }
@@ -269,16 +281,17 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       process.stderr.write('\n');
 
       if (requestedStart < effectiveMinDate) {
-        const missingDays = Math.ceil((new Date(effectiveMinDate).getTime() - new Date(requestedStart).getTime()) / (24 * 60 * 60 * 1000));
-        process.stderr.write(chalk.red('Missing:') + ` ${requestedStart} to ${effectiveMinDate} (${missingDays} days, expired and deleted)
-`);
+        const dayBeforeMin = new Date(new Date(effectiveMinDate).getTime() - 86400000).toISOString().split('T')[0];
+        const missingDays = Math.ceil((new Date(dayBeforeMin).getTime() - new Date(requestedStart).getTime()) / (24 * 60 * 60 * 1000)) + 1;
+        process.stderr.write(chalk.red('Missing:') + ` ${requestedStart} to ${dayBeforeMin} (${missingDays} days, expired and deleted)\n`);
         process.stderr.write(chalk.yellow('Tip:') + ' Run fetch-reports regularly to keep a local archive and avoid data loss:\n');
         process.stderr.write(chalk.gray('       ') + chalk.cyan(`staqan-yt fetch-reports --type=${options.type}\n`));
         process.stderr.write('\n');
       }
 
       if (requestedEnd > effectiveMaxDate) {
-        process.stderr.write(chalk.red('Future dates not available:') + ` ${effectiveMaxDate} to ${requestedEnd}\n`);
+        const dayAfterMax = new Date(new Date(effectiveMaxDate).getTime() + 86400000).toISOString().split('T')[0];
+        process.stderr.write(chalk.red('Future dates not available:') + ` ${dayAfterMax} to ${requestedEnd}\n`);
         process.stderr.write('\n');
       }
     }
@@ -307,7 +320,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     debug('Cache coverage:', coverage);
 
     // Step 6: Load cached data
-    const allData: Record<string, string>[] = [];
+    let allData: Record<string, string>[] = [];
     const cachedReports: CacheIndexEntry[] = [];
 
     for (const range of coverage.fullyCovered) {
@@ -430,6 +443,26 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     spinner.succeed(`Retrieved ${cachedReports.length} cached + ${reportsToFetch.length} new report(s)`);
     process.stderr.write('\n');
+
+    // Deduplicate rows by (date, video_id) — YouTube may serve duplicate
+    // reports with slightly different values for the same day; keep last seen.
+    const seen = new Map<string, number>();
+    allData = allData.filter((row, i) => {
+      const key = `${row.date}|${row.video_id}`;
+      const prev = seen.get(key);
+      if (prev !== undefined) {
+        // Keep the later entry (overwrite)
+        return i === prev;
+      }
+      seen.set(key, i);
+      return true;
+    });
+    // Deduplicate: last-write-wins (Map preserves insertion order)
+    const dedupMap = new Map<string, Record<string, string>>();
+    for (const row of allData) {
+      dedupMap.set(`${row.date}|${row.video_id}`, row);
+    }
+    allData = [...dedupMap.values()];
 
     // Step 8: Filter by video ID if specified
     let filteredData = allData;

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -301,7 +301,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     const filteredReports = reports.filter((report: typeof reports[0]) => {
       const reportStart = report.startTime!.split('T')[0];
       const reportEnd = report.endTime!.split('T')[0];
-      return reportStart >= adjustedStart && reportEnd <= adjustedEnd;
+      return reportStart <= adjustedEnd && reportEnd >= adjustedStart;
     });
     reports = filteredReports;
 
@@ -444,20 +444,8 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     spinner.succeed(`Retrieved ${cachedReports.length} cached + ${reportsToFetch.length} new report(s)`);
     process.stderr.write('\n');
 
-    // Deduplicate rows by (date, video_id) — YouTube may serve duplicate
-    // reports with slightly different values for the same day; keep last seen.
-    const seen = new Map<string, number>();
-    allData = allData.filter((row, i) => {
-      const key = `${row.date}|${row.video_id}`;
-      const prev = seen.get(key);
-      if (prev !== undefined) {
-        // Keep the later entry (overwrite)
-        return i === prev;
-      }
-      seen.set(key, i);
-      return true;
-    });
-    // Deduplicate: last-write-wins (Map preserves insertion order)
+    // Deduplicate by (date, video_id) — YouTube may serve duplicate
+    // reports for the same day; last-write-wins.
     const dedupMap = new Map<string, Record<string, string>>();
     for (const row of allData) {
       dedupMap.set(`${row.date}|${row.video_id}`, row);
@@ -526,7 +514,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     }
 
     // Step 10: Warn about missing dates in the returned data
-    if (filteredData.length > 0) {
+    if (filteredData.length > 0 && !options.videoId) {
       const returnedDates = new Set(filteredData.map(row => row.date));
       // Generate expected date range
       const rangeStart = new Date(adjustedStart);

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -111,6 +111,20 @@ export async function removeCacheEntry(channelId: string, reportId: string): Pro
 /**
  * Find cached reports for a type and date range (filtered by channelId)
  */
+/**
+ * Check if a specific report (by reportId) is already cached.
+ * Each YouTube Reporting API report has a unique ID — matching by ID
+ * avoids false-positive overlap when adjacent reports share a boundary
+ * date (e.g. 04-20→04-21 and 04-21→04-22 both contain "04-21").
+ */
+export async function isReportCached(
+  channelId: string,
+  reportId: string
+): Promise<boolean> {
+  const index = await loadCacheIndex(channelId);
+  return index.entries.some(entry => entry.reportId === reportId);
+}
+
 export async function findCachedReports(
   channelId: string,
   reportTypeId: string,
@@ -456,6 +470,41 @@ export function findDateGaps(
 }
 
 /**
+ * Convert YYYYMMDD string to YYYY-MM-DD for consistent date handling
+ */
+function normalizeDate(d: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(d)) return d;
+  if (/^\d{4}\d{2}\d{2}$/.test(d)) return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
+  // Handle ISO timestamps
+  return d.split('T')[0];
+}
+
+/**
+ * Get actual data dates for a cached report by reading its metadata file.
+ * The metadata file always stores startTimeActual/endTimeActual (parsed from CSV).
+ * We use these instead of the API report time windows for gap analysis,
+ * because API windows span 2 calendar days and overlap with adjacent reports.
+ */
+async function getActualDates(
+  entry: CacheIndexEntry,
+  channelId: string
+): Promise<{ start: string; end: string }> {
+  const metadata = await loadReportMetadata(channelId, entry.reportId, entry.reportTypeId);
+  if (metadata?.startTimeActual && metadata?.endTimeActual) {
+    return {
+      start: normalizeDate(metadata.startTimeActual),
+      end: normalizeDate(metadata.endTimeActual),
+    };
+  }
+
+  // Last resort: use API time windows (may have overlap issues)
+  return {
+    start: entry.startTime.split('T')[0],
+    end: entry.endTime.split('T')[0],
+  };
+}
+
+/**
  * Analyze cache coverage for requested date range
  */
 export async function analyzeCacheCoverage(
@@ -483,16 +532,20 @@ export async function analyzeCacheCoverage(
   const partiallyCovered: CacheCoverage['partiallyCovered'] = [];
   const notCovered: string[] = [];
 
-  const cachedRanges = cachedReports.map(r => ({
-    start: r.startTime.split('T')[0],
-    end: r.endTime.split('T')[0],
-  }));
+  // Resolve actual data dates for each cached report (reads metadata if needed)
+  const entriesWithDates = await Promise.all(
+    cachedReports.map(async (r) => ({
+      entry: r,
+      dates: await getActualDates(r, channelId),
+    }))
+  );
 
+  const cachedRanges = entriesWithDates.map(e => e.dates);
   const gaps = findDateGaps(cachedRanges, requestedStart, requestedEnd);
 
-  for (const cachedReport of cachedReports) {
-    const cachedStart = cachedReport.startTime.split('T')[0];
-    const cachedEnd = cachedReport.endTime.split('T')[0];
+  for (const { dates } of entriesWithDates) {
+    const cachedStart = dates.start;
+    const cachedEnd = dates.end;
 
     const overlap = computeDateRangeOverlap(
       cachedStart,


### PR DESCRIPTION
## Summary

Three bugs causing ~50% data loss in YouTube Reporting API archival, plus missing pagination and silent incomplete results.

### Root Cause: Overlap Skip Bug
`findCachedReports` used date-range overlap to check if a report was cached. Adjacent YouTube reports share a boundary date (e.g. `04-20→04-21` and `04-21→04-22`), causing `computeDateRangeOverlap` to report false matches. ~50% of reports were silently skipped during `fetch-reports`.

**Fix:** New `isReportCached()` checks by unique `reportId` instead of date overlap.

### Missing Pagination
Both `fetch-reports` and `get-report-data` only fetched the first API page (100 items). Reports on page 2+ were never seen or downloaded.

**Fix:** Paginate through all pages.

### Coverage Analysis Bug
`analyzeCacheCoverage` used 2-day API time windows for gap analysis, which overlap and produce false coverage. Also ignored local cache when data had expired from API.

**Fix:** Read actual CSV data dates from `.metadata.json` files (always existed). Honor local cache floor/ceiling. Allow cache-only ranges when no API reports match.

### Incomplete Data Warning
`get-report-data` now warns about missing dates in the returned data (`⚠️ Incomplete Data`), showing gap ranges and a tip to run `fetch-reports`.

## Changed Files
- `lib/cache.ts` — `isReportCached()` + `getActualDates()` + fixed `analyzeCacheCoverage`
- `commands/fetch-reports.ts` — reportId-based cache check + pagination
- `commands/get-report-data.ts` — pagination + cache-aware date range + incomplete data warning

## Compatibility
- **No index schema changes.** No migration needed. Existing caches work as-is.
- Actual dates are read from `.metadata.json` files which have always been stored alongside cached reports.

## Test Plan
- [x] `fetch-reports --force` downloads all 105 reports (was only getting 100)
- [x] `fetch-reports` (incremental) correctly skips already-cached by reportId
- [x] `get-report-data` returns 83 unique dates across full range (was 47)
- [x] Cache-only ranges (expired from API) still return data
- [x] Incomplete data warning shown when gaps exist
- [x] No warning when data is complete
- [x] JSON/CSV output formats unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retrieve all available reports via pagination before processing.
  * Improve cache checks to skip only when forced and avoid false cache hits.
  * Deduplicate aggregated rows to prevent duplicate output.

* **New Features**
  * Clamp requested date ranges against effective report windows (cache + API).
  * Emit a formatted "⚠️ Incomplete Data" warning listing grouped missing-date gaps.

* **Improvements**
  * More accurate cache coverage analysis using stored report metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->