### PR TITLE
fix: validate --format in get-caption (#69)

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -428,7 +428,7 @@ program
   .command('get-caption')
   .description('Download caption content to stdout (get caption ID from list-captions)')
   .requiredOption('--caption-id <id>', 'Caption ID')
-  .option('--format <format>', 'Caption format: srt, vtt, sbv, srv2, ttml, json (default: json)', 'json')
+  .option('--format <format>', 'Caption format: srt, vtt, sbv, scc, ttml, json (default: json)', 'json')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('get-caption', getCaptionCommand));
 

--- a/commands/get-caption.ts
+++ b/commands/get-caption.ts
@@ -38,16 +38,14 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
 
     // Provide helpful context for common API limitations
     if (errMessage.includes('permissions') || errMessage.includes('not sufficient')) {
-      error('Caption download not available');
+      error('Caption download not available — you can only download captions from your own videos');
       console.log('');
       console.log(chalk.yellow('YouTube API Limitation:'));
-      console.log(chalk.gray('Caption downloads are restricted by YouTube and may not be available for all videos.'));
+      console.log(chalk.gray('The captions.download API only works for videos on your authenticated channel.'));
+      console.log(chalk.gray('Downloading captions from other channels\' videos is not permitted.'));
       console.log('');
-      console.log(chalk.gray('Downloads typically work for:'));
-      console.log('  • Captions manually uploaded by the content owner');
-      console.log('  • Captions with third-party contributions enabled');
-      console.log('');
-      console.log(chalk.gray('Auto-generated captions usually cannot be downloaded via the API.'));
+      console.log(chalk.gray('To get the transcript of a video you don\'t own, use a third-party tool or'));
+      console.log(chalk.gray('the YouTube website\'s subtitle/transcript feature instead.'));
     } else {
       error(errMessage);
     }

--- a/commands/get-caption.ts
+++ b/commands/get-caption.ts
@@ -13,6 +13,12 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
     process.exit(1);
   }
 
+  const validFormats = ['srt', 'vtt', 'sbv', 'scc', 'ttml', 'json'];
+  if (options.format && !validFormats.includes(options.format)) {
+    error(`Invalid format '${options.format}'. Valid: ${validFormats.join(', ')}`);
+    process.exit(1);
+  }
+
   // Note: For caption metadata, use list-captions --video-id <videoId>
   // This command focuses on downloading caption content
   const format = options.format || 'json';

--- a/commands/get-caption.ts
+++ b/commands/get-caption.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { downloadCaption } from '../lib/youtube';
 import { error, debug, initCommand, createSpinner } from '../lib/utils';
-import { GetCaptionOptions } from '../types';
+import { GetCaptionOptions, CAPTION_FORMATS } from '../types';
 
 async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
   initCommand(options);
@@ -13,9 +13,8 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
     process.exit(1);
   }
 
