### PR TITLE
fix: hoist jobs.list() and add RPM retry to fetch-reports

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -15,6 +15,7 @@ import { acquireLock, getLockPath } from '../lib/lock';
 import https from 'https';
 import { createWriteStream, unlinkSync } from 'fs';
 import { promises as fs } from 'fs';
+import { pipeline } from 'stream/promises';
 import { unlink } from 'fs/promises';
 import path from 'path';
 import chalk from 'chalk';
@@ -28,6 +29,18 @@ interface FetchReportsOptions {
   force?: boolean;
   verify?: boolean;
   verbose?: boolean;
+}
+
+/**
+ * Build a filesystem-safe temp path for a report download.
+ *
+ * `report.id` comes from an external API response and is interpolated into a
+ * temp filename. Strip anything outside [A-Za-z0-9._-] so a malicious or
+ * malformed ID (e.g. "../foo" or "id/with/slashes") can't escape /tmp.
+ */
+function safeTmpReportPath(reportId: string | null | undefined): string {
+  const safeId = String(reportId ?? 'report').replace(/[^A-Za-z0-9._-]/g, '_');
+  return path.join('/tmp', `${safeId}.csv`);
 }
 
 /**
@@ -80,15 +93,17 @@ function downloadOnce(
         }
 
         const file = createWriteStream(dest);
-        response.pipe(file);
-        file.on('finish', () => {
-          file.close();
-          resolve({ statusCode: 200, retryAfterSec: 0 });
-        });
-        file.on('error', (err) => {
-          unlink(dest).catch(() => {});
-          reject(err);
-        });
+        // Use pipeline (not .pipe) so a read-side error mid-stream rejects
+        // cleanly and tears down both ends — otherwise a partial file can
+        // survive and skip the retry path. See nodejs stream docs:
+        //   https://nodejs.org/api/stream.html#streamstreampipelinesource-transforms-destination-options
+        pipeline(response, file).then(
+          () => resolve({ statusCode: 200, retryAfterSec: 0 }),
+          (err) => {
+            unlink(dest).catch(() => {});
+            reject(err);
+          }
+        );
       })
       .on('error', (err) => {
         unlink(dest).catch(() => {});
@@ -114,7 +129,7 @@ async function downloadReport(
   report: { id?: string | null; downloadUrl?: string | null; startTime?: string | null; endTime?: string | null; createTime?: string | null },
   auth: { getAccessToken(): Promise<{ token?: string | null }> }
 ): Promise<{ csvData: string; headers: string[]; data: Record<string, string>[]; minDate: string; maxDate: string }> {
-  const tmpPath = path.join('/tmp', `${report.id}.csv`);
+  const tmpPath = safeTmpReportPath(report.id);
   const credentials = await auth.getAccessToken();
   const accessToken = credentials.token || '';
 
@@ -131,6 +146,17 @@ async function downloadReport(
         break;
       }
       // 429 from download host — exponential backoff, honoring Retry-After.
+      //
+      // Daily-quota exhaustion manifests as a 429 with a multi-thousand-second
+      // Retry-After (often ~86400s). Sleeping and retrying just hides the real
+      // problem, so abort immediately when the header says the wait is more
+      // than 30 minutes — that's clearly not an RPM hiccup.
+      if (result.retryAfterSec >= 30 * 60) {
+        throw new Error(
+          `YouTube Reporting download quota appears exhausted for ${report.id}. ` +
+          `Server Retry-After is ${result.retryAfterSec}s; aborting instead of retrying.`
+        );
+      }
       const expSec = Math.min(baseDelaySec * 2 ** (attempt - 1), maxDelaySec);
       const waitSec = result.retryAfterSec > 0
         ? Math.min(Math.max(result.retryAfterSec, expSec), maxDelaySec)

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, debug, success, warning, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange } from '../lib/utils';
+import { error, debug, success, warning, progress, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, withRateLimitRetry } from '../lib/utils';
 import {
   isReportCached,
   saveReportToCache,
@@ -14,6 +14,7 @@ import { getConfigValue, getLockTimeout } from '../lib/config';
 import { acquireLock, getLockPath } from '../lib/lock';
 import https from 'https';
 import { createWriteStream, unlinkSync } from 'fs';
+import { promises as fs } from 'fs';
 import { unlink } from 'fs/promises';
 import path from 'path';
 import chalk from 'chalk';
@@ -30,61 +31,135 @@ interface FetchReportsOptions {
 }
 
 /**
- * Download a report from YouTube
+ * Single-attempt HTTPS GET that streams the response body into `dest`.
+ * Resolves with the final HTTP status code (200 = success). Caller decides
+ * whether to retry based on the status.
+ *
+ * The YouTube Reporting download host doesn't return structured JSON errors,
+ * so we can't use isRateLimitError() here — we have to inspect
+ * `response.statusCode` and `response.headers['retry-after']` directly.
  */
