### PR TITLE
fix: validate --content-type in get-channel-search-terms (#67)

### DIFF
--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -38,6 +38,16 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
   try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
   try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
 
+  // Validate --content-type against the allowlist. The type is already
+  // narrowed to 'all' | 'video' | 'shorts' in types/index.ts, but commander.js
+  // passes arbitrary strings through at runtime, so an unknown value would
+  // silently fall through to the 'all' branch via CONTENT_TYPE_FILTERS lookup.
+  const validContentTypes = Object.keys(CONTENT_TYPE_FILTERS).concat('all');
+  if (options.contentType !== undefined && !validContentTypes.includes(options.contentType)) {
+    error(`Invalid --content-type "${options.contentType}". Valid values: ${validContentTypes.join(', ')}`);
+    process.exit(1);
+  }
+
   await withSpinner('Resolving channel...', 'Failed to fetch channel search terms', async (spinner) => {
     // Resolve channel from arg or config default
     const channelArg = await requireChannel(options.channel);


### PR DESCRIPTION
Closes #67
Found while testing: #88

## Problem

`staqan-yt get-channel-search-terms --content-type invalid` silently returned all-content results with exit code 0, as if `--content-type all` had been requested.

Root cause: `commands/get-channel-search-terms.ts` looked the value up in `CONTENT_TYPE_FILTERS` and treated the resulting `undefined` as "no filter applied". The TypeScript type in `types/index.ts` (`'all' | 'video' | 'shorts'`) is purely compile-time — commander.js passes arbitrary strings through at runtime.

## Fix

Validate `--content-type` against the allowlist before any API calls. Mirrors the runtime validation pattern added in #85 / #86 for `list-comments --sort`, `fetch-reports --types`, etc.

```ts
const validContentTypes = Object.keys(CONTENT_TYPE_FILTERS).concat('all');
if (options.contentType !== undefined && !validContentTypes.includes(options.contentType)) {
  error(`Invalid --content-type "${options.contentType}". Valid values: ${validContentTypes.join(', ')}`);
  process.exit(1);
}
```

The allowlist is derived from `CONTENT_TYPE_FILTERS` itself (plus `'all'`), so adding a new content type means updating the filter map and nothing else.

## Verified

```
$ staqan-yt get-channel-search-terms --content-type invalid
✗ Invalid --content-type "invalid". Valid values: video, shorts, all
$ echo $?
1
```

- `--content-type invalid` → exit 1 with clear error ✓
- `--content-type foo` → exit 1 ✓
- `--content-type VIDEO` → exit 1 (case-sensitive, matches allowlist) ✓
- `--content-type all` → validation passes (unchanged behavior) ✓
- no `--content-type` → validation passes via `all` default (unchanged) ✓
- `--content-type video` / `--content-type shorts` → validation passes (unchanged)

## Out of scope (separate finding)

While smoke-testing the happy path I noticed that `--content-type video` and `--content-type shorts` both pass validation but the YouTube Analytics API rejects the filter with:

```
✗ Invalid value (LONG_FORM_CONTENT) given in field parameters.filters.
```

That's a separate bug — the filter values being sent to the API aren't accepted by the report. Tracked in #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the channel search command’s content-type option.
  * Invalid content-type values now return a clear error with the list of allowed values and stop execution.
  * Prevents unsupported content-type inputs from being treated as if no filter was selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->