### PR TITLE
fix: validate --start-date / --end-date format across 5 commands

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, debug, success, warning, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
+import { error, debug, success, warning, initCommand, withSpinner, formatTimestampWithTimezone, parseDateOption } from '../lib/utils';
 import {
   isReportCached,
   saveReportToCache,
@@ -102,6 +102,17 @@ async function downloadReport(
  */
 async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> {
   initCommand(options);
+
+  let parsedStartDate: string | undefined;
+  let parsedEndDate: string | undefined;
+  try {
+    parsedStartDate = parseDateOption(options.startDate, '--start-date');
+    parsedEndDate = parseDateOption(options.endDate, '--end-date');
+  } catch (e) { error((e as Error).message); process.exit(1); }
+  if (parsedStartDate && parsedEndDate && parsedStartDate > parsedEndDate) {
+    error('--start-date must be before --end-date');
+    process.exit(1);
+  }
 
   await withSpinner('Initializing...', 'Failed to fetch reports', async (spinner) => {
     // Resolve channel handle → canonical channel ID for cache namespacing
@@ -242,11 +253,11 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       }
 
       // Filter by date range if specified (compare date portions only)
-      if (options.startDate || options.endDate) {
+      if (parsedStartDate || parsedEndDate) {
         const allMinDate = reports[reports.length - 1].startTime!.split('T')[0]; // Oldest
         const allMaxDate = reports[0].endTime!.split('T')[0]; // Newest
-        const filteredStart = (options.startDate || allMinDate).split('T')[0];
-        const filteredEnd = (options.endDate || allMaxDate).split('T')[0];
+        const filteredStart = (parsedStartDate || allMinDate).split('T')[0];
+        const filteredEnd = (parsedEndDate || allMaxDate).split('T')[0];
 
         // Validate that start date is not after end date
         if (filteredStart > filteredEnd) {

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner } from '../lib/utils';
+import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, parseDateOption } from '../lib/utils';
 import { requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelAnalyticsOptions } from '../types';
@@ -32,6 +32,17 @@ const REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
 
 async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Promise<void> {
   initCommand(options);
+
+  let parsedStartDate: string | undefined;
+  let parsedEndDate: string | undefined;
+  try {
+    parsedStartDate = parseDateOption(options.startDate, '--start-date');
+    parsedEndDate = parseDateOption(options.endDate, '--end-date');
+  } catch (e) { error((e as Error).message); process.exit(1); }
+  if (parsedStartDate && parsedEndDate && parsedStartDate > parsedEndDate) {
+    error('--start-date must be before --end-date');
+    process.exit(1);
+  }
 
   await withSpinner('Fetching channel analytics...', 'Failed to fetch channel analytics', async (spinner) => {
     // Determine channel ID
@@ -88,8 +99,8 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     spinner.succeed('Channel information retrieved');
 
     // Determine date range (default: last 30 days)
-    const endDate = options.endDate || new Date().toISOString().split('T')[0];
-    const startDate = options.startDate ||
+    const endDate = parsedEndDate || new Date().toISOString().split('T')[0];
+    const startDate = parsedStartDate ||
       new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
     debug(`Date range: ${startDate} to ${endDate}`);

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
+import { parseChannelHandle, error, parsePositiveInt, parseDateOption, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelSearchTermsOptions } from '../types';
@@ -34,6 +34,17 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
 
   let rawLimit: number;
   try { rawLimit = parsePositiveInt(options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
+
+  let parsedStartDate: string | undefined;
+  let parsedEndDate: string | undefined;
+  try {
+    parsedStartDate = parseDateOption(options.startDate, '--start-date');
+    parsedEndDate = parseDateOption(options.endDate, '--end-date');
+  } catch (e) { error((e as Error).message); process.exit(1); }
+  if (parsedStartDate && parsedEndDate && parsedStartDate > parsedEndDate) {
+    error('--start-date must be before --end-date');
+    process.exit(1);
+  }
 
   await withSpinner('Resolving channel...', 'Failed to fetch channel search terms', async (spinner) => {
     // Resolve channel from arg or config default
@@ -135,8 +146,8 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
       ? `${videoFilter};${sourceFilter};${contentTypeFilter}`
       : `${videoFilter};${sourceFilter}`;
 
-    const endDate = options.endDate || new Date().toISOString().split('T')[0];
-    const startDate = options.startDate || YOUTUBE_START_DATE;
+    const endDate = parsedEndDate || new Date().toISOString().split('T')[0];
+    const startDate = parsedStartDate || YOUTUBE_START_DATE;
     const isLifetime = startDate === YOUTUBE_START_DATE;
     // API enforces maxResults ≤ 25 for this report type
     const limit = Math.min(rawLimit, MAX_RESULTS_LIMIT);

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
+import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, parseDateOption } from '../lib/utils';
 import { getOutputFormat, getConfigValue } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 import {
@@ -98,6 +98,17 @@ async function downloadReport(
  */
 async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
   initCommand(options);
+
+  let parsedStartDate: string | undefined;
+  let parsedEndDate: string | undefined;
+  try {
+    parsedStartDate = parseDateOption(options.startDate, '--start-date');
+    parsedEndDate = parseDateOption(options.endDate, '--end-date');
+  } catch (e) { error((e as Error).message); process.exit(1); }
+  if (parsedStartDate && parsedEndDate && parsedStartDate > parsedEndDate) {
+    error('--start-date must be before --end-date');
+    process.exit(1);
+  }
 
   await withSpinner('Checking for existing reporting job...', 'Failed to fetch report data', async (spinner) => {
     // Resolve channel handle → canonical channel ID for cache namespacing
@@ -206,8 +217,8 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     const minDate = reports[reports.length - 1].startTime!.split('T')[0]; // Oldest
     const maxDate = reports[0].endTime!.split('T')[0]; // Newest
 
-    const requestedStart = options.startDate || minDate;
-    const requestedEnd = options.endDate || maxDate;
+    const requestedStart = parsedStartDate || minDate;
+    const requestedEnd = parsedEndDate || maxDate;
 
     // Check if requested range is available
     if (!minDate || !maxDate || !requestedStart || !requestedEnd) {

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,13 +1,24 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner, parseDateOption } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
 
 async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void> {
   initCommand(options);
+
+  let parsedStartDate: string | undefined;
+  let parsedEndDate: string | undefined;
+  try {
+    parsedStartDate = parseDateOption(options.startDate, '--start-date');
+    parsedEndDate = parseDateOption(options.endDate, '--end-date');
+  } catch (e) { error((e as Error).message); process.exit(1); }
+  if (parsedStartDate && parsedEndDate && parsedStartDate > parsedEndDate) {
+    error('--start-date must be before --end-date');
+    process.exit(1);
+  }
 
   // Extract video ID from options
   const videoId = options.videoId;
@@ -48,8 +59,8 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
 
     // Calculate date range
     // Default: full historical data from upload date to today
-    const endDate = options.endDate || new Date().toISOString().split('T')[0];
-    const startDate = options.startDate || publishedAt.split('T')[0];
+    const endDate = parsedEndDate || new Date().toISOString().split('T')[0];
+    const startDate = parsedStartDate || publishedAt.split('T')[0];
 
     debug(`Date range: ${startDate} to ${endDate}`);
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -323,10 +323,15 @@ function parsePositiveInt(limitOpt: string | undefined, defaultValue: number): n
 
 function parseDateOption(opt: string | undefined, flag: string): string | undefined {
   if (opt === undefined) return undefined;
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(opt) || isNaN(Date.parse(opt))) {
+  const parts = opt.split('-');
+  if (parts.length !== 3 || !/^\d{4}$/.test(parts[0]) || !/^\d{1,2}$/.test(parts[1]) || !/^\d{1,2}$/.test(parts[2])) {
     throw new Error(`${flag} must be in YYYY-MM-DD format`);
   }
-  return opt;
+  const normalized = `${parts[0]}-${parts[1].padStart(2, '0')}-${parts[2].padStart(2, '0')}`;
+  if (isNaN(Date.parse(normalized))) {
+    throw new Error(`${flag} must be in YYYY-MM-DD format`);
+  }
+  return normalized;
 }
 
 function validatePrivacyFilter(privacy: string[] | undefined): void {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -321,6 +321,14 @@ function parsePositiveInt(limitOpt: string | undefined, defaultValue: number): n
   return n;
 }
 
+function parseDateOption(opt: string | undefined, flag: string): string | undefined {
+  if (opt === undefined) return undefined;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(opt) || isNaN(Date.parse(opt))) {
+    throw new Error(`${flag} must be in YYYY-MM-DD format`);
+  }
+  return opt;
+}
+
 function validatePrivacyFilter(privacy: string[] | undefined): void {
   if (!privacy || privacy.length === 0) return;
   const valid = ['public', 'private', 'unlisted'];
@@ -536,5 +544,6 @@ export {
   sleep,
   retryWithBackoff,
   parsePositiveInt,
+  parseDateOption,
   validatePrivacyFilter,
 };


### PR DESCRIPTION
## Summary

- Adds `parseDateOption(opt, flag)` helper to `lib/utils.ts` — throws if value is present but not `YYYY-MM-DD`, callers catch-and-die (same pattern as `parsePositiveInt`)
- Applies validation before `withSpinner` in all 5 affected commands: `get-video-analytics`, `get-channel-analytics`, `get-channel-search-terms`, `fetch-reports`, `get-report-data`
- When both flags are provided, also rejects reversed ranges (`--start-date > --end-date`) before any API call

## Test plan

- [x] `--start-date "not-a-date"` → `✗ --start-date must be in YYYY-MM-DD format`, exit 1
- [x] `--start-date 2026-01-01 --end-date 2025-01-01` → `✗ --start-date must be before --end-date`, exit 1
- [x] Invalid month (`2025-13-01`) rejected by `Date.parse` check
- [x] Valid date passes through to API call as before
- [x] All 5 commands tested manually

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)