### PR TITLE
fix: rename --tags to --replace and validate mutual exclusivity with --add/--remove

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,5 +1,23 @@
 # Breaking Changes
 
+## v2.1.0
+
+**`--tags` → `--replace`** in `update-video-tags`:
+
+| Before | After |
+|---|---|
+| `--tags "foo,bar"` | `--replace "foo,bar"` |
+
+**Why:** `--tags` was ambiguous — `--replace` makes it clear this replaces all tags.
+
+**Also:** Mixing modes now errors (was silently ignored before):
+```bash
+# ✗ --replace cannot be combined with --add or --remove
+staqan-yt update-video-tags --video-id ID --replace "foo" --add "bar"
+```
+
+---
+
 ## v2.0.0: Channel-isolated cache and data storage
 
 **Directory structure change** — all per-channel data now lives under a channel ID namespace:

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -248,7 +248,7 @@ staqan-yt get-video-analytics --video-id dQw4w9WgXcQ
 
 # Get/update tags
 staqan-yt get-video-tags --video-id dQw4w9WgXcQ
-staqan-yt update-video-tags --video-id dQw4w9WgXcQ --tags "tag1,tag2"
+staqan-yt update-video-tags --video-id dQw4w9WgXcQ --replace "tag1,tag2"
 
 # Get thumbnail
 staqan-yt get-thumbnail --video-id dQw4w9WgXcQ

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -338,7 +338,7 @@ program
   .command('update-video-tags')
   .description('Update video tags (replace, add, or remove)')
   .requiredOption('--video-id <id>', 'Video ID')
-  .option('--tags <tags>', 'Replace all tags with comma-separated list')
+  .option('--replace <tags>', 'Replace all tags with comma-separated list')
   .option('--add <tags>', 'Add comma-separated tags')
   .option('--remove <tags>', 'Remove comma-separated tags')
   .option('--dry-run', 'Preview changes without applying them')

--- a/commands/update-video-tags.ts
+++ b/commands/update-video-tags.ts
@@ -19,8 +19,16 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     debug(`Parsed video ID: ${parsedId}`);
 
     // Validate that at least one update is provided
