### PR TITLE
feat: add download-thumbnail command

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -22,6 +22,7 @@ import getVideoRetention = require('../commands/get-video-retention');
 import getVideoTags = require('../commands/get-video-tags');
 import updateVideoTags = require('../commands/update-video-tags');
 import getThumbnail = require('../commands/get-thumbnail');
+import downloadThumbnail = require('../commands/download-thumbnail');
 import mcpCommand = require('../commands/mcp');
 import getPlaylistCommand = require('../commands/get-playlist');
 import getPlaylistsCommand = require('../commands/get-playlists');
@@ -355,6 +356,15 @@ program
   .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('get-thumbnail', getThumbnail));
+
+program
+  .command('download-thumbnail')
+  .description('Download a video thumbnail image to disk')
+  .requiredOption('--video-id <id>', 'Video ID')
+  .option('--quality <quality>', 'Thumbnail quality: default, medium, high, standard, maxres (default: maxres)')
+  .option('--path <dir>', 'Output directory (default: current working directory)')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action(withHelpWrapper('download-thumbnail', downloadThumbnail));
 
 // MCP server command
 program

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -363,6 +363,7 @@ program
   .requiredOption('--video-id <id>', 'Video ID')
   .option('--quality <quality>', 'Thumbnail quality: default, medium, high, standard, maxres (default: maxres)')
   .option('--path <dir>', 'Output directory (default: current working directory)')
+  .option('--output <format>', 'Output format: json, text, pretty (default: pretty)')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('download-thumbnail', downloadThumbnail));
 

--- a/commands/download-thumbnail.ts
+++ b/commands/download-thumbnail.ts
@@ -29,12 +29,18 @@ async function downloadFile(url: string, destPath: string): Promise<void> {
         }
 
         const file = createWriteStream(tempPath);
+        const fail = (err: Error) => {
+          reject(err);
+          response.destroy();
+          file.destroy();
+        };
+
+        response.once('error', fail);
         response.pipe(file);
 
         file.on('finish', () => file.close());
         file.on('close', resolve);