-  const validFormats = ['srt', 'vtt', 'sbv', 'scc', 'ttml', 'json'];
-  if (options.format && !validFormats.includes(options.format)) {
-    error(`Invalid format '${options.format}'. Valid: ${validFormats.join(', ')}`);
+  if (options.format && !(CAPTION_FORMATS as readonly string[]).includes(options.format)) {
+    error(`Invalid format '${options.format}'. Valid: ${CAPTION_FORMATS.join(', ')}`);
     process.exit(1);
   }
 

--- a/docs/commands/configuration.md
+++ b/docs/commands/configuration.md
@@ -209,7 +209,7 @@ staqan-yt list-report-jobs --type <Tab>  # Report type IDs
 # Static value completion
 staqan-yt get-video --output <Tab>   # json  table  text  pretty  csv
 staqan-yt list-comments --sort <Tab> # top  new
-staqan-yt get-caption --format <Tab> # srt  vtt  sbv  srv2  ttml  json
+staqan-yt get-caption --format <Tab> # srt  vtt  sbv  scc  ttml  json
 ```
 
 Dynamic completion caches results locally for 5 minutes (report types: 1 hour), so it stays fast on repeated presses.

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -139,7 +139,7 @@ staqan-yt get-caption --caption-id <captionId>
 
 - `--caption-id <id>` - Caption track ID (get from `list-captions`) (required)
 
-- `--format <format>` - Caption format: srt, vtt, sbv, srv2, ttml, json (default: json)
+- `--format <format>` - Caption format: srt, vtt, sbv, scc, ttml, json (default: json)
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
 
@@ -166,7 +166,7 @@ staqan-yt get-caption --caption-id en.dQw4w9WgXcQ --format json | jq -r '.[].tex
 
 **Text formats:**
 - `json` - Structured JSON with timing (default)
-- `srv2` - YouTube's internal format
+- `scc` - Scenarist Closed Caption format
 
 **Subtitle formats:**
 - `srt` - SubRip format (most players)

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -193,12 +193,14 @@ Use `staqan-yt list-captions --video-id <your-video-id>` to get the exact captio
 ### Working with Captions
 
 **Extract plain text:**
+
 ```bash
 staqan-yt get-caption --caption-id <caption-id> --format json | \
   jq -r '.[].text' > transcript.txt
 ```
 
 **Create word cloud:**
+
 ```bash
 staqan-yt get-caption --caption-id <caption-id> --format json | \
   jq -r '.[].text' | \
@@ -209,6 +211,7 @@ staqan-yt get-caption --caption-id <caption-id> --format json | \
 ```
 
 **Find mentions:**
+
 ```bash
 staqan-yt get-caption --caption-id <caption-id> --format json | \
   jq -r '.[].text' | \

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -143,23 +143,25 @@ staqan-yt get-caption --caption-id <captionId>
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
 
+> **Ownership requirement:** The YouTube API only allows downloading captions from videos on your own authenticated channel. `list-captions` works for any video, but `get-caption` will return a permissions error for videos you don't own.
+
 ### Examples
 
 ```bash
-# Get caption ID first
-staqan-yt list-captions --video-id dQw4w9WgXcQ
+# List captions on one of your own videos to get the caption ID
+staqan-yt list-captions --video-id <your-video-id>
 
 # Download captions (JSON format by default)
-staqan-yt get-caption --caption-id en.dQw4w9WgXcQ
+staqan-yt get-caption --caption-id <caption-id>
 
 # Download as SRT (subtitle file format)
-staqan-yt get-caption --caption-id en.dQw4w9WgXcQ --format srt > captions.srt
+staqan-yt get-caption --caption-id <caption-id> --format srt > captions.srt
 
 # Download as VTT
-staqan-yt get-caption --caption-id en.dQw4w9WgXcQ --format vtt > captions.vtt
+staqan-yt get-caption --caption-id <caption-id> --format vtt > captions.vtt
 
 # Download as text
-staqan-yt get-caption --caption-id en.dQw4w9WgXcQ --format json | jq -r '.[].text'
+staqan-yt get-caption --caption-id <caption-id> --format json | jq -r '.[].text'
 ```
 
 ### Caption Formats
@@ -182,21 +184,23 @@ Caption IDs typically follow the format:
 ```
 
 Examples:
-- `en.dQw4w9WgXcQ` - English captions
-- `ja.dQw4w9WgXcQ` - Japanese captions
-- `en.dQw4w9WgXcQ.3` - Multiple English tracks
+- `en.<video-id>` - English captions
+- `ja.<video-id>` - Japanese captions
+- `en.<video-id>.3` - Multiple English tracks
+
+Use `staqan-yt list-captions --video-id <your-video-id>` to get the exact caption ID for your videos.
 
 ### Working with Captions
 
 **Extract plain text:**
 ```bash
-staqan-yt get-caption en.dQw4w9WgXcQ --format json | \
+staqan-yt get-caption --caption-id <caption-id> --format json | \
   jq -r '.[].text' > transcript.txt
 ```
 
 **Create word cloud:**
 ```bash
-staqan-yt get-caption en.dQw4w9WgXcQ --format json | \
+staqan-yt get-caption --caption-id <caption-id> --format json | \
   jq -r '.[].text' | \
   tr '[:upper:]' '[:lower:]' | \
   tr -d '[:punct:]' | \
@@ -206,7 +210,7 @@ staqan-yt get-caption en.dQw4w9WgXcQ --format json | \
 
 **Find mentions:**
 ```bash
-staqan-yt get-caption en.dQw4w9WgXcQ --format json | \
+staqan-yt get-caption --caption-id <caption-id> --format json | \
   jq -r '.[].text' | \
   grep -i '@\|twitter\|instagram'
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -151,7 +151,7 @@ staqan-yt list-report-jobs --type <Tab>  # Report type IDs
 staqan-yt get-video --<Tab>          # --output, --verbose
 staqan-yt get-video --output <Tab>   # json  table  text  pretty  csv
 staqan-yt list-comments --sort <Tab> # top  new
-staqan-yt get-caption --format <Tab> # srt  vtt  sbv  srv2  ttml  json
+staqan-yt get-caption --format <Tab> # srt  vtt  sbv  scc  ttml  json
 ```
 
 Dynamic ID completion (video IDs, playlist IDs, report types) fetches live data from YouTube and caches results for 5 minutes. It requires a default channel to be configured.

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -297,7 +297,7 @@ _staqa_nyt_completion() {
     --sort|-s)
       COMPREPLY=( \$(compgen -W "top new" -- "\${cur}") ); return ;;
     --format)
