### PR TITLE
fix: get-playlists --playlist-ids crashes with map is not a function

### DIFF
--- a/commands/get-playlists.ts
+++ b/commands/get-playlists.ts
@@ -5,10 +5,13 @@ import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { OutputOption, VerboseOption } from '../types';
 
-async function getPlaylistsCommand(playlistIds: string[], options: OutputOption & VerboseOption): Promise<void> {
+interface PlaylistIdsOption { playlistIds: string[]; }
+
+async function getPlaylistsCommand(options: PlaylistIdsOption & OutputOption & VerboseOption): Promise<void> {
   initCommand(options);
 
   await withSpinner('Fetching playlist information...', 'Failed to fetch playlist information', async (spinner) => {
+    const playlistIds = options.playlistIds;
     const parsedIds = playlistIds.map(parsePlaylistId);
     debug(`Parsing ${playlistIds.length} playlist ID(s)`, playlistIds);
     debug(`Parsed IDs:`, parsedIds);

--- a/commands/get-playlists.ts
+++ b/commands/get-playlists.ts
@@ -3,15 +3,13 @@ import { getPlaylistsById } from '../lib/youtube';
 import { formatDate, formatNumber, debug, parsePlaylistId, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-import { OutputOption, VerboseOption } from '../types';
-
-interface PlaylistIdsOption { playlistIds: string[]; }
+import { OutputOption, VerboseOption, PlaylistIdsOption } from '../types';
 
 async function getPlaylistsCommand(options: PlaylistIdsOption & OutputOption & VerboseOption): Promise<void> {
   initCommand(options);
 
   await withSpinner('Fetching playlist information...', 'Failed to fetch playlist information', async (spinner) => {
-    const playlistIds = options.playlistIds;
+    const playlistIds = options.playlistIds!;
     const parsedIds = playlistIds.map(parsePlaylistId);
     debug(`Parsing ${playlistIds.length} playlist ID(s)`, playlistIds);
     debug(`Parsed IDs:`, parsedIds);


### PR DESCRIPTION
## Summary

- Commander delivers variadic `--playlist-ids` values in `options.playlistIds`, not as a positional argument
- The function signature had `playlistIds` as the first param, so it was receiving the options object and calling `.map()` on it
- Fixed by reading `options.playlistIds` instead, matching the pattern used by `get-videos`

## Test plan

- [x] `get-playlists --playlist-ids <id1> <id2>` no longer crashes
- [x] Returns correct playlist metadata
- [x] `npm run type-check` clean
- [x] `npm run build` clean

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the playlists command interface for consistency: the command now accepts a single consolidated options object, simplifying how playlist selections and output preferences are provided and processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->