### PR TITLE
fix: get-caption outputs Blob instead of caption content (#53)

### DIFF
--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -917,7 +917,7 @@ async function downloadCaption(captionId: string, format: CaptionFormat = 'json'
   // The download endpoint returns the caption content
   const response = await youtube.captions.download({
     id: captionId,
-  });
+  }, { responseType: 'text' });
 
   // The response is the actual caption content
   const content = response.data as string;


### PR DESCRIPTION
## Summary

- `captions.download()` was returning a `Blob` object when `responseType` was not set
- Casting `response.data as string` called `.toString()` on the Blob, producing `"Blob (18.1 KB)"`
- Fix: pass `{ responseType: 'text' }` as the second argument so `response.data` is already a string

Fixes #53

## Test plan

- [ ] `staqan-yt list-captions --video-id <id>` — copy a caption ID
- [ ] `staqan-yt get-caption --caption-id <id>` — should output caption text, not `Blob (N KB)`
- [ ] `staqan-yt get-caption --caption-id <id> --format srt` — same check for SRT format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caption retrieval to ensure proper text format handling from the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->