### PR TITLE
fix: remove --quality from get-thumbnail (#65)

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -352,7 +352,6 @@ program
   .command('get-thumbnail')
   .description('Get video thumbnail URLs')
   .requiredOption('--video-id <id>', 'Video ID')
-  .option('--quality <quality>', 'Specific quality (default, medium, high, standard, maxres)')
   .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('get-thumbnail', getThumbnail));

--- a/commands/get-thumbnail.ts
+++ b/commands/get-thumbnail.ts
@@ -6,10 +6,11 @@ import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { GetThumbnailOptions } from '../types';
 
+const THUMBNAIL_SIZES = ['default', 'medium', 'high', 'standard', 'maxres'] as const;
+
 async function getThumbnailCommand(options: GetThumbnailOptions): Promise<void> {
   initCommand(options);
 
-  // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
     error('Required: --video-id');
@@ -43,11 +44,9 @@ async function getThumbnailCommand(options: GetThumbnailOptions): Promise<void> 
 
     const outputFormat = await getOutputFormat(options.output);
 
-    // Prepare flattened thumbnail data for structured formats
     const thumbnailData: Array<{ quality: string; url: string; width?: number; height?: number }> = [];
     if (thumbnails) {
-      const sizes = ['default', 'medium', 'high', 'standard', 'maxres'] as const;
-      sizes.forEach(size => {
+      THUMBNAIL_SIZES.forEach(size => {
         const thumbnail = thumbnails[size];
         if (thumbnail && thumbnail.url) {
           thumbnailData.push({
@@ -62,7 +61,7 @@ async function getThumbnailCommand(options: GetThumbnailOptions): Promise<void> 
 
     switch (outputFormat) {
       case 'json':
-        console.log(formatJson({ videoId: parsedId, title, thumbnails }));
+        console.log(formatJson({ videoId: parsedId, title, thumbnails: thumbnailData }));
         break;
 
       case 'table':
@@ -99,18 +98,6 @@ async function getThumbnailCommand(options: GetThumbnailOptions): Promise<void> 
             }
             console.log('');
           });
-
-          // If quality option specified, show only that one
-          if (options.quality) {
-            const quality = options.quality.toLowerCase();
-            const selectedThumb = thumbnailData.find(t => t.quality === quality);
-            if (selectedThumb) {
-              console.log(chalk.bold(`Selected Quality (${quality}):`));
-              console.log(chalk.blue(selectedThumb.url));
-            } else {
-              console.log(chalk.yellow(`No thumbnail found for quality: ${options.quality}`));
-            }
-          }
         }
         console.log('');
         break;

--- a/docs/commands/content-management.md
+++ b/docs/commands/content-management.md
@@ -155,26 +155,21 @@ staqan-yt get-thumbnail --video-id <videoId>
 ### Options
 
 - `--video-id <id>` - YouTube video ID or video URL (required)
-
-- `--quality <quality>` - Specific quality (default, medium, high, standard, maxres)
-- `--output <format>` - Output format: json, table, text, pretty (default: pretty)
+- `--output <format>` - Output format: json, table, text, pretty, csv (default: pretty)
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
 
 ### Examples
 
 ```bash
-# Get all thumbnail qualities
+# List all thumbnail qualities
 staqan-yt get-thumbnail --video-id dQw4w9WgXcQ
-
-# Get specific quality
-staqan-yt get-thumbnail --video-id dQw4w9WgXcQ --quality maxres
 
 # Export to JSON
 staqan-yt get-thumbnail --video-id dQw4w9WgXcQ --output json
 
-# Get URL only (text format)
-staqan-yt get-thumbnail --video-id dQw4w9WgXcQ --quality maxres --output text
+# Tab-separated URLs (for scripting)
+staqan-yt get-thumbnail --video-id dQw4w9WgXcQ --output text
 ```
 
 ### Thumbnail Qualities
@@ -187,35 +182,38 @@ staqan-yt get-thumbnail --video-id dQw4w9WgXcQ --quality maxres --output text
 | `standard` | 640x480 | High quality |
 | `maxres` | 1280x720 | Best quality |
 
-### Output Structure
+### Output Structure (JSON)
 
 ```json
 {
-  "default": "https://i.ytimg.com/vi/dQw4w9WgXcQ/default.jpg",
-  "medium": "https://i.ytimg.com/vi/dQw4w9WgXcQ/mqdefault.jpg",
-  "high": "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
-  "standard": "https://i.ytimg.com/vi/dQw4w9WgXcQ/sddefault.jpg",
-  "maxres": "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
+  "videoId": "dQw4w9WgXcQ",
+  "title": "Never Gonna Give You Up",
+  "thumbnails": [
+    { "quality": "default", "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/default.jpg", "width": 120, "height": 90 },
+    { "quality": "maxres", "url": "https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg", "width": 1280, "height": 720 }
+  ]
 }
 ```
 
 ### Use Cases
 
-- **Download thumbnails** - Save images for analysis
+- **Browse available URLs** - Pick the right quality for your use case
 - **A/B testing** - Compare thumbnail performance
 - **Social media** - Use thumbnails for promotion
-- **Archive** - Backup all thumbnail versions
+- **Scripting** - Feed URLs into curl/wget for download
 
-### Download Thumbnails
+### Download a Thumbnail
+
+To download the maxres thumbnail:
 
 ```bash
-# Get URL and download
-url=$(staqan-yt get-thumbnail --video-id VIDEO_ID --quality maxres --output text)
+# Get the maxres URL and download
+url=$(staqan-yt get-thumbnail --video-id VIDEO_ID --output text | grep maxres | cut -f2)
 curl -o thumbnail.jpg "$url"
 
 # Download all qualities
 staqan-yt get-thumbnail --video-id VIDEO_ID --output json | \
-  jq -r '.[]' | \
+  jq -r '.thumbnails[] | .url' | \
   while read url; do
     filename=$(basename "$url")
     curl -o "$filename" "$url"
@@ -353,7 +351,7 @@ done
 staqan-yt list-videos @yourchannel --output json | \
   jq -r '.[].id' | \
   while read id; do
-    url=$(staqan-yt get-thumbnail --video-id "$id" --quality maxres --output text)
+    url=$(staqan-yt get-thumbnail --video-id "$id" --output text | grep maxres | cut -f2)
     curl -o "${id}.jpg" "$url"
   done
 ```

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -132,7 +132,7 @@ export function getCommandOptions(command: string): string[] {
     'list-comments': ['--limit', '-l', '--sort', '-s', ...outputOptions, ...verboseOption],
     'get-video-tags': [...outputOptions, ...verboseOption],
     'update-video-tags': ['--replace', '--add', '--remove', '--dry-run', '--yes', '-y', ...outputOptions, ...verboseOption],
-    'get-thumbnail': ['--quality', ...outputOptions, ...verboseOption],
+    'get-thumbnail': [...outputOptions, ...verboseOption],
     'get-playlist': [...outputOptions, ...verboseOption],
     'get-playlists': [...outputOptions, ...verboseOption],
     'list-playlists': ['--channel', '--limit', '-l', '--privacy', ...outputOptions, ...verboseOption],
@@ -292,8 +292,6 @@ _staqa_nyt_completion() {
       ;;
     --privacy)
       COMPREPLY=( \$(compgen -W "public private unlisted" -- "\${cur}") ); return ;;
-    --quality)
-      COMPREPLY=( \$(compgen -W "maxres standard high medium default" -- "\${cur}") ); return ;;
     --sort|-s)
       COMPREPLY=( \$(compgen -W "top new" -- "\${cur}") ); return ;;
     --format)
@@ -330,7 +328,7 @@ _staqa_nyt_completion() {
       COMPREPLY=( \$(compgen -W "--video-id --replace --add --remove --dry-run --yes --output --verbose" -- "\${cur}") )
       ;;
     get-thumbnail)
-      COMPREPLY=( \$(compgen -W "--video-id --quality --output --verbose" -- "\${cur}") )
+      COMPREPLY=( \$(compgen -W "--video-id --output --verbose" -- "\${cur}") )
       ;;
     get-playlist)
       COMPREPLY=( \$(compgen -W "--playlist-id --output --verbose" -- "\${cur}") )
@@ -671,7 +669,6 @@ ${commandList}
       local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--video-id[Video ID]: :_staqan_yt_video_ids' \\
-        '--quality[Thumbnail quality]:quality:(maxres standard high medium default)' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;

--- a/types/index.ts
+++ b/types/index.ts
@@ -209,9 +209,7 @@ export interface UpdateTagsOptions extends VerboseOption, VideoIdOption {
 }
 
 // Thumbnail command options
-export interface GetThumbnailOptions extends OutputOption, VerboseOption, VideoIdOption {
-  quality?: string;
-}
+export interface GetThumbnailOptions extends OutputOption, VerboseOption, VideoIdOption {}
 
 export interface UpdateThumbnailOptions extends VerboseOption {
   file: string;


### PR DESCRIPTION
## Summary
- Removed `--quality` from `get-thumbnail` — it's a metadata listing command, so showing all available thumbnail URLs is the right behaviour; filtering by quality doesn't make sense here
- Downloading a specific quality will be a separate `download-thumbnail` command (defaulting to `maxres`, saving as `{videoId}_maxres.jpg`)
- Normalised JSON output to the same flat array shape used by table/csv/text

## Test plan
- [ ] `staqan-yt get-thumbnail --video-id <id>` → lists all quality levels in all output formats
- [ ] `staqan-yt get-thumbnail --video-id <id> --quality maxres` → unknown flag error from Commander

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **CSV** output format for the **get-thumbnail** command.
  * Improved **JSON** output to return thumbnail metadata in a richer structure (including `videoId`, `title`, and per-thumbnail details like quality, URL, width, and height).

* **Changes**
  * Removed the **`--quality`** option from **get-thumbnail** (including shell autocompletion behavior).

* **Documentation**
  * Updated **get-thumbnail** command docs and examples to reflect the new output formats and `--quality` removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->