### PR TITLE
fix: validate date options and use local timezone for default date ranges

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, debug, success, warning, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
+import { error, debug, success, warning, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange } from '../lib/utils';
 import {
   isReportCached,
   saveReportToCache,
@@ -102,6 +102,9 @@ async function downloadReport(
  */
 async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> {
   initCommand(options);
+  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Initializing...', 'Failed to fetch reports', async (spinner) => {
     // Resolve channel handle → canonical channel ID for cache namespacing

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -251,9 +251,10 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         const filteredStart = (options.startDate || allMinDate).split('T')[0];
         const filteredEnd = (options.endDate || allMaxDate).split('T')[0];
 
-        // Validate that start date is not after end date
-        if (filteredStart > filteredEnd) {
-          error('start-date must be before or equal to end-date');
+        try {
+          validateDateRange(filteredStart, filteredEnd);
+        } catch (e) {
+          error((e as Error).message);
           console.log(chalk.gray('Provided:') + ` start-date=${filteredStart}, end-date=${filteredEnd}`);
           console.log('');
           process.exit(1);

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, validateDateOption, validateDateRange } from '../lib/utils';
+import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, toLocalYmd, validateDateOption, validateDateRange } from '../lib/utils';
 import { requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelAnalyticsOptions } from '../types';
@@ -92,9 +92,9 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     spinner.succeed('Channel information retrieved');
 
     // Determine date range (default: last 30 days)
-    const endDate = options.endDate || new Date().toISOString().split('T')[0];
+    const endDate = options.endDate || toLocalYmd(new Date());
     const startDate = options.startDate ||
-      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+      toLocalYmd(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
 
     try {
       validateDateRange(startDate, endDate);

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner } from '../lib/utils';
+import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, validateDateOption, validateDateRange } from '../lib/utils';
 import { requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelAnalyticsOptions } from '../types';
@@ -32,6 +32,10 @@ const REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
 
 async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Promise<void> {
   initCommand(options);
+
+  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching channel analytics...', 'Failed to fetch channel analytics', async (spinner) => {
     // Determine channel ID
@@ -92,6 +96,7 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     const startDate = options.startDate ||
       new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
+    validateDateRange(startDate, endDate);
     debug(`Date range: ${startDate} to ${endDate}`);
 
     // Determine dimensions and metrics based on report type or custom

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -96,7 +96,12 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     const startDate = options.startDate ||
       new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
-    validateDateRange(startDate, endDate);
+    try {
+      validateDateRange(startDate, endDate);
+    } catch (e) {
+      error((e as Error).message);
+      process.exit(1);
+    }
     debug(`Date range: ${startDate} to ${endDate}`);
 
     // Determine dimensions and metrics based on report type or custom

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -141,7 +141,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     const endDate = options.endDate || toLocalYmd(new Date());
     const startDate = options.startDate || YOUTUBE_START_DATE;
     const isLifetime = startDate === YOUTUBE_START_DATE;
-    validateDateRange(startDate, endDate);
+    try { validateDateRange(startDate, endDate); } catch (e) { spinner.stop(); error((e as Error).message); process.exit(1); }
     // API enforces maxResults ≤ 25 for this report type
     const limit = Math.min(rawLimit, MAX_RESULTS_LIMIT);
 

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
+import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, validateDateOption, validateDateRange } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelSearchTermsOptions } from '../types';
@@ -34,6 +34,9 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
 
   let rawLimit: number;
   try { rawLimit = parsePositiveInt(options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Resolving channel...', 'Failed to fetch channel search terms', async (spinner) => {
     // Resolve channel from arg or config default
@@ -138,6 +141,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     const endDate = options.endDate || new Date().toISOString().split('T')[0];
     const startDate = options.startDate || YOUTUBE_START_DATE;
     const isLifetime = startDate === YOUTUBE_START_DATE;
+    validateDateRange(startDate, endDate);
     // API enforces maxResults ≤ 25 for this report type
     const limit = Math.min(rawLimit, MAX_RESULTS_LIMIT);
 

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, validateDateOption, validateDateRange } from '../lib/utils';
+import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelSearchTermsOptions } from '../types';
@@ -138,7 +138,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
       ? `${videoFilter};${sourceFilter};${contentTypeFilter}`
       : `${videoFilter};${sourceFilter}`;
 
-    const endDate = options.endDate || new Date().toISOString().split('T')[0];
+    const endDate = options.endDate || toLocalYmd(new Date());
     const startDate = options.startDate || YOUTUBE_START_DATE;
     const isLifetime = startDate === YOUTUBE_START_DATE;
     validateDateRange(startDate, endDate);

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -220,11 +220,12 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       process.exit(1);
     }
 
-    // Validate that start date is not after end date
-    if (requestedStart > requestedEnd) {
+    try {
+      validateDateRange(requestedStart, requestedEnd);
+    } catch (e) {
       spinner.fail('Invalid date range');
       console.log('');
-      error('start-date must be before or equal to end-date');
+      error((e as Error).message);
       console.log(chalk.gray('Provided:') + ` start-date=${requestedStart}, end-date=${requestedEnd}`);
       console.log('');
       process.exit(1);

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone } from '../lib/utils';
+import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange } from '../lib/utils';
 import { getOutputFormat, getConfigValue } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 import {
@@ -98,6 +98,9 @@ async function downloadReport(
  */
 async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
   initCommand(options);
+  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Checking for existing reporting job...', 'Failed to fetch report data', async (spinner) => {
     // Resolve channel handle → canonical channel ID for cache namespacing

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchTermsOptions } from '../types';
@@ -42,11 +42,11 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     const title = videoResponse.data.items[0].snippet?.title || 'Untitled';
 
     // Date range: last 30 days
-    const endDate = new Date().toISOString().split('T')[0];
+    const endDate = toLocalYmd(new Date());
     const startDate = (() => {
       const date = new Date();
       date.setDate(date.getDate() - 30);
-      return date.toISOString().split('T')[0];
+      return toLocalYmd(date);
     })();
 
     debug(`Date range: ${startDate} to ${endDate}`);

--- a/commands/get-traffic-sources.ts
+++ b/commands/get-traffic-sources.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, error, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { TrafficSourcesOptions } from '../types';
@@ -39,11 +39,11 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
     const title = videoResponse.data.items[0].snippet?.title || 'Untitled';
 
     // Date range: last 30 days
-    const endDate = new Date().toISOString().split('T')[0];
+    const endDate = toLocalYmd(new Date());
     const startDate = (() => {
       const date = new Date();
       date.setDate(date.getDate() - 30);
-      return date.toISOString().split('T')[0];
+      return toLocalYmd(date);
     })();
 
     debug(`Date range: ${startDate} to ${endDate}`);

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner, validateDateOption, validateDateRange } from '../lib/utils';
+import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
@@ -52,7 +52,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
 
     // Calculate date range
     // Default: full historical data from upload date to today
-    const endDate = options.endDate || new Date().toISOString().split('T')[0];
+    const endDate = options.endDate || toLocalYmd(new Date());
     const startDate = options.startDate || publishedAt.split('T')[0];
 
     try { validateDateRange(startDate, endDate); } catch (e) { spinner.stop(); error((e as Error).message); process.exit(1); }

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner, validateDateOption, validateDateRange } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
@@ -15,6 +15,10 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     error('Required: --video-id');
     process.exit(1);
   }