-async function downloadReport(
-  report: { id?: string | null; downloadUrl?: string | null; startTime?: string | null; endTime?: string | null; createTime?: string | null },
-  auth: { getAccessToken(): Promise<{ token?: string | null }> }
-): Promise<{ csvData: string; headers: string[]; data: Record<string, string>[]; minDate: string; maxDate: string }> {
-  const tmpPath = path.join('/tmp', `${report.id}.csv`);
-
-  // Get access token for authenticated request
-  const credentials = await auth.getAccessToken();
-  const accessToken = credentials.token || '';
-
-  await new Promise<void>((resolve, reject) => {
-    const url = new URL(report.downloadUrl!);
-
-    debug(`Downloading from: ${report.downloadUrl}`);
+function downloadOnce(
+  downloadUrl: string,
+  accessToken: string,
+  dest: string
+): Promise<{ statusCode: number; retryAfterSec: number }> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(downloadUrl);
+    debug(`Downloading from: ${downloadUrl}`);
 
     const options = {
       hostname: url.hostname,
       path: url.pathname + url.search,
       headers: {
         'Authorization': `Bearer ${accessToken}`,
-      }
+      },
     };
 
-    https.get(options, (response) => {
-      debug(`Response status: ${response.statusCode}`);
+    https
+      .get(options, (response) => {
+        debug(`Response status: ${response.statusCode}`);
 
-      if (response.statusCode !== 200) {
-        unlink(tmpPath).catch(() => {});
-        reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
-        return;
-      }
+        // 429 = RPM limit. Surface the status + Retry-After header so the
+        // retry loop can decide. Drain the body so the socket closes cleanly.
+        if (response.statusCode === 429) {
+          response.resume();
+          unlink(dest).catch(() => {});
+          resolve({
+            statusCode: 429,
+            retryAfterSec: Number(response.headers['retry-after']) || 0,
+          });
+          return;
+        }
 
-      const file = createWriteStream(tmpPath);
-      response.pipe(file);
+        if (response.statusCode !== 200) {
+          response.resume();
+          unlink(dest).catch(() => {});
+          reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
+          return;
+        }
 
-      file.on('finish', () => {
-        file.close();
-        resolve();
-      });
-
-      file.on('error', (err) => {
-        unlink(tmpPath).catch(() => {});
+        const file = createWriteStream(dest);
+        response.pipe(file);
+        file.on('finish', () => {
+          file.close();
+          resolve({ statusCode: 200, retryAfterSec: 0 });
+        });
+        file.on('error', (err) => {
+          unlink(dest).catch(() => {});
+          reject(err);
+        });
+      })
+      .on('error', (err) => {
+        unlink(dest).catch(() => {});
         reject(err);
       });
-    }).on('error', (err) => {
-      unlink(tmpPath).catch(() => {});
-      reject(err);
-    });
   });
+}
 
-  // Parse CSV
-  const fs = await import('fs');
-  const csvData = fs.readFileSync(tmpPath, 'utf-8');
+/**
+ * Download a report from YouTube.
+ *
+ * Retries on HTTP 429 (RPM/minute quota) with exponential backoff: 5s → 10s
+ * → 20s → 40s → 80s, capped at 90s. If the server provides a Retry-After
+ * header, the larger of (header, exponential) is used. After 5 failed
+ * attempts we bail with a clear message instead of looping forever — daily
+ * quota exhaustion looks like the same 429 with a multi-thousand-second
+ * Retry-After, and the user should see that immediately rather than wait.
+ *
+ * Also retries on transient network errors (ECONNRESET / ETIMEDOUT / EAI_AGAIN)
+ * with a fixed 5s wait between attempts.
+ */
+async function downloadReport(
+  report: { id?: string | null; downloadUrl?: string | null; startTime?: string | null; endTime?: string | null; createTime?: string | null },
+  auth: { getAccessToken(): Promise<{ token?: string | null }> }
+): Promise<{ csvData: string; headers: string[]; data: Record<string, string>[]; minDate: string; maxDate: string }> {
+  const tmpPath = path.join('/tmp', `${report.id}.csv`);
+  const credentials = await auth.getAccessToken();
+  const accessToken = credentials.token || '';
+
+  const maxRetries = 5;
+  const baseDelaySec = 5;
+  const maxDelaySec = 90;
+
+  let success = false;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const result = await downloadOnce(report.downloadUrl!, accessToken, tmpPath);
+      if (result.statusCode === 200) {
+        success = true;
+        break;
+      }
+      // 429 from download host — exponential backoff, honoring Retry-After.
+      const expSec = Math.min(baseDelaySec * 2 ** (attempt - 1), maxDelaySec);
+      const waitSec = result.retryAfterSec > 0
+        ? Math.min(Math.max(result.retryAfterSec, expSec), maxDelaySec)
+        : expSec;
+      if (attempt >= maxRetries) {
+        throw new Error(
+          `YouTube Reporting download quota exhausted after ${maxRetries} retries ` +
+          `(last wait: ${waitSec}s) for ${report.id}. Aborting.`
+        );
+      }
+      progress(`Download RPM 429 for ${report.id}, backing off ${waitSec}s (attempt ${attempt}/${maxRetries})...`);
+      await new Promise((r) => setTimeout(r, waitSec * 1000));
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if ((code === 'ECONNRESET' || code === 'ETIMEDOUT' || code === 'EAI_AGAIN') && attempt < maxRetries) {
+        progress(`Download network error (${code}) for ${report.id}, retrying in 5s (attempt ${attempt}/${maxRetries})...`);
+        await new Promise((r) => setTimeout(r, 5000));
+        continue;
+      }
+      // Non-retriable — bubble up so the caller logs it.
+      throw err;
+    }
+  }
+
+  if (!success) {
+    throw new Error(`Download failed for ${report.id} after ${maxRetries} attempts`);
+  }
+
+  const csvData = await fs.readFile(tmpPath, 'utf-8');
   const parsed = parseCsvAndExtractRange(csvData);
 
   // Cleanup