-      COMPREPLY=( \$(compgen -W "srt vtt sbv srv2 ttml json" -- "\${cur}") ); return ;;
+      COMPREPLY=( \$(compgen -W "srt vtt sbv scc ttml json" -- "\${cur}") ); return ;;
     staqan-yt)
       COMPREPLY=( \$(compgen -W "${commands}" -- "\${cur}") )
       return
@@ -777,7 +777,7 @@ ${commandList}
       local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--caption-id[Caption ID]:id:( )' \\
-        '--format[Caption format]:format:(srt vtt sbv srv2 ttml json)' \\
+        '--format[Caption format]:format:(srt vtt sbv scc ttml json)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-channel)

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -906,7 +906,7 @@ async function listCaptions(videoId: string): Promise<CaptionInfo[]> {
 /**
  * Download caption content
  * @param captionId - Caption track ID
- * @param format - Output format (srt, vtt, sbv, srv2, ttml, or json for raw)
+ * @param format - Output format (srt, vtt, sbv, scc, ttml, or json for raw)
  * @returns Caption content as string
  */
 async function downloadCaption(captionId: string, format: CaptionFormat = 'json'): Promise<string> {

--- a/types/index.ts
+++ b/types/index.ts
@@ -283,7 +283,8 @@ export interface ChannelInfo {
 // Caption-related types
 export type CaptionTrackKind = 'standard' | 'ASR' | 'forced';
 
-export type CaptionFormat = 'srt' | 'vtt' | 'sbv' | 'scc' | 'ttml' | 'json';
+export const CAPTION_FORMATS = ['srt', 'vtt', 'sbv', 'scc', 'ttml', 'json'] as const;
+export type CaptionFormat = typeof CAPTION_FORMATS[number];
 
 export interface CaptionInfo {
   id: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -283,7 +283,7 @@ export interface ChannelInfo {
 // Caption-related types
 export type CaptionTrackKind = 'standard' | 'ASR' | 'forced';
 
-export type CaptionFormat = 'srt' | 'vtt' | 'sbv' | 'srv2' | 'ttml' | 'json';
+export type CaptionFormat = 'srt' | 'vtt' | 'sbv' | 'scc' | 'ttml' | 'json';
 
 export interface CaptionInfo {
   id: string;


### PR DESCRIPTION
## Summary
- Adds a whitelist check for `--format` in `get-caption` before any API call
- Invalid values now exit immediately with a clear error message instead of producing a misleading `caption-not-found` API error
- Corrects the valid format list: replaces `srv2` (not in YouTube API docs) with `scc`; keeps `json` as the CLI-level "return raw" default

## Valid formats (per [YouTube API docs](https://developers.google.com/youtube/v3/docs/captions/download))
`srt`, `vtt`, `sbv`, `scc`, `ttml`, `json`

## Test plan
- [ ] `staqan-yt get-caption --caption-id <id> --format invalid` → exits with `Invalid format 'invalid'. Valid: srt, vtt, sbv, scc, ttml, json`
- [ ] `staqan-yt get-caption --caption-id <id> --format srt` → proceeds normally
- [ ] `staqan-yt get-caption --caption-id <id>` (no format) → defaults to `json`, proceeds normally

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `get-caption --format` validation against the supported caption formats (srt, vtt, sbv, scc, ttml, json), returning an error for unsupported values.
* **Bug Fixes**
  * Improved caption download error messaging for restricted caption permissions, clarifying the limitation when captions aren’t available from the authenticated channel.
* **Documentation**
  * Updated `get-caption` docs, examples, and shell completion suggestions to replace `srv2` with `scc`.
* **Chores**
  * Kept caption format metadata and completion lists consistent across the CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->