+
+  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching video information...', 'Failed to fetch analytics', async (spinner) => {
     const parsedId = parseVideoId(videoId);
@@ -51,6 +55,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     const endDate = options.endDate || new Date().toISOString().split('T')[0];
     const startDate = options.startDate || publishedAt.split('T')[0];
 
+    try { validateDateRange(startDate, endDate); } catch (e) { spinner.stop(); error((e as Error).message); process.exit(1); }
     debug(`Date range: ${startDate} to ${endDate}`);
 
     // Default metrics

--- a/commands/get-video-retention.ts
+++ b/commands/get-video-retention.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, convertToCSV, chunkDateRange, retryWithBackoff, parseDuration, formatTimestamp, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, error, debug, convertToCSV, chunkDateRange, retryWithBackoff, parseDuration, formatTimestamp, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { RetentionOptions } from '../types';
@@ -48,7 +48,7 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
     }
 
     // Calculate date range (default: full historical data)
-    const endDate = new Date().toISOString().split('T')[0];
+    const endDate = toLocalYmd(new Date());
     const startDate = publishedAt.split('T')[0];
 
     debug(`Date range: ${startDate} to ${endDate}`);

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -17,7 +17,7 @@ import {
 } from '../lib/youtube';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, chunkDateRange, retryWithBackoff, initCommand } from '../lib/utils';
