### PR TITLE
fix: address CodeRabbit review findings from #85

### DIFF
--- a/commands/config.ts
+++ b/commands/config.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { getConfig, getConfigValue, setConfigValue, DEFAULT_LOCK_TIMEOUT_MS } from '../lib/config';
 import { success, error, info, CACHE_DIR } from '../lib/utils';
-import { ConfigKey } from '../types';
+import { ConfigKey, CONFIG_KEYS, CONFIG_KEY_HELP } from '../types';
 import { installCompletion, detectShell } from '../lib/completion';
 
 async function invalidateChannelCache(): Promise<void> {
@@ -70,14 +70,13 @@ async function configCommand(
       }
 
       // Validate key
-      const validKeys: ConfigKey[] = ['default.channel', 'default.output', 'lock.timeout'];
-      if (!validKeys.includes(key as ConfigKey)) {
+      if (!CONFIG_KEYS.includes(key as ConfigKey)) {
         error(`Invalid config key: ${key}`);
         console.log('');
         console.log('Available keys:');
-        console.log('  default.channel  - Default channel handle or ID (e.g., @staqan)');
-        console.log('  default.output   - Default output format (json|table|text|pretty|csv)');
-        console.log('  lock.timeout     - Lock acquisition timeout in ms (default: 60000)');
+        CONFIG_KEYS.forEach(k => {
+          console.log(`  ${k.padEnd(18)} - ${CONFIG_KEY_HELP[k]}`);
+        });
         process.exit(1);
       }
 
@@ -97,14 +96,13 @@ async function configCommand(
         process.exit(1);
       }
 
-      const validKeys: ConfigKey[] = ['default.channel', 'default.output', 'lock.timeout'];
-      if (!validKeys.includes(key as ConfigKey)) {
+      if (!CONFIG_KEYS.includes(key as ConfigKey)) {
         error(`Invalid config key: ${key}`);
         console.log('');
         console.log('Available keys:');
-        console.log('  default.channel  - Default channel handle or ID (e.g., @staqan)');
-        console.log('  default.output   - Default output format (json|table|text|pretty|csv)');
-        console.log('  lock.timeout     - Lock acquisition timeout in ms (default: 60000)');
+        CONFIG_KEYS.forEach(k => {
+          console.log(`  ${k.padEnd(18)} - ${CONFIG_KEY_HELP[k]}`);
+        });
         process.exit(1);
       }
 

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -6,6 +6,13 @@ import { success, error, info, CACHE_DIR } from '../lib/utils';
 import { ConfigKey, CONFIG_KEYS, CONFIG_KEY_HELP } from '../types';
 import { installCompletion, detectShell } from '../lib/completion';
 
+function printAvailableConfigKeys(): void {
+  console.log('Available keys:');
+  CONFIG_KEYS.forEach(k => {
+    console.log(`  ${k.padEnd(18)} - ${CONFIG_KEY_HELP[k]}`);
+  });
+}
+
 async function invalidateChannelCache(): Promise<void> {
   // Per-channel completion caches (video-id, playlist-id) are channel-specific.
   // When the default channel changes, wipe them all so stale IDs aren't suggested.
@@ -62,10 +69,7 @@ async function configCommand(
       if (!key || !value) {
         error('Usage: staqan-yt config set <key> <value>');
         console.log('');
-        console.log('Available keys:');
-        console.log('  default.channel  - Default channel handle or ID (e.g., @staqan)');
-        console.log('  default.output   - Default output format (json|table|text|pretty|csv)');
-        console.log('  lock.timeout     - Lock acquisition timeout in ms (default: 60000)');
+        printAvailableConfigKeys();
         process.exit(1);
       }
 
@@ -73,10 +77,7 @@ async function configCommand(
       if (!CONFIG_KEYS.includes(key as ConfigKey)) {
         error(`Invalid config key: ${key}`);
         console.log('');
-        console.log('Available keys:');
-        CONFIG_KEYS.forEach(k => {
-          console.log(`  ${k.padEnd(18)} - ${CONFIG_KEY_HELP[k]}`);
-        });
+        printAvailableConfigKeys();
         process.exit(1);
       }
 
@@ -99,10 +100,7 @@ async function configCommand(
       if (!CONFIG_KEYS.includes(key as ConfigKey)) {
         error(`Invalid config key: ${key}`);
         console.log('');
-        console.log('Available keys:');
-        CONFIG_KEYS.forEach(k => {
-          console.log(`  ${k.padEnd(18)} - ${CONFIG_KEY_HELP[k]}`);
-        });
+        printAvailableConfigKeys();
         process.exit(1);
       }
 

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -162,6 +162,13 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
           error('--types cannot be empty. Provide comma-separated type IDs or omit the flag.');
           process.exit(1);
         }
+        const availableIds = new Set(reportTypes.map(t => t.id).filter((id): id is string => Boolean(id)));
+        const invalidIds = requestedIds.filter(id => !availableIds.has(id));
+        if (invalidIds.length > 0) {
+          spinner.fail('Invalid --types');
+          error(`Unknown report type ID(s): ${invalidIds.join(', ')}`);
+          process.exit(1);
+        }
         reportTypes = reportTypes.filter(t => requestedIds.includes(t.id!));
         debug(`Filtering by multiple types: ${requestedIds.join(', ')}`);
       }

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -109,7 +109,10 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     let metrics: string;
     let reportName = '';
 
-    if (options.report && (options.dimensions || options.metrics)) {
+    if (
+      options.report !== undefined &&
+      (options.dimensions !== undefined || options.metrics !== undefined)
+    ) {
       spinner.fail('Conflicting options');
       error('Cannot combine --report with --dimensions or --metrics. Use one or the other.');
       process.exit(1);

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -25,9 +25,9 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
   }
 
   // Determine sort order
-  const validSorts = ['new', 'relevance'];
+  const validSorts = ['new', 'top'];
   if (options.sort !== undefined && !validSorts.includes(options.sort)) {
-    error(`Invalid --sort "${options.sort}". Valid values: new, relevance`);
+    error(`Invalid --sort "${options.sort}". Valid values: new, top`);
     process.exit(1);
   }
   const sortOrder = options.sort === 'new' ? 'time' : 'relevance';

--- a/types/index.ts
+++ b/types/index.ts
@@ -350,6 +350,16 @@ export interface Config {
 
 export type ConfigKey = 'default.channel' | 'default.output' | 'lock.timeout';
 
+// Canonical list of all config keys for validation
+export const CONFIG_KEYS: ConfigKey[] = ['default.channel', 'default.output', 'lock.timeout'];
+
+// Help text for each config key
+export const CONFIG_KEY_HELP: Record<ConfigKey, string> = {
+	'default.channel': 'Default channel handle or ID (e.g., @staqan)',
+	'default.output': 'Default output format (json|table|text|pretty|csv)',
+	'lock.timeout': 'Lock acquisition timeout in ms (default: 60000)',
+};
+
 // Completion types
 export type CompletionType = 'video-id' | 'playlist-id' | 'report-type';
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -350,15 +350,15 @@ export interface Config {
 
 export type ConfigKey = 'default.channel' | 'default.output' | 'lock.timeout';
 
-// Canonical list of all config keys for validation
-export const CONFIG_KEYS: ConfigKey[] = ['default.channel', 'default.output', 'lock.timeout'];
-
 // Help text for each config key
 export const CONFIG_KEY_HELP: Record<ConfigKey, string> = {
 	'default.channel': 'Default channel handle or ID (e.g., @staqan)',
 	'default.output': 'Default output format (json|table|text|pretty|csv)',
 	'lock.timeout': 'Lock acquisition timeout in ms (default: 60000)',
 };
+
+// Derived from CONFIG_KEY_HELP so the two can never drift apart
+export const CONFIG_KEYS = Object.keys(CONFIG_KEY_HELP) as ConfigKey[];
 
 // Completion types
 export type CompletionType = 'video-id' | 'playlist-id' | 'report-type';


### PR DESCRIPTION
## Summary

Addresses all 4 issues found by CodeRabbit during review of PR #85:

1. **🟠 Major** - list-comments: accept documented `top` sort value
   - Changed validation from `['new', 'relevance']` to `['new', 'top']`  
   - `top` is the documented default in bin/staqan-yt.ts and lib/completion.ts
   - Previously rejected its own default value

2. **🟡 Minor** - get-channel-analytics: detect conflict by flag presence, not truthiness
   - Changed from `options.report && (options.dimensions || options.metrics)`
   - To: `options.report !== undefined && (options.dimensions !== undefined || options.metrics !== undefined)`
   - Now correctly catches `--report X --dimensions ""` as a conflict (empty string is still a flag)

3. **🟡 Minor** - fetch-reports: reject unknown type IDs instead of silently ignoring
   - Added validation to check requestedIds against availableIds before filtering  
   - Errors with list of unknown IDs if any don't match discovered report types
   - Previously `--types valid-id,typo` would silently fetch only `valid-id`

4. **🔵 Trivial** - config: centralize config key allowlist to avoid duplication
   - Export CONFIG_KEYS array and CONFIG_KEY_HELP from types/index.ts
   - Import and use in commands/config.ts for both set and get branches
   - Eliminates duplicate hardcoded arrays that could drift apart
   - Single source of truth for config key validation and help text

## Test plan

- [x] `staqan-yt list-comments --video-id <id> --sort top` → works (was rejected before)
- [x] `staqan-yt list-comments --video-id <id> --sort garbage` → still errors  
- [x] `staqan-yt get-channel-analytics --channel @x --report demographics --dimensions ""` → conflict error (was silent before)
- [x] `staqan-yt get-channel-analytics --channel @x --report demographics --metrics ""` → conflict error (was silent before)
- [x] `staqan-yt config get typo.key` → errors with centralized key list
- [x] `staqan-yt config get default.channel` → still works with centralized validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration commands now show valid settings and descriptions dynamically, with improved validation for invalid keys.
  * Report fetching now rejects unknown report type filters instead of ignoring them.
* **Bug Fixes**
  * Tightened command option validation to better catch conflicting inputs.
  * Updated comment sorting validation to match the supported sort options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->