@@ -145,9 +220,10 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       // Step 1: Discover report types
       spinner.text = 'Discovering report types...';
 
-      const typesResponse = await youtubeReporting.reportTypes.list({
-        onBehalfOfContentOwner: undefined,
-      });
+      const typesResponse = await withRateLimitRetry(
+        () => youtubeReporting.reportTypes.list({ onBehalfOfContentOwner: undefined }),
+        { label: 'reportTypes.list' }
+      );
 
       let reportTypes = typesResponse.data.reportTypes || [];
 
@@ -184,7 +260,24 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       spinner.succeed(`Found ${reportTypes.length} report type(s)`);
       console.log('');
 
-      // Step 2: Process each report type
+      // Step 2: Fetch existing jobs ONCE and index by reportTypeId.
+      //
+      // Previously this was called inside the per-report-type loop, so a run
+      // with N report types made N identical jobs.list() calls (~95% wasted
+      // quota). With ~20 report types this single hoist cuts the listing-phase
+      // API usage by ~95%.
+      spinner.text = 'Fetching reporting jobs...';
+      const jobsResponse = await withRateLimitRetry(
+        () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined }),
+        { label: 'jobs.list' }
+      );
+      const jobsByReportType = new Map<string, NonNullable<typeof jobsResponse.data.jobs>[number]>();
+      for (const job of jobsResponse.data.jobs || []) {
+        if (job.reportTypeId) jobsByReportType.set(job.reportTypeId, job);
+      }
+      debug(`Indexed ${jobsByReportType.size} existing job(s) by reportTypeId`);
+
+      // Step 3: Process each report type
       let totalDownloaded = 0;
       let totalSkipped = 0;
       let totalErrors = 0;
@@ -193,13 +286,8 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       const reportTypeId = reportType.id!;
       spinner.text = `Processing ${reportTypeId}...`;
 
-      // Find or create job
-      const jobsResponse = await youtubeReporting.jobs.list({
-        onBehalfOfContentOwner: undefined,
-      });
-
-      const jobs = jobsResponse.data.jobs || [];
-      const matchingJob = jobs.find((job: typeof jobs[0]) => job.reportTypeId === reportTypeId);
+      // Look up the job from the pre-fetched map (no API call).
+      const matchingJob = jobsByReportType.get(reportTypeId);
 
       let jobId: string;
 
@@ -210,12 +298,15 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         // Create new job
         spinner.text = `Creating new job for ${reportTypeId}...`;
 