-
-        file.on('error', reject);
+        file.once('error', fail);
       });
 
       req.setTimeout(30_000, () => {

--- a/commands/download-thumbnail.ts
+++ b/commands/download-thumbnail.ts
@@ -1,0 +1,138 @@
+import chalk from 'chalk';
+import https from 'https';
+import http from 'http';
+import { createWriteStream } from 'fs';
+import { unlink } from 'fs/promises';
+import path from 'path';
+import { getAuthenticatedClient } from '../lib/auth';
+import { google } from 'googleapis';
+import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { DownloadThumbnailOptions } from '../types';
+
+const QUALITY_ORDER = ['maxres', 'standard', 'high', 'medium', 'default'] as const;
+type Quality = typeof QUALITY_ORDER[number];
+
+const VALID_QUALITIES = new Set<string>(QUALITY_ORDER);
+
+async function downloadFile(url: string, destPath: string): Promise<void> {
+  const parsedUrl = new URL(url);
+  const transport = parsedUrl.protocol === 'https:' ? https : http;
+
+  await new Promise<void>((resolve, reject) => {
+    transport.get(url, (response) => {
+      if (response.statusCode !== 200) {
+        unlink(destPath).catch(() => {});
+        reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
+        return;
+      }
+
+      const file = createWriteStream(destPath);
+      response.pipe(file);
+
+      file.on('finish', () => {
+        file.close();
+        resolve();
+      });
+
+      file.on('error', (err) => {
+        unlink(destPath).catch(() => {});
+        reject(err);
+      });
+    }).on('error', (err) => {
+      unlink(destPath).catch(() => {});
+      reject(err);
+    });
+  });
+}
+
+async function downloadThumbnailCommand(options: DownloadThumbnailOptions): Promise<void> {
+  initCommand(options);
+
+  if (!options.videoId) {
+    error('Required: --video-id');
+    process.exit(1);
+  }
+
+  const quality: Quality = (options.quality as Quality) || 'maxres';
+  if (!VALID_QUALITIES.has(quality)) {
+    error(`Invalid --quality "${quality}". Valid values: ${QUALITY_ORDER.join(', ')}`);
+    process.exit(1);
+  }
+
+  const outputDir = options.path ? path.resolve(options.path) : process.cwd();
+
+  await withSpinner('Fetching thumbnail URL...', 'Failed to download thumbnail', async (spinner) => {
+    const parsedId = parseVideoId(options.videoId!);
+    debug('Parsed video ID', parsedId);
+
+    const auth = await getAuthenticatedClient();
+    const youtube = google.youtube({ version: 'v3', auth });
+
+    const response = await youtube.videos.list({
+      part: ['snippet'],
+      id: [parsedId],
+    });
+
+    if (!response.data.items || response.data.items.length === 0) {
+      spinner.fail('Video not found');
+      error(`No video found with ID: ${parsedId}`);
+      process.exit(1);
+    }
+
+    const thumbnails = response.data.items[0].snippet?.thumbnails;
+    if (!thumbnails) {
+      spinner.fail('No thumbnails available');
+      error('No thumbnail data returned for this video');
+      process.exit(1);
+    }
+
+    // Find the best available quality, falling back down the order if not present
+    let resolvedQuality: Quality | null = null;
+    let thumbnailUrl: string | null = null;
+
+    if (thumbnails[quality]?.url) {
+      resolvedQuality = quality;
+      thumbnailUrl = thumbnails[quality]!.url!;
+    } else {
+      const startIdx = QUALITY_ORDER.indexOf(quality);
+      for (let i = startIdx + 1; i < QUALITY_ORDER.length; i++) {
+        const q = QUALITY_ORDER[i];
+        if (thumbnails[q]?.url) {
+          resolvedQuality = q;
+          thumbnailUrl = thumbnails[q]!.url!;
+          break;
+        }
+      }
+    }
+
+    if (!resolvedQuality || !thumbnailUrl) {
+      spinner.fail('No thumbnail available');
+      error(`No thumbnail found for video: ${parsedId}`);
+      process.exit(1);
+    }
+
+    if (resolvedQuality !== quality) {
+      spinner.text = `Quality "${quality}" not available, falling back to "${resolvedQuality}"...`;
+    }
+
+    const filename = `${parsedId}_${resolvedQuality}.jpg`;
+    const destPath = path.join(outputDir, filename);
+
+    debug('Downloading from', thumbnailUrl);
+    debug('Saving to', destPath);
+
+    spinner.text = `Downloading ${resolvedQuality} thumbnail...`;
+    await downloadFile(thumbnailUrl, destPath);
+
+    spinner.succeed('Thumbnail downloaded');
+    console.log('');
+
+    if (resolvedQuality !== quality) {
+      console.log(chalk.yellow(`Note: "${quality}" quality not available; used "${resolvedQuality}" instead.`));
+    }
+    console.log(chalk.gray('Saved: ') + chalk.green(destPath));
+    console.log('');
+  });
+}
+
+export = downloadThumbnailCommand;

--- a/commands/download-thumbnail.ts
+++ b/commands/download-thumbnail.ts
@@ -31,10 +31,8 @@ async function downloadFile(url: string, destPath: string): Promise<void> {
         const file = createWriteStream(tempPath);
         response.pipe(file);
 
-        file.on('finish', () => {
-          file.close();
-          resolve();
-        });
+        file.on('finish', () => file.close());
+        file.on('close', resolve);
 
         file.on('error', reject);
       });

--- a/commands/download-thumbnail.ts
+++ b/commands/download-thumbnail.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import https from 'https';
 import http from 'http';
 import { createWriteStream } from 'fs';
-import { unlink } from 'fs/promises';
+import { rename, unlink } from 'fs/promises';
 import path from 'path';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
@@ -17,32 +17,39 @@ const VALID_QUALITIES = new Set<string>(QUALITY_ORDER);
 async function downloadFile(url: string, destPath: string): Promise<void> {
   const parsedUrl = new URL(url);
   const transport = parsedUrl.protocol === 'https:' ? https : http;
+  const tempPath = `${destPath}.${process.pid}.${Date.now()}.tmp`;
 
-  await new Promise<void>((resolve, reject) => {
-    transport.get(url, (response) => {
-      if (response.statusCode !== 200) {
-        unlink(destPath).catch(() => {});
-        reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
-        return;
-      }
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const req = transport.get(url, (response) => {
+        if (response.statusCode !== 200) {
+          response.resume();
+          reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
+          return;
+        }
 
-      const file = createWriteStream(destPath);
-      response.pipe(file);
+        const file = createWriteStream(tempPath);
+        response.pipe(file);
 
-      file.on('finish', () => {
-        file.close();
-        resolve();
+        file.on('finish', () => {
+          file.close();
+          resolve();
+        });
+
+        file.on('error', reject);
       });
 
-      file.on('error', (err) => {
-        unlink(destPath).catch(() => {});
-        reject(err);
+      req.setTimeout(30_000, () => {
+        req.destroy(new Error('Thumbnail download timed out'));
       });
-    }).on('error', (err) => {
-      unlink(destPath).catch(() => {});
-      reject(err);
+      req.on('error', reject);
     });
-  });
+
+    await rename(tempPath, destPath);
+  } catch (err) {
+    await unlink(tempPath).catch(() => {});
+    throw err;
+  }
 }
 
 async function downloadThumbnailCommand(options: DownloadThumbnailOptions): Promise<void> {

--- a/commands/download-thumbnail.ts
+++ b/commands/download-thumbnail.ts
@@ -3,10 +3,13 @@ import https from 'https';
 import http from 'http';
 import { createWriteStream } from 'fs';
 import { rename, unlink } from 'fs/promises';
+import { randomUUID } from 'crypto';
 import path from 'path';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
 import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatJson } from '../lib/formatters';
 import { DownloadThumbnailOptions } from '../types';
 
 const QUALITY_ORDER = ['maxres', 'standard', 'high', 'medium', 'default'] as const;
@@ -17,7 +20,7 @@ const VALID_QUALITIES = new Set<string>(QUALITY_ORDER);
 async function downloadFile(url: string, destPath: string): Promise<void> {
   const parsedUrl = new URL(url);
   const transport = parsedUrl.protocol === 'https:' ? https : http;
-  const tempPath = `${destPath}.${process.pid}.${Date.now()}.tmp`;
+  const tempPath = `${destPath}.${randomUUID()}.tmp`;
 
   try {
     await new Promise<void>((resolve, reject) => {
@@ -71,6 +74,7 @@ async function downloadThumbnailCommand(options: DownloadThumbnailOptions): Prom
   }
 
   const outputDir = options.path ? path.resolve(options.path) : process.cwd();
+  const outputFormat = await getOutputFormat(options.output);
 
   await withSpinner('Fetching thumbnail URL...', 'Failed to download thumbnail', async (spinner) => {
     const parsedId = parseVideoId(options.videoId!);
@@ -136,13 +140,28 @@ async function downloadThumbnailCommand(options: DownloadThumbnailOptions): Prom
     await downloadFile(thumbnailUrl, destPath);
 
     spinner.succeed('Thumbnail downloaded');
-    console.log('');
 
-    if (resolvedQuality !== quality) {
-      console.log(chalk.yellow(`Note: "${quality}" quality not available; used "${resolvedQuality}" instead.`));
+    const result = { videoId: parsedId, quality: resolvedQuality, path: destPath };
+
+    switch (outputFormat) {
+      case 'json':
+        console.log(formatJson(result));
+        break;
+
+      case 'text':
+        console.log(destPath);
+        break;
+
+      case 'pretty':
+      default:
+        console.log('');
+        if (resolvedQuality !== quality) {
+          console.log(chalk.yellow(`Note: "${quality}" quality not available; used "${resolvedQuality}" instead.`));
+        }
+        console.log(chalk.gray('Saved: ') + chalk.green(destPath));
+        console.log('');
+        break;
     }
-    console.log(chalk.gray('Saved: ') + chalk.green(destPath));
-    console.log('');
   });
 }
 

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import https from 'https';
 import http from 'http';
 import { rename, unlink, writeFile } from 'fs/promises';
+import { randomUUID } from 'crypto';
 import path from 'path';
 import {
   CallToolRequestSchema,
@@ -1210,7 +1211,7 @@ async function handleToolCall(name: string, args: any) {
 
       if (args.filePath) {
         const dest = path.resolve(args.filePath);
-        const tempDest = `${dest}.${process.pid}.${Date.now()}.tmp`;
+        const tempDest = `${dest}.${randomUUID()}.tmp`;
         try {
           await writeFile(tempDest, imageBytes);
           await rename(tempDest, dest);

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -1,5 +1,10 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import https from 'https';
+import http from 'http';
+import { createWriteStream } from 'fs';
+import { unlink } from 'fs/promises';
+import path from 'path';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -396,6 +401,29 @@ const TOOLS: Tool[] = [
           type: 'string',
           description: 'Specific quality to return (optional): default, medium, high, standard, or maxres',
           enum: ['default', 'medium', 'high', 'standard', 'maxres'],
+        },
+      },
+      required: ['videoId'],
+    },
+  },
+  {
+    name: 'youtube_download_thumbnail',
+    description: 'Download a video thumbnail as a JPEG image. Without filePath, returns the image inline; with filePath, saves to disk and returns the path.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        videoId: {
+          type: 'string',
+          description: 'YouTube video ID (11 characters)',
+        },
+        quality: {
+          type: 'string',
+          description: 'Thumbnail size quality (default: maxres). Falls back to the next available quality if the requested one is not present.',
+          enum: ['default', 'medium', 'high', 'standard', 'maxres'],
+        },
+        filePath: {
+          type: 'string',
+          description: 'Absolute path or path relative to cwd to save the JPEG to. Omit to receive the image inline.',
         },
       },
       required: ['videoId'],
@@ -1110,6 +1138,93 @@ async function handleToolCall(name: string, args: any) {
             type: 'text',
             text: JSON.stringify({ videoId: parsedId, title, thumbnails }, null, 2),
           },
+        ],
+      };
+    }
+
+    case 'youtube_download_thumbnail': {
+      const QUALITY_ORDER = ['maxres', 'standard', 'high', 'medium', 'default'] as const;
+      type ThumbQuality = typeof QUALITY_ORDER[number];
+
+      const parsedId = parseVideoId(args.videoId);
+      const requestedQuality: ThumbQuality = (args.quality as ThumbQuality) || 'maxres';
+
+      const thumbResponse = await youtube.videos.list({
+        part: ['snippet'],
+        id: [parsedId],
+      });
+
+      if (!thumbResponse.data.items || thumbResponse.data.items.length === 0) {
+        throw new Error(`Video not found: ${parsedId}`);
+      }
+
+      const thumbnails = thumbResponse.data.items[0].snippet?.thumbnails;
+      if (!thumbnails) {
+        throw new Error(`No thumbnail data for video: ${parsedId}`);
+      }
+
+      let resolvedQuality: ThumbQuality | null = null;
+      let thumbnailUrl: string | null = null;
+
+      if (thumbnails[requestedQuality]?.url) {
+        resolvedQuality = requestedQuality;
+        thumbnailUrl = thumbnails[requestedQuality]!.url!;
+      } else {
+        const startIdx = QUALITY_ORDER.indexOf(requestedQuality);
+        for (let i = startIdx + 1; i < QUALITY_ORDER.length; i++) {
+          const q = QUALITY_ORDER[i];
+          if (thumbnails[q]?.url) {
+            resolvedQuality = q;
+            thumbnailUrl = thumbnails[q]!.url!;
+            break;
+          }
+        }
+      }
+
+      if (!resolvedQuality || !thumbnailUrl) {
+        throw new Error(`No thumbnail available for video: ${parsedId}`);
+      }
+
+      const imageBytes = await new Promise<Buffer>((resolve, reject) => {
+        const parsedUrl = new URL(thumbnailUrl!);
+        const transport = parsedUrl.protocol === 'https:' ? https : http;
+        transport.get(thumbnailUrl!, (res) => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
+            return;
+          }
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => resolve(Buffer.concat(chunks)));
+          res.on('error', reject);
+        }).on('error', reject);
+      });
+
+      if (args.filePath) {
+        const dest = path.resolve(args.filePath);
+        await new Promise<void>((resolve, reject) => {
+          const file = createWriteStream(dest);
+          file.write(imageBytes, (err) => {
+            if (err) { unlink(dest).catch(() => {}); reject(err); return; }
+            file.end(() => resolve());
+          });
+          file.on('error', (err) => { unlink(dest).catch(() => {}); reject(err); });
+        });
+        const note = resolvedQuality !== requestedQuality
+          ? ` (requested "${requestedQuality}", used "${resolvedQuality}")`
+          : '';
+        return {
+          content: [{ type: 'text', text: `Saved thumbnail to ${dest}${note}.` }],
+        };
+      }
+
+      const note = resolvedQuality !== requestedQuality
+        ? ` (requested "${requestedQuality}", used "${resolvedQuality}")`
+        : '';
+      return {
+        content: [
+          { type: 'text', text: `Thumbnail for ${parsedId} — quality: ${resolvedQuality}${note}` },
+          { type: 'image', data: imageBytes.toString('base64'), mimeType: 'image/jpeg' },
         ],
       };
     }

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -2,8 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import https from 'https';
 import http from 'http';
-import { createWriteStream } from 'fs';
-import { unlink } from 'fs/promises';
+import { rename, unlink, writeFile } from 'fs/promises';
 import path from 'path';
 import {
   CallToolRequestSchema,
@@ -1147,7 +1146,11 @@ async function handleToolCall(name: string, args: any) {
       type ThumbQuality = typeof QUALITY_ORDER[number];
 
       const parsedId = parseVideoId(args.videoId);
-      const requestedQuality: ThumbQuality = (args.quality as ThumbQuality) || 'maxres';
+      const requestedQualityInput = args.quality ?? 'maxres';
+      if (!(QUALITY_ORDER as readonly string[]).includes(requestedQualityInput)) {
+        throw new Error(`Invalid quality "${requestedQualityInput}". Valid values: ${QUALITY_ORDER.join(', ')}`);
+      }
+      const requestedQuality = requestedQualityInput as ThumbQuality;
 
       const thumbResponse = await youtube.videos.list({
         part: ['snippet'],
@@ -1188,8 +1191,9 @@ async function handleToolCall(name: string, args: any) {
       const imageBytes = await new Promise<Buffer>((resolve, reject) => {
         const parsedUrl = new URL(thumbnailUrl!);
         const transport = parsedUrl.protocol === 'https:' ? https : http;
-        transport.get(thumbnailUrl!, (res) => {
+        const req = transport.get(thumbnailUrl!, (res) => {
           if (res.statusCode !== 200) {
+            res.resume();
             reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
             return;
           }
@@ -1197,19 +1201,23 @@ async function handleToolCall(name: string, args: any) {
           res.on('data', (chunk: Buffer) => chunks.push(chunk));
           res.on('end', () => resolve(Buffer.concat(chunks)));
           res.on('error', reject);
-        }).on('error', reject);
+        });
+        req.setTimeout(30_000, () => {
+          req.destroy(new Error('Thumbnail download timed out'));
+        });
+        req.on('error', reject);
       });
 
       if (args.filePath) {
         const dest = path.resolve(args.filePath);
-        await new Promise<void>((resolve, reject) => {
-          const file = createWriteStream(dest);
-          file.write(imageBytes, (err) => {
-            if (err) { unlink(dest).catch(() => {}); reject(err); return; }
-            file.end(() => resolve());
-          });
-          file.on('error', (err) => { unlink(dest).catch(() => {}); reject(err); });
-        });
+        const tempDest = `${dest}.${process.pid}.${Date.now()}.tmp`;
+        try {
+          await writeFile(tempDest, imageBytes);
+          await rename(tempDest, dest);
+        } catch (err) {
+          await unlink(tempDest).catch(() => {});
+          throw err;
+        }
         const note = resolvedQuality !== requestedQuality
           ? ` (requested "${requestedQuality}", used "${resolvedQuality}")`
           : '';

--- a/lib/customHelp.ts
+++ b/lib/customHelp.ts
@@ -49,6 +49,7 @@ const COMMAND_GROUPS: Record<string, string[]> = {
     'get-playlist',
     'get-playlists',
     'get-thumbnail',
+    'download-thumbnail',
     'get-video-tags',
     'update-video-tags',
   ],

--- a/types/index.ts
+++ b/types/index.ts
@@ -217,6 +217,11 @@ export interface UpdateThumbnailOptions extends VerboseOption {
   yes?: boolean;
 }
 
+export interface DownloadThumbnailOptions extends VerboseOption, VideoIdOption {
+  quality?: string;
+  path?: string;
+}
+
 // Comments command options
 export interface ListCommentsOptions extends OutputOption, VerboseOption, LimitOption, VideoIdOption {
   sort?: 'top' | 'new';

--- a/types/index.ts
+++ b/types/index.ts
@@ -217,7 +217,7 @@ export interface UpdateThumbnailOptions extends VerboseOption {
   yes?: boolean;
 }
 
-export interface DownloadThumbnailOptions extends VerboseOption, VideoIdOption {
+export interface DownloadThumbnailOptions extends OutputOption, VerboseOption, VideoIdOption {
   quality?: string;
   path?: string;
 }


### PR DESCRIPTION
## Summary

- Adds `download-thumbnail` CLI command: downloads a video thumbnail to disk as `{videoId}_{quality}.jpg`, defaulting to `maxres` with graceful fallback down the quality ladder
- Adds `youtube_download_thumbnail` MCP tool: follows Chrome DevTools `take_screenshot` behaviour — omit `filePath` to receive the JPEG inline as an image content block, provide `filePath` to save to disk and get the path back
- Registers the command in the `Content Management` help group alongside `get-thumbnail`

## Test plan

- [ ] `staqan-yt download-thumbnail --video-id <id>` saves `<id>_maxres.jpg` in cwd
- [ ] `--quality high` saves `<id>_high.jpg`; invalid quality exits with error
- [ ] `--path ~/thumbnails` saves to that directory
- [ ] Quality fallback: use a video without `maxres`; tool uses next available quality and prints a note
- [ ] MCP: call `youtube_download_thumbnail` without `filePath` → image content block returned
- [ ] MCP: call with `filePath` → file saved, path returned as text

Closing: #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `download-thumbnail` CLI command to download YouTube video thumbnails using `--video-id`.
  * Supports `--quality` (with automatic fallback to the next available quality) and `--path` to save the thumbnail to disk; also returns clear status when the requested quality isn’t available.
  * Introduced an MCP tool (`youtube_download_thumbnail`) that can either save the image to a file or return it inline as base64.
* **Improvements**
  * Updated command help so `download-thumbnail` is listed under Content Management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->