-    if (!options.tags && !options.add && !options.remove) {
-      error('Please provide at least one of --tags, --add, or --remove');
+    if (!options.replace && !options.add && !options.remove) {
+      error('Please provide at least one of --replace, --add, or --remove');
+      process.exit(1);
+    }
+
+    // --replace is rewrite mode; --add/--remove is incremental mode — cannot mix
+    if (options.replace && (options.add || options.remove)) {
+      error('--replace cannot be combined with --add or --remove');
+      console.log(chalk.gray('  Rewrite mode:      --replace "foo,bar"'));
+      console.log(chalk.gray('  Incremental mode:  --add "foo" --remove "bar"'));
       process.exit(1);
     }
 
@@ -50,9 +58,9 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     // Calculate new tags
     let newTags: string[] = [];
 
-    if (options.tags) {
+    if (options.replace) {
       // Replace all tags
-      newTags = options.tags.split(',').map(t => t.trim()).filter(t => t.length > 0);
+      newTags = options.replace.split(',').map((t: string) => t.trim()).filter((t: string) => t.length > 0);
     } else {
       // Start with current tags
       newTags = [...currentTags];
@@ -152,7 +160,18 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     success(`Video updated: https://youtube.com/watch?v=${parsedId}`);
   } catch (err) {
     console.log('');
-    error(`Failed to update tags: ${(err as Error).message}`);
+    const errorMessage = (err as Error).message;
+    if (errorMessage.includes('invalid video keywords')) {
+      error('Cannot update video tags');
+      console.log('');
+      console.log(chalk.gray('This usually means one of two things:'));
+      console.log(chalk.gray('  1. You don\'t have permission to modify this video (not your channel)'));
+      console.log(chalk.gray('  2. Tags contain invalid characters or exceed length limits'));
+      console.log('');
+      console.log(chalk.gray('Tip: Tags use comma-separated format: --add "tokyo bar,craft beer,nightlife"'));
+    } else {
+      error(`Failed to update tags: ${errorMessage}`);
+    }
     process.exit(1);
   }
 }

--- a/docs/commands/content-management.md
+++ b/docs/commands/content-management.md
@@ -105,14 +105,17 @@ staqan-yt update-video-tags --video-id dQw4w9WgXcQ \
 **Replace (`--replace`):**
 - Replaces ALL existing tags
 - Use this for complete tag overhaul
+- Cannot be combined with `--add` or `--remove`
 
 **Add (`--add`):**
 - Adds new tags to existing ones
 - Preserves all current tags
+- Can be combined with `--remove`
 
 **Remove (`--remove`):**
 - Removes specified tags if they exist
 - Keeps all other tags
+- Can be combined with `--add`
 
 ### Safety Features
 

--- a/docs/commands/content-management.md
+++ b/docs/commands/content-management.md
@@ -66,7 +66,7 @@ staqan-yt update-video-tags --video-id <videoId>
 
 - `--video-id <id>` - YouTube video ID or video URL (required)
 
-- `--tags <tags>` - Replace all tags with comma-separated list
+- `--replace <tags>` - Replace all tags with comma-separated list
 - `--add <tags>` - Add comma-separated tags
 - `--remove <tags>` - Remove comma-separated tags
 - `--dry-run` - Preview changes without applying them
@@ -79,7 +79,7 @@ staqan-yt update-video-tags --video-id <videoId>
 ```bash
 # Replace all tags
 staqan-yt update-video-tags --video-id dQw4w9WgXcQ \
-  --tags "youtube,tutorial,how to,programming"
+  --replace "youtube,tutorial,how to,programming"
 
 # Add tags to existing
 staqan-yt update-video-tags --video-id dQw4w9WgXcQ \
@@ -102,7 +102,7 @@ staqan-yt update-video-tags --video-id dQw4w9WgXcQ \
 
 ### Operation Modes
 
-**Replace (`--tags`):**
+**Replace (`--replace`):**
 - Replaces ALL existing tags
 - Use this for complete tag overhaul
 

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -131,7 +131,7 @@ export function getCommandOptions(command: string): string[] {
     'get-channel-search-terms': ['--channel', '--limit', '-l', '--content-type', '--start-date', '--end-date', ...outputOptions, ...verboseOption],
     'list-comments': ['--limit', '-l', '--sort', '-s', ...outputOptions, ...verboseOption],
     'get-video-tags': [...outputOptions, ...verboseOption],
-    'update-video-tags': ['--tags', '--add', '--remove', '--dry-run', '--yes', '-y', ...outputOptions, ...verboseOption],
+    'update-video-tags': ['--replace', '--add', '--remove', '--dry-run', '--yes', '-y', ...outputOptions, ...verboseOption],
     'get-thumbnail': ['--quality', ...outputOptions, ...verboseOption],
     'get-playlist': [...outputOptions, ...verboseOption],
     'get-playlists': [...outputOptions, ...verboseOption],
@@ -327,7 +327,7 @@ _staqa_nyt_completion() {
       COMPREPLY=( \$(compgen -W "--video-id --output --verbose" -- "\${cur}") )
       ;;
     update-video-tags)
-      COMPREPLY=( \$(compgen -W "--video-id --tags --add --remove --dry-run --yes --output --verbose" -- "\${cur}") )
+      COMPREPLY=( \$(compgen -W "--video-id --replace --add --remove --dry-run --yes --output --verbose" -- "\${cur}") )
       ;;
     get-thumbnail)
       COMPREPLY=( \$(compgen -W "--video-id --quality --output --verbose" -- "\${cur}") )
@@ -658,7 +658,7 @@ ${commandList}
       local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--tags[Replace all tags]:tags:' \\
+        '--replace[Replace all tags]:tags:' \\
         '--add[Add tags]:tags:' \\
         '--remove[Remove tags]:tags:' \\
         '--dry-run[Preview changes]' \\

--- a/types/index.ts
+++ b/types/index.ts
@@ -201,7 +201,7 @@ export interface RetentionOptions extends OutputOption, VerboseOption, VideoIdOp
 export interface GetTagsOptions extends OutputOption, VerboseOption, VideoIdOption {}
 
 export interface UpdateTagsOptions extends VerboseOption, VideoIdOption {
-  tags?: string;
+  replace?: string;
   add?: string;
   remove?: string;
   dryRun?: boolean;


### PR DESCRIPTION
## Summary

**BREAKING CHANGE (part of 2.1.0 milestone)**

- Renames `--tags` to `--replace` for clarity — rewrite mode is now explicit at the flag name level
- Adds validation: `--replace` cannot be combined with `--add` or `--remove` (previously silent ignore)
- Improves permission error message — explains "you don't own this video" vs "invalid tag characters" instead of misleading "invalid keywords"

## Root cause

Original `--tags` flag had silent failure when combined with `--add`/`--remove` because the code branch never reached them:

```typescript
if (options.tags) {
  newTags = options.tags.split(',')...  // --add/--remove never reached
} else {
  if (options.add) { ... }
  if (options.remove) { ... }
}
```

## Breaking change

**Before:**
```bash
staqan-yt update-video-tags --video-id ID --tags "foo,bar"
```

**After (2.1.0):**
```bash
staqan-yt update-video-tags --video-id ID --replace "foo,bar"
```

**Rationale:** `--replace` makes the mode (rewrite all vs incremental add/remove) immediately clear from the flag name. This aligns with the project's goal of consistent, discoverable CLI ergonomics.

## Test plan

- [x] `--replace "foo,bar"` → rewrite mode works
- [x] `--replace "foo" --add "bar"` → `✗ --replace cannot be combined with --add or --remove`, exit 1
- [x] `--add "tag"` alone → incremental mode works
- [x] `--add "x" --remove "y"` together → works (add + remove in one pass)
- [x] Old `--tags` flag → `Error: unknown option '--tags'` (breaking change confirmed)
- [x] Unowned video write → clear error explaining both possible causes

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the replace flag so it accepts its own arguments and no longer conflicts with other tag options.
  * Enforced that replace cannot be used with add or remove.

* **Improvements**
  * Better, multi-line error messages and a tags input tip for invalid keyword errors.

* **Documentation**
  * Updated docs, examples, and shell completions to reflect the new replace flag.

* **Breaking Changes**
  * CLI now uses --replace (replacing --tags) and rejects combined replace/add/remove usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->