+import { parseVideoId, chunkDateRange, retryWithBackoff, initCommand, toLocalYmd } from '../lib/utils';
 import { requireChannel } from '../lib/config';
 
 // Tool definitions
@@ -665,9 +665,9 @@ async function handleToolCall(name: string, args: any) {
       }
 
       // Determine date range (default: last 30 days)
-      const endDate = args.endDate || new Date().toISOString().split('T')[0];
+      const endDate = args.endDate || toLocalYmd(new Date());
       const startDate = args.startDate ||
-        new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+        toLocalYmd(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
 
       // Determine dimensions and metrics
       let dimensions: string;
@@ -755,7 +755,7 @@ async function handleToolCall(name: string, args: any) {
       }
 
       // Calculate date range
-      const endDate = args.endDate || new Date().toISOString().split('T')[0];
+      const endDate = args.endDate || toLocalYmd(new Date());
       const startDate = args.startDate || publishedAt.split('T')[0];
 
       // Default metrics
@@ -810,7 +810,7 @@ async function handleToolCall(name: string, args: any) {
       const analyticsResponse = await youtubeAnalytics.reports.query({
         ids: 'channel==MINE',
         startDate: '2000-01-01',
-        endDate: new Date().toISOString().split('T')[0],
+        endDate: toLocalYmd(new Date()),
         metrics: 'views',
         dimensions: 'insightTrafficSourceDetail',
         filters: `video==${parsedId};insightTrafficSourceType==YT_SEARCH`,
@@ -873,7 +873,7 @@ async function handleToolCall(name: string, args: any) {
         throw new Error('No videos found for this channel.');
       }
 
-      const endDate = args.endDate || new Date().toISOString().split('T')[0];
+      const endDate = args.endDate || toLocalYmd(new Date());
       const startDate = args.startDate || '2005-02-14';
       const limit = Math.min(args.limit || 25, 25);
       const CONTENT_TYPE_FILTERS: Record<string, string> = {
@@ -922,7 +922,7 @@ async function handleToolCall(name: string, args: any) {
       const analyticsResponse = await youtubeAnalytics.reports.query({
         ids: 'channel==MINE',
         startDate: '2000-01-01',
-        endDate: new Date().toISOString().split('T')[0],
+        endDate: toLocalYmd(new Date()),
         metrics: 'views',
         dimensions: 'insightTrafficSourceType',
         filters: `video==${parsedId}`,
@@ -945,7 +945,7 @@ async function handleToolCall(name: string, args: any) {
       const analyticsResponse = await youtubeAnalytics.reports.query({
         ids: 'channel==MINE',
         startDate: '2000-01-01',
-        endDate: new Date().toISOString().split('T')[0],
+        endDate: toLocalYmd(new Date()),
         metrics: 'audienceWatchRatio,relativeRetentionPerformance',
         dimensions: 'elapsedVideoTimeRatio',
         filters: `video==${parsedId}`,

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -17,7 +17,7 @@ import {
 } from '../lib/youtube';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, chunkDateRange, retryWithBackoff, initCommand, toLocalYmd } from '../lib/utils';
+import { parseVideoId, chunkDateRange, retryWithBackoff, initCommand, toLocalYmd, validateDateOption, validateDateRange } from '../lib/utils';
 import { requireChannel } from '../lib/config';
 
 // Tool definitions
@@ -664,10 +664,14 @@ async function handleToolCall(name: string, args: any) {
         }
       }
 
+      if (args.startDate) validateDateOption('startDate', args.startDate);
+      if (args.endDate) validateDateOption('endDate', args.endDate);
+
       // Determine date range (default: last 30 days)
       const endDate = args.endDate || toLocalYmd(new Date());
       const startDate = args.startDate ||
         toLocalYmd(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
+      validateDateRange(startDate, endDate);
 
       // Determine dimensions and metrics
       let dimensions: string;
@@ -754,9 +758,13 @@ async function handleToolCall(name: string, args: any) {
         throw new Error('Video publish date is missing');
       }
 
+      if (args.startDate) validateDateOption('startDate', args.startDate);
+      if (args.endDate) validateDateOption('endDate', args.endDate);
+
       // Calculate date range
       const endDate = args.endDate || toLocalYmd(new Date());
       const startDate = args.startDate || publishedAt.split('T')[0];
+      validateDateRange(startDate, endDate);
 
       // Default metrics
       const metrics = args.metrics || 'views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares';
@@ -873,8 +881,12 @@ async function handleToolCall(name: string, args: any) {
         throw new Error('No videos found for this channel.');
       }
 
+      if (args.startDate) validateDateOption('startDate', args.startDate);
+      if (args.endDate) validateDateOption('endDate', args.endDate);
+
       const endDate = args.endDate || toLocalYmd(new Date());
       const startDate = args.startDate || '2005-02-14';
+      validateDateRange(startDate, endDate);
       const limit = Math.min(args.limit || 25, 25);
       const CONTENT_TYPE_FILTERS: Record<string, string> = {
         video: 'creatorContentType==LONG_FORM_CONTENT',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -321,6 +321,13 @@ function parsePositiveInt(limitOpt: string | undefined, defaultValue: number): n
   return n;
 }
 
+function toLocalYmd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
 function validateDateOption(flag: string, value: string): void {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     throw new Error(`${flag} must be in YYYY-MM-DD format (got: ${value})`);
@@ -555,6 +562,7 @@ export {
   sleep,
   retryWithBackoff,
   parsePositiveInt,
+  toLocalYmd,
   validateDateOption,
   validateDateRange,
   validatePrivacyFilter,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -333,10 +333,9 @@ function validateDateOption(flag: string, value: string): void {
     throw new Error(`${flag} must be in YYYY-MM-DD format (got: ${value})`);
   }
   // Catch invalid calendar dates like 2024-02-30.
-  // Intentionally uses the local system timezone — dates are treated as wall-clock
-  // calendar values. Future config support may allow a timezone override here.
+  // Days-in-month check is tz-independent; UTC methods make that explicit.
   const [y, m, d] = value.split('-').map(Number);
-  if (m < 1 || m > 12 || d < 1 || d > new Date(y, m, 0).getDate()) {
+  if (m < 1 || m > 12 || d < 1 || d > new Date(Date.UTC(y, m, 0)).getUTCDate()) {
     throw new Error(`${flag} is not a valid date: ${value}`);
   }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -321,6 +321,25 @@ function parsePositiveInt(limitOpt: string | undefined, defaultValue: number): n
   return n;
 }
 
+function validateDateOption(flag: string, value: string): void {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error(`${flag} must be in YYYY-MM-DD format (got: ${value})`);
+  }
+  // Catch invalid calendar dates like 2024-02-30.
+  // User input is a local-timezone calendar date; validate purely as such.
+  // new Date(y, m, 0).getDate() = days in month m of year y (tz-independent).
+  const [y, m, d] = value.split('-').map(Number);
+  if (m < 1 || m > 12 || d < 1 || d > new Date(y, m, 0).getDate()) {
+    throw new Error(`${flag} is not a valid date: ${value}`);
+  }
+}
+
+function validateDateRange(startDate: string, endDate: string): void {
+  if (startDate > endDate) {
+    throw new Error(`--start-date must be on or before --end-date (${startDate} > ${endDate})`);
+  }
+}
+
 function validatePrivacyFilter(privacy: string[] | undefined): void {
   if (!privacy || privacy.length === 0) return;
   const valid = ['public', 'private', 'unlisted'];
@@ -536,5 +555,7 @@ export {
   sleep,
   retryWithBackoff,
   parsePositiveInt,
+  validateDateOption,
+  validateDateRange,
   validatePrivacyFilter,
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -326,8 +326,8 @@ function validateDateOption(flag: string, value: string): void {
     throw new Error(`${flag} must be in YYYY-MM-DD format (got: ${value})`);
   }
   // Catch invalid calendar dates like 2024-02-30.
-  // User input is a local-timezone calendar date; validate purely as such.
-  // new Date(y, m, 0).getDate() = days in month m of year y (tz-independent).
+  // Intentionally uses the local system timezone — dates are treated as wall-clock
+  // calendar values. Future config support may allow a timezone override here.
   const [y, m, d] = value.split('-').map(Number);
   if (m < 1 || m > 12 || d < 1 || d > new Date(y, m, 0).getDate()) {
     throw new Error(`${flag} is not a valid date: ${value}`);


### PR DESCRIPTION
## Summary

- Adds \`validateDateOption(flag, value)\` and \`validateDateRange(startDate, endDate)\` helpers to \`lib/utils.ts\`
- Adds \`toLocalYmd(d: Date): string\` helper to produce local-timezone \`YYYY-MM-DD\` strings for user-facing default dates
- Date input/output uses local timezone (user-facing calendar dates); internal timestamps (cache metadata, expiry fields) remain UTC
- Validation applied to 5 CLI commands: \`get-video-analytics\`, \`get-channel-analytics\`, \`get-channel-search-terms\`, \`fetch-reports\`, \`get-report-data\`
- Validation applied to 3 MCP tool handlers: \`youtube_get_channel_analytics\`, \`youtube_get_video_analytics\`, \`youtube_get_channel_search_terms\`
- Local-date defaults applied to 7 commands: \`get-channel-analytics\`, \`get-video-analytics\`, \`get-channel-search-terms\`, \`get-search-terms\`, \`get-traffic-sources\`, \`get-video-retention\`, \`mcp\`
- Days-in-month check in \`validateDateOption\` uses UTC methods for explicitness

## Before / After

**Before:** invalid dates passed silently to the API, and default date ranges were computed in UTC — potentially shifting analytics windows by 1 day for non-UTC users

```
$ staqan-yt get-video-analytics --video-id ID --start-date "yesterday"
✔ Retrieved 0 row(s) of analytics data
No analytics data available for this time period.
```

**After:**
```
$ staqan-yt get-video-analytics --video-id ID --start-date "yesterday"
✗ --start-date must be in YYYY-MM-DD format (got: yesterday)

$ staqan-yt get-video-analytics --video-id ID --start-date "2024-13-01"
✗ --start-date is not a valid date: 2024-13-01

$ staqan-yt get-video-analytics --video-id ID --start-date "2025-01-01" --end-date "2024-01-01"
✗ --start-date must be on or before --end-date (2025-01-01 > 2024-01-01)
```

## Test plan

- [x] \`--start-date "yesterday"\` → format error, exit 1
- [x] \`--start-date "2024-13-01"\` → invalid calendar date error, exit 1
- [x] \`--start-date "20240101"\` → format error (missing dashes), exit 1
- [x] \`--start-date "2025-01-01" --end-date "2024-01-01"\` → range error, exit 1
- [x] \`--start-date "2024-01-01" --end-date "2024-01-31"\` → proceeds normally, exit 0
- [x] Default date ranges reflect local calendar date, not UTC
- [x] MCP tool handlers reject malformed dates before hitting the API
- [x] Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date range validation to prevent invalid date combinations (start date after end date).
  * Fixed date calculations to use local dates instead of UTC formats for consistency.

* **New Features**
  * Enhanced date option validation with clear error messages when invalid dates are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->