-        const createResponse = await youtubeReporting.jobs.create({
-          requestBody: {
-            reportTypeId: reportTypeId,
-            name: `${reportTypeId} Report Job`,
-          },
-        });
+        const createResponse = await withRateLimitRetry(
+          () => youtubeReporting.jobs.create({
+            requestBody: {
+              reportTypeId: reportTypeId,
+              name: `${reportTypeId} Report Job`,
+            },
+          }),
+          { label: `jobs.create(${reportTypeId})` }
+        );
 
         jobId = createResponse.data.id!;
         debug(`Created new job: ${jobId}`);
@@ -239,11 +330,14 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       const allFetchedReports: any[] = [];
       let reportsPageToken: string | undefined;
       do {
-        const reportsResponse = await youtubeReporting.jobs.reports.list({
-          jobId,
-          onBehalfOfContentOwner: undefined,
-          pageToken: reportsPageToken,
-        });
+        const reportsResponse = await withRateLimitRetry(
+          () => youtubeReporting.jobs.reports.list({
+            jobId,
+            onBehalfOfContentOwner: undefined,
+            pageToken: reportsPageToken,
+          }),
+          { label: `jobs.reports.list(${reportTypeId})` }
+        );
         const pageReports = reportsResponse.data.reports || [];
         allFetchedReports.push(...pageReports);
         reportsPageToken = reportsResponse.data.nextPageToken || undefined;

--- a/docs/commands/reporting-api.md
+++ b/docs/commands/reporting-api.md
@@ -486,7 +486,22 @@ Reporting API quota usage:
 - **list-report-types**: 1 unit
 - **list-report-jobs**: 1 unit
 - **get-report-data**: 1 unit (cached: 0 units)
-- **fetch-reports**: 1 unit per report downloaded
+- **fetch-reports**: 1 unit per report downloaded, plus:
+  - 1 unit for `reportTypes.list`
+  - 1 unit for `jobs.list` (called once per run, not once per type)
+  - 1 unit per `jobs.reports.list` page per type
+  - 1 unit per `jobs.create` for new types
+
+### Rate-limit handling
+
+`fetch-reports` automatically retries on `HTTP 429 / Free requests per minute`
+errors with exponential backoff (5s → 10s → 20s → 40s → 80s, capped at 90s) and
+honors the server's `Retry-After` header. Daily quota exhaustion
+(`Free requests per day`) aborts the run immediately with a clear message —
+no amount of waiting will recover within the same window.
+
+Downloads themselves also retry on 429 and on transient network errors
+(`ECONNRESET` / `ETIMEDOUT` / `EAI_AGAIN`).
 
 ## Notes
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -455,6 +455,51 @@ async function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Classify a Google API error by quota type.
+ *
+ * Returns:
+ *   'rpm'   — YouTube Reporting/Data API "Free requests per minute" limit hit.
+ *             Retriable after the per-minute window resets (≈60s).
+ *   'daily' — Daily quota exhausted. Not retriable; abort the run.
+ *   null    — Some other error; let the caller decide what to do.
+ *
+ * YouTube's error message format (per API docs and observed in cron logs):
+ *   "Quota exceeded for quota metric 'Free requests' and limit 'Free requests per minute'"
+ *   "Quota exceeded for quota metric 'Free requests' and limit 'Free requests per day'"
+ *
+ * Both arrive as HTTP 429 with reason `rateLimitExceeded`, so status code alone
+ * can't tell them apart — we have to inspect the message text.
+ *
+ * The googleapis library surfaces the API's `errors[].message` either in
+ * `err.message` or nested in `err.response.data.error.errors[]`. We check both.
+ */
+function isRateLimitError(err: unknown): 'rpm' | 'daily' | null {
+  if (!err || typeof err !== 'object') return null;
+
+  const messages: string[] = [];
+
+  // googleapis / GaxiosError: the API message is usually on err.message
+  const topMessage = (err as { message?: unknown }).message;
+  if (typeof topMessage === 'string') messages.push(topMessage);
+
+  // Some errors nest the YouTube message under response.data.error.errors[].message
+  const nested = (err as { response?: { data?: { error?: { errors?: Array<{ message?: unknown }>; message?: unknown } } } }).response?.data?.error;
+  if (nested?.message && typeof nested.message === 'string') messages.push(nested.message);
+  if (Array.isArray(nested?.errors)) {
+    for (const e of nested.errors) {
+      if (e && typeof e.message === 'string') messages.push(e.message);
+    }
+  }
+
+  for (const msg of messages) {
+    const lower = msg.toLowerCase();
+    if (lower.includes('per day')) return 'daily';
+    if (lower.includes('per minute') || lower.includes('per minute ')) return 'rpm';
+  }
+  return null;
+}
+
+/**
  * Retry a function with exponential backoff
  */
 async function retryWithBackoff<T>(
@@ -484,6 +529,60 @@ async function retryWithBackoff<T>(
   }
 
   throw lastError || new Error('Max retries exceeded');
+}
+
+/**
+ * Retry a YouTube API call that may hit the per-minute (RPM) quota limit.
+ *
+ * On "Free requests per minute": backs off exponentially — 5s → 10s → 20s →
+ * 40s → 80s, capped at `maxDelayMs` (default 90s) — and retries, up to
+ * `maxRetries` times. Each retry emits a `progress()` line so the user (or
+ * cron log) can see what's happening. Honors the server's Retry-After header
+ * if present and larger than the exponential wait.
+ *
+ * On "Free requests per day" (or any longer-window quota — week / month):
+ * throws immediately with a clear message — no amount of waiting will
+ * recover within the same window, so retrying wastes time and hides the
+ * real problem from the operator.
+ *
+ * On any other error: re-throws as-is.
+ */
+async function withRateLimitRetry<T>(
+  fn: () => Promise<T>,
+  opts: { maxRetries?: number; baseDelayMs?: number; maxDelayMs?: number; label?: string } = {}
+): Promise<T> {
+  const maxRetries = opts.maxRetries ?? 5;
+  const baseDelayMs = opts.baseDelayMs ?? 5_000;
+  const maxDelayMs = opts.maxDelayMs ?? 90_000;
+  const label = opts.label ?? 'API call';
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const kind = isRateLimitError(err);
+      if (kind === 'daily') {
+        throw new Error(
+          `Daily YouTube API quota exhausted while running ${label}. ` +
+          `Aborting — wait until 00:00 PT (quota reset) or request a quota increase. ` +
+          `Original error: ${(err as Error).message}`
+        );
+      }
+      if (kind === 'rpm' && attempt < maxRetries) {
+        const expMs = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+        const waitSec = Math.round(expMs / 1000);
+        progress(`RPM quota hit on ${label} (attempt ${attempt}/${maxRetries}), backing off ${waitSec}s before retry...`);
+        await sleep(expMs);
+        continue;
+      }
+      // Not a retriable rate-limit error (or out of attempts) — bubble up.
+      throw err;
+    }
+  }
+  // Should be unreachable, but keep typescript happy.
+  throw lastError instanceof Error ? lastError : new Error(`Max RPM retries exceeded for ${label}`);
 }
 
 /**
@@ -560,6 +659,8 @@ export {
   chunkDateRange,
   sleep,
   retryWithBackoff,
+  isRateLimitError,
+  withRateLimitRetry,
   parsePositiveInt,
   toLocalYmd,
   validateDateOption,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -500,6 +500,38 @@ function isRateLimitError(err: unknown): 'rpm' | 'daily' | null {
 }
 
 /**
+ * Extract the server's `Retry-After` value (in seconds) from a thrown API
+ * error, if any. Supports both gaxios's Headers-like object (with `.get`)
+ * and plain Node IncomingHttpHeaders (lowercase keys).
+ *
+ * YouTube may send this on 429 responses to suggest a longer wait than our
+ * default exponential backoff. Per the HTTP spec it can be either a delta in
+ * seconds or an HTTP-date; we only honor the numeric form.
+ */
+function getRetryAfterMs(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const response = (err as { response?: { headers?: unknown } }).response;
+  const headers = response?.headers as unknown;
+  if (!headers) return undefined;
+
+  // gaxios Headers — has .get(name)
+  if (typeof (headers as { get?: unknown }).get === 'function') {
+    const v = (headers as { get: (n: string) => string | null }).get('retry-after');
+    if (v) {
+      const n = Number(v);
+      return Number.isFinite(n) && n >= 0 ? n * 1000 : undefined;
+    }
+  }
+  // Plain IncomingHttpHeaders — lowercase keys
+  const raw = (headers as Record<string, unknown>)['retry-after'];
+  if (typeof raw === 'string' || typeof raw === 'number') {
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n * 1000 : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Retry a function with exponential backoff
  */
 async function retryWithBackoff<T>(
@@ -538,7 +570,8 @@ async function retryWithBackoff<T>(
  * 40s → 80s, capped at `maxDelayMs` (default 90s) — and retries, up to
  * `maxRetries` times. Each retry emits a `progress()` line so the user (or
  * cron log) can see what's happening. Honors the server's Retry-After header
- * if present and larger than the exponential wait.
+ * (via getRetryAfterMs) and waits the larger of (Retry-After, exponential),
+ * but still capped by `maxDelayMs`.
  *
  * On "Free requests per day" (or any longer-window quota — week / month):
  * throws immediately with a clear message — no amount of waiting will
@@ -572,9 +605,15 @@ async function withRateLimitRetry<T>(
       }
       if (kind === 'rpm' && attempt < maxRetries) {
         const expMs = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
-        const waitSec = Math.round(expMs / 1000);
-        progress(`RPM quota hit on ${label} (attempt ${attempt}/${maxRetries}), backing off ${waitSec}s before retry...`);
-        await sleep(expMs);
+        // Honor server's Retry-After when it's larger than our exponential wait.
+        const serverMs = getRetryAfterMs(err);
+        const waitMs = serverMs !== undefined
+          ? Math.min(Math.max(serverMs, expMs), maxDelayMs)
+          : expMs;
+        const waitSec = Math.round(waitMs / 1000);
+        const source = serverMs !== undefined && serverMs > expMs ? ' (server Retry-After)' : '';
+        progress(`RPM quota hit on ${label} (attempt ${attempt}/${maxRetries}), backing off ${waitSec}s${source} before retry...`);
+        await sleep(waitMs);
         continue;
       }
       // Not a retriable rate-limit error (or out of attempts) — bubble up.
@@ -660,6 +699,7 @@ export {
   sleep,
   retryWithBackoff,
   isRateLimitError,
+  getRetryAfterMs,
   withRateLimitRetry,
   parsePositiveInt,
   toLocalYmd,


### PR DESCRIPTION
Fixes #84 — fetch-reports daily cron fails 8/14 runs from quota exhaustion.

## Root causes

1. **jobs.list() called inside the report-type loop** (~20× per run instead of 1×). Each iteration re-fetched the identical jobs list.
2. **No differentiation between RPM and daily quota** — RPM 429 just failed immediately, and any retry would have used the wrong backoff (1s/2s/4s exponential from `retryWithBackoff`, not the ~60s RPM window reset).

## Fix

**commands/fetch-reports.ts:**
- Hoist `jobs.list()` out of the loop, index results into a `Map<reportTypeId, Job>`. Cuts listing-phase API usage by ~95% for the default 20-type run.
- Wrap every googleapis call (`reportTypes.list`, `jobs.list`, `jobs.create`, `jobs.reports.list`) with `withRateLimitRetry()`.
- Refactor `downloadReport` into `downloadOnce` + retry loop. Retries on HTTP 429 from the download host with exponential backoff (5s→10s→20s→40s→80s, capped 90s), honoring `Retry-After` header. Also retries on transient network errors.

**lib/utils.ts (new helpers, reusable):**
- `isRateLimitError(err)` → `'rpm' | 'daily' | null`. Parses both `err.message` and nested `err.response.data.error.errors[]` for the YouTube "Free requests per minute" vs "Free requests per day" messages.
- `withRateLimitRetry(fn, opts)` → exponential backoff on RPM, immediate throw on daily, pass-through on everything else. Defaults: 5 retries, 5s base / 90s max delay.

## Verified

```
[DEBUG] Indexed 20 existing job(s) by reportTypeId
[DEBUG] Found existing job: 3ed3845f-76fa-4bfe-9b1d-c286deaffa84
...
✔ channel_basic_a3: 0 downloaded, 74 cached, 0 errors
✓ Fetch complete!
```

- `npm run type-check` — pass
- `npm run lint` — pass (no new warnings)
- `npm run build` — pass
- End-to-end against real Reporting API with `--types` filter — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter retry handling for report downloads and API calls when rate limits or temporary network issues occur.
  * Improved report fetching to reuse existing job data within a run, reducing unnecessary repeated requests.

* **Bug Fixes**
  * Better recovery from HTTP 429 responses by honoring retry timing and cleaning up incomplete downloads.
  * Added support for transient connection failures during downloads, helping report retrieval complete more reliably.

* **Documentation**
  * Updated reporting quota and rate-limit guidance to reflect the new retry behavior and request usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->