### PR TITLE
fix: validate --limit option, add parsePositiveInt helper

### DIFF
--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
+import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelSearchTermsOptions } from '../types';
@@ -31,6 +31,8 @@ const YOUTUBE_START_DATE = '2005-02-14';
 
 async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions): Promise<void> {
   initCommand(options);
+
+  const rawLimit = parsePositiveInt(options.limit, 25);
 
   await withSpinner('Resolving channel...', 'Failed to fetch channel search terms', async (spinner) => {
     // Resolve channel from arg or config default
@@ -136,7 +138,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     const startDate = options.startDate || YOUTUBE_START_DATE;
     const isLifetime = startDate === YOUTUBE_START_DATE;
     // API enforces maxResults ≤ 25 for this report type
-    const limit = Math.min(options.limit ? parseInt(options.limit, 10) : 25, MAX_RESULTS_LIMIT);
+    const limit = Math.min(rawLimit, MAX_RESULTS_LIMIT);
 
     debug('Video count in filter:', videoIds.length);
     debug('Filters (truncated):', filters.substring(0, 120) + '...');

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -32,7 +32,8 @@ const YOUTUBE_START_DATE = '2005-02-14';
 async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions): Promise<void> {
   initCommand(options);
 
-  const rawLimit = parsePositiveInt(options.limit, 25);
+  let rawLimit: number;
+  try { rawLimit = parsePositiveInt(options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Resolving channel...', 'Failed to fetch channel search terms', async (spinner) => {
     // Resolve channel from arg or config default

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchTermsOptions } from '../types';
@@ -15,6 +15,8 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     error('Required: --video-id');
     process.exit(1);
   }
+
+  const limit = parsePositiveInt(options.limit, 50);
 
   await withSpinner('Fetching search terms...', 'Failed to fetch search terms', async (spinner) => {
     const parsedId = parseVideoId(videoId);
@@ -47,8 +49,6 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     })();
 
     debug(`Date range: ${startDate} to ${endDate}`);
-
-    const limit = options.limit ? parseInt(options.limit, 10) : 50;
 
     // Fetch search terms data
     const analyticsResponse = await youtubeAnalytics.reports.query({

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -16,7 +16,8 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     process.exit(1);
   }
 
-  const limit = parsePositiveInt(options.limit, 50);
+  let limit: number;
+  try { limit = parsePositiveInt(options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching search terms...', 'Failed to fetch search terms', async (spinner) => {
     const parsedId = parseVideoId(videoId);

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { listVideoComments } from '../lib/youtube';
-import { formatDate, error, debug, parseVideoId, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, error, parsePositiveInt, debug, parseVideoId, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ListCommentsOptions } from '../types';
@@ -26,7 +26,7 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
 
   // Determine sort order
   const sortOrder = options.sort === 'new' ? 'time' : 'relevance';
-  const limit = parseInt(options.limit || '20');
+  const limit = parsePositiveInt(options.limit, 20);
 
   debug(`Fetching comments for video: ${videoId}, limit: ${limit}, sort: ${sortOrder}`);
 

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -26,7 +26,8 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
 
   // Determine sort order
   const sortOrder = options.sort === 'new' ? 'time' : 'relevance';
-  const limit = parsePositiveInt(options.limit, 20);
+  let limit: number;
+  try { limit = parsePositiveInt(options.limit, 20); } catch (e) { error((e as Error).message); process.exit(1); }
 
   debug(`Fetching comments for video: ${videoId}, limit: ${limit}, sort: ${sortOrder}`);
 

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { listChannelPlaylists } from '../lib/youtube';
-import { formatDate, formatNumber, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
+import { formatDate, formatNumber, error, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterOption } from '../types';
@@ -9,7 +9,8 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
   initCommand(options);
   validatePrivacyFilter(options.privacy);
 
-  const limit = parsePositiveInt(options.limit, 50);
+  let limit: number;
+  try { limit = parsePositiveInt(options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching channel playlists...', 'Failed to fetch playlists', async (spinner) => {
     const channel = await requireChannel(options.channel);

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { listChannelPlaylists } from '../lib/youtube';
-import { formatDate, formatNumber, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
+import { formatDate, formatNumber, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterOption } from '../types';
@@ -9,11 +9,10 @@ async function listPlaylistsCommand(options: ChannelOption & OutputOption & Limi
   initCommand(options);
   validatePrivacyFilter(options.privacy);
 
+  const limit = parsePositiveInt(options.limit, 50);
+
   await withSpinner('Fetching channel playlists...', 'Failed to fetch playlists', async (spinner) => {
     const channel = await requireChannel(options.channel);
-    debug(`Using channel: ${channel}`);
-
-    const limit = parseInt(options.limit || '50');
     debug(`Channel handle: ${channel}, limit: ${limit}`);
 
     let playlists = await listChannelPlaylists(channel, limit);

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getChannelVideos } from '../lib/youtube';
-import { formatDate, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
+import { formatDate, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption } from '../types';
@@ -9,11 +9,10 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
   initCommand(options);
   validatePrivacyFilter(options.privacy);
 
+  const limit = parsePositiveInt(options.limit, 50);
+
   await withSpinner('Fetching channel videos...', 'Failed to fetch videos', async (spinner) => {
     const channel = await requireChannel(options.channel);
-    debug(`Using channel: ${channel}`);
-
-    const limit = parseInt(options.limit || '50');
     debug(`Channel handle: ${channel}, limit: ${limit}`);
 
     let videos = await getChannelVideos(channel, limit);

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getChannelVideos } from '../lib/youtube';
-import { formatDate, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
+import { formatDate, error, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption } from '../types';
@@ -9,7 +9,8 @@ async function channelVideosCommand(options: ChannelOption & OutputOption & Limi
   initCommand(options);
   validatePrivacyFilter(options.privacy);
 
-  const limit = parsePositiveInt(options.limit, 50);
+  let limit: number;
+  try { limit = parsePositiveInt(options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching channel videos...', 'Failed to fetch videos', async (spinner) => {
     const channel = await requireChannel(options.channel);

--- a/commands/search-videos.ts
+++ b/commands/search-videos.ts
@@ -64,7 +64,8 @@ async function searchVideosCommand(options: SearchVideosOptions & QueryOption): 
     ? `Searching YouTube for "${query}"...`
     : `Searching ${targetChannel} for "${query}"...`;
 
-  const limit = parsePositiveInt(options.limit, 25);
+  let limit: number;
+  try { limit = parsePositiveInt(options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner(spinnerMessage, 'Search failed', async (spinner) => {
     debug(`Search mode: ${searchMode}, query: "${query}", limit: ${limit}`);

--- a/commands/search-videos.ts
+++ b/commands/search-videos.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { searchVideos } from '../lib/youtube';
-import { formatDate, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, error, parsePositiveInt, debug, initCommand, withSpinner } from '../lib/utils';
 import { getConfigValue, getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchVideosOptions, QueryOption } from '../types';
@@ -64,8 +64,9 @@ async function searchVideosCommand(options: SearchVideosOptions & QueryOption): 
     ? `Searching YouTube for "${query}"...`
     : `Searching ${targetChannel} for "${query}"...`;
 
+  const limit = parsePositiveInt(options.limit, 25);
+
   await withSpinner(spinnerMessage, 'Search failed', async (spinner) => {
-    const limit = parseInt(options.limit || '25');
     debug(`Search mode: ${searchMode}, query: "${query}", limit: ${limit}`);
 
     const videos = await searchVideos(query, {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -315,6 +315,15 @@ function chunkDateRange(startDate: string, endDate: string): { start: string; en
  * type is PrivacyStatus[], but at runtime the values are unvalidated strings
  * until this function confirms them.
  */
+function parsePositiveInt(limitOpt: string | undefined, defaultValue: number): number {
+  const limit = limitOpt ? parseInt(limitOpt, 10) : defaultValue;
+  if (isNaN(limit) || limit < 1) {
+    error('--limit must be a positive integer');
+    process.exit(1);
+  }
+  return limit;
+}
+
 function validatePrivacyFilter(privacy: string[] | undefined): void {
   if (!privacy || privacy.length === 0) return;
   const valid = ['public', 'private', 'unlisted'];
@@ -529,5 +538,6 @@ export {
   chunkDateRange,
   sleep,
   retryWithBackoff,
+  parsePositiveInt,
   validatePrivacyFilter,
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -316,12 +316,9 @@ function chunkDateRange(startDate: string, endDate: string): { start: string; en
  * until this function confirms them.
  */
 function parsePositiveInt(limitOpt: string | undefined, defaultValue: number): number {
-  const limit = limitOpt ? parseInt(limitOpt, 10) : defaultValue;
-  if (isNaN(limit) || limit < 1) {
-    error('--limit must be a positive integer');
-    process.exit(1);
-  }
-  return limit;
+  const n = limitOpt ? parseInt(limitOpt, 10) : defaultValue;
+  if (isNaN(n) || n < 1) throw new Error('--limit must be a positive integer');
+  return n;
 }
 
 function validatePrivacyFilter(privacy: string[] | undefined): void {


### PR DESCRIPTION
## Summary

- Passing `--limit abc` (or any non-numeric value) previously sent `NaN` directly to the YouTube API, returning a confusing `Invalid value at 'max_results' (TYPE_UINT32), "NaN"` error
- `--limit 0` and negative values were also silently accepted
- Adds a shared `parsePositiveInt(opt, default)` helper to `lib/utils.ts` to keep validation in one place
- Applied to all 6 affected commands: `list-videos`, `list-playlists`, `list-comments`, `search-videos`, `get-search-terms`, `get-channel-search-terms`
- Validation now fires before the spinner starts, giving a clean error with no confusing spinner failure message

## Test plan

- [x] `staqan-yt list-videos --limit abc` → `✗ --limit must be a positive integer` (exit 1)
- [x] `staqan-yt list-playlists --limit 0` → `✗ --limit must be a positive integer` (exit 1)
- [x] `staqan-yt list-comments --video-id ID --limit xyz` → `✗ --limit must be a positive integer` (exit 1)
- [x] `staqan-yt search-videos --query test --limit -5` → `✗ --limit must be a positive integer` (exit 1)
- [x] `staqan-yt list-videos --limit 5` → works correctly (exit 0)
- [x] `npm run type-check` → clean

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the `--limit` option parsing across multiple commands with consistent validation, default values, and improved error messages for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->