### PR TITLE
fix: reject invalid flags instead of silently falling back

### DIFF
--- a/commands/config.ts
+++ b/commands/config.ts
@@ -97,6 +97,17 @@ async function configCommand(
         process.exit(1);
       }
 
+      const validKeys: ConfigKey[] = ['default.channel', 'default.output', 'lock.timeout'];
+      if (!validKeys.includes(key as ConfigKey)) {
+        error(`Invalid config key: ${key}`);
+        console.log('');
+        console.log('Available keys:');
+        console.log('  default.channel  - Default channel handle or ID (e.g., @staqan)');
+        console.log('  default.output   - Default output format (json|table|text|pretty|csv)');
+        console.log('  lock.timeout     - Lock acquisition timeout in ms (default: 60000)');
+        process.exit(1);
+      }
+
       const currentValue = await getConfigValue(key as ConfigKey);
 
       if (currentValue !== undefined) {

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -155,8 +155,13 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       if (options.type) {
         reportTypes = reportTypes.filter(t => t.id === options.type);
         debug(`Filtering by single type: ${options.type}`);
-      } else if (options.types) {
-        const requestedIds = options.types.split(',');
+      } else if (options.types !== undefined) {
+        const requestedIds = options.types.split(',').map(s => s.trim()).filter(Boolean);
+        if (requestedIds.length === 0) {
+          spinner.fail('Invalid --types');
+          error('--types cannot be empty. Provide comma-separated type IDs or omit the flag.');
+          process.exit(1);
+        }
         reportTypes = reportTypes.filter(t => requestedIds.includes(t.id!));
         debug(`Filtering by multiple types: ${requestedIds.join(', ')}`);
       }

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -109,6 +109,12 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     let metrics: string;
     let reportName = '';
 
+    if (options.report && (options.dimensions || options.metrics)) {
+      spinner.fail('Conflicting options');
+      error('Cannot combine --report with --dimensions or --metrics. Use one or the other.');
+      process.exit(1);
+    }
+
     if (options.report) {
       // Use predefined report type
       const reportConfig = REPORT_TYPES[options.report];

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -25,6 +25,11 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
   }
 
   // Determine sort order
+  const validSorts = ['new', 'relevance'];
+  if (options.sort !== undefined && !validSorts.includes(options.sort)) {
+    error(`Invalid --sort "${options.sort}". Valid values: new, relevance`);
+    process.exit(1);
+  }
   const sortOrder = options.sort === 'new' ? 'time' : 'relevance';
   let limit: number;
   try { limit = parsePositiveInt(options.limit, 20); } catch (e) { error((e as Error).message); process.exit(1); }


### PR DESCRIPTION
## Summary

All 5 remaining silent-validation bugs from the June audit, fixed in one pass:

- **#68** `config get <bad-key>` — was printing `not set` for typos; now errors with the valid-key list (same as `config set` already did)
- **#66** `list-comments --sort <garbage>` — silently mapped anything that wasn't `new` to `relevance`; now errors immediately  
- **#70** `get-channel-analytics --report X --dimensions Y` — `--dimensions`/`--metrics` were silently ignored when `--report` was present; now exits with a clear conflict message
- **#71** `fetch-reports --types ""` — empty string is falsy so the filter branch was skipped and **all** report types were downloaded; now errors on empty/whitespace-only `--types`
- **#65** `get-thumbnail --quality` — confirmed this was a false positive; `download-thumbnail` (added in #83) already validates quality correctly; `get-thumbnail` has no `--quality` flag

## Test plan

- [x] `staqan-yt config get bad.key` → error listing valid keys ✅
- [x] `staqan-yt list-comments --video-id <id> --sort garbage` → error listing valid values ✅
- [x] `staqan-yt get-channel-analytics --channel @x --report demographics --dimensions "country"` → conflict error ✅
- [x] `staqan-yt fetch-reports --types ""` → empty-types error (no API calls made) ✅
- [x] All valid usages of the above commands still work as expected ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)