### PR TITLE
fix(#76,#77,#78): align helpers with throw-and-catch pattern

### DIFF
--- a/commands/auth.ts
+++ b/commands/auth.ts
@@ -1,4 +1,4 @@
-import { authenticate } from '../lib/auth';
+import { authenticate, CredentialsMissingError, printCredentialsSetupInstructions } from '../lib/auth';
 import { success, error } from '../lib/utils';
 
 async function authCommand(): Promise<void> {
@@ -12,6 +12,12 @@ async function authCommand(): Promise<void> {
   } catch (err) {
     console.log('');
     error(`Authentication failed: ${(err as Error).message}`);
+    // When the credentials file is missing, print the setup instructions so
+    // the user can fix it without a second guess about where to look.
+    if (err instanceof CredentialsMissingError) {
+      console.log('');
+      printCredentialsSetupInstructions();
+    }
     process.exit(1);
   }
 }

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, debug, success, warning, progress, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, withRateLimitRetry } from '../lib/utils';
+import { error, debug, success, warning, progress, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, withRateLimitRetry, runOrExit } from '../lib/utils';
 import {
   isReportCached,
   saveReportToCache,
@@ -203,9 +203,9 @@ async function downloadReport(
  */
 async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> {
   initCommand(options);
-  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  runOrExit(() => { if (options.startDate) validateDateOption('--start-date', options.startDate); });
+  runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
+  runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
   await withSpinner('Initializing...', 'Failed to fetch reports', async (spinner) => {
     // Resolve channel handle → canonical channel ID for cache namespacing

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, toLocalYmd, validateDateOption, validateDateRange } from '../lib/utils';
+import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelAnalyticsOptions } from '../types';
@@ -33,9 +33,9 @@ const REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
 async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Promise<void> {
   initCommand(options);
 
-  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  runOrExit(() => { if (options.startDate) validateDateOption('--start-date', options.startDate); });
+  runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
+  runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
   await withSpinner('Fetching channel analytics...', 'Failed to fetch channel analytics', async (spinner) => {
     // Determine channel ID

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -35,7 +35,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
   initCommand(options);
 
   let rawLimit: number;
-  try { rawLimit = parsePositiveInt(options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { rawLimit = parsePositiveInt('--limit', options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
   try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
   try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
   try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
+import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, parseDuration, runOrExit } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelSearchTermsOptions } from '../types';
@@ -34,11 +34,10 @@ const VIDEOS_LIST_CHUNK_SIZE = 50;
 async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions): Promise<void> {
   initCommand(options);
 
-  let rawLimit: number;
-  try { rawLimit = parsePositiveInt('--limit', options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  const rawLimit = runOrExit(() => parsePositiveInt('--limit', options.limit, 25));
+  runOrExit(() => { if (options.startDate) validateDateOption('--start-date', options.startDate); });
+  runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
+  runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
   // Validate --content-type against the allowlist. The type is already
   // narrowed to 'all' | 'video' | 'shorts' in types/index.ts, but commander.js
@@ -195,7 +194,9 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     const endDate = options.endDate || toLocalYmd(new Date());
     const startDate = options.startDate || YOUTUBE_START_DATE;
     const isLifetime = startDate === YOUTUBE_START_DATE;
-    try { validateDateRange(startDate, endDate); } catch (e) { spinner.stop(); error((e as Error).message); process.exit(1); }
+    // validateDateRange throws on bad ranges; withSpinner's catch handles it
+    // (fail + error + exit) — no manual try/catch needed here.
+    validateDateRange(startDate, endDate);
     // API enforces maxResults ≤ 25 for this report type
     const limit = Math.min(rawLimit, MAX_RESULTS_LIMIT);
 

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange } from '../lib/utils';
+import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { getOutputFormat, getConfigValue } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 import {
@@ -98,9 +98,9 @@ async function downloadReport(
  */
 async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
   initCommand(options);
-  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  runOrExit(() => { if (options.startDate) validateDateOption('--start-date', options.startDate); });
+  runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
+  runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
   await withSpinner('Checking for existing reporting job...', 'Failed to fetch report data', async (spinner) => {
     // Resolve channel handle → canonical channel ID for cache namespacing

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -17,7 +17,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
   }
 
   let limit: number;
-  try { limit = parsePositiveInt(options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { limit = parsePositiveInt('--limit', options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching search terms...', 'Failed to fetch search terms', async (spinner) => {
     const parsedId = parseVideoId(videoId);

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
+import { parseVideoId, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, runOrExit } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchTermsOptions } from '../types';
@@ -16,8 +16,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     process.exit(1);
   }
 
-  let limit: number;
-  try { limit = parsePositiveInt('--limit', options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
+  const limit = runOrExit(() => parsePositiveInt('--limit', options.limit, 50));
 
   await withSpinner('Fetching search terms...', 'Failed to fetch search terms', async (spinner) => {
     const parsedId = parseVideoId(videoId);

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange } from '../lib/utils';
+import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
@@ -16,9 +16,9 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     process.exit(1);
   }
 
-  try { if (options.startDate) validateDateOption('--start-date', options.startDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.endDate) validateDateOption('--end-date', options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
-  try { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); } catch (e) { error((e as Error).message); process.exit(1); }
+  runOrExit(() => { if (options.startDate) validateDateOption('--start-date', options.startDate); });
+  runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
+  runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
   await withSpinner('Fetching video information...', 'Failed to fetch analytics', async (spinner) => {
     const parsedId = parseVideoId(videoId);
@@ -55,7 +55,8 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     const endDate = options.endDate || toLocalYmd(new Date());
     const startDate = options.startDate || publishedAt.split('T')[0];
 
-    try { validateDateRange(startDate, endDate); } catch (e) { spinner.stop(); error((e as Error).message); process.exit(1); }
+    // validateDateRange throws on bad ranges; withSpinner's catch handles it.
+    validateDateRange(startDate, endDate);
     debug(`Date range: ${startDate} to ${endDate}`);
 
     // Default metrics

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -32,7 +32,7 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
   }
   const sortOrder = options.sort === 'new' ? 'time' : 'relevance';
   let limit: number;
-  try { limit = parsePositiveInt(options.limit, 20); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { limit = parsePositiveInt('--limit', options.limit, 20); } catch (e) { error((e as Error).message); process.exit(1); }
 
   debug(`Fetching comments for video: ${videoId}, limit: ${limit}, sort: ${sortOrder}`);
 

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { listVideoComments } from '../lib/youtube';
-import { formatDate, error, parsePositiveInt, debug, parseVideoId, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, error, parsePositiveInt, debug, parseVideoId, initCommand, withSpinner, runOrExit } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ListCommentsOptions } from '../types';
@@ -31,8 +31,7 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
     process.exit(1);
   }
   const sortOrder = options.sort === 'new' ? 'time' : 'relevance';
-  let limit: number;
-  try { limit = parsePositiveInt('--limit', options.limit, 20); } catch (e) { error((e as Error).message); process.exit(1); }
+  const limit = runOrExit(() => parsePositiveInt('--limit', options.limit, 20));
 
   debug(`Fetching comments for video: ${videoId}, limit: ${limit}, sort: ${sortOrder}`);
 

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -1,16 +1,15 @@
 import chalk from 'chalk';
 import { listChannelPlaylists } from '../lib/youtube';
-import { formatDate, formatNumber, error, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
+import { formatDate, formatNumber, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter, runOrExit } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterOption } from '../types';
 
 async function listPlaylistsCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
-  try { validatePrivacyFilter(options.privacy); } catch (e) { error((e as Error).message); process.exit(1); }
+  runOrExit(() => validatePrivacyFilter(options.privacy));
 
-  let limit: number;
-  try { limit = parsePositiveInt('--limit', options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
+  const limit = runOrExit(() => parsePositiveInt('--limit', options.limit, 50));
 
   await withSpinner('Fetching channel playlists...', 'Failed to fetch playlists', async (spinner) => {
     const channel = await requireChannel(options.channel);

--- a/commands/list-playlists.ts
+++ b/commands/list-playlists.ts
@@ -7,10 +7,10 @@ import { ChannelOption, OutputOption, LimitOption, VerboseOption, PrivacyFilterO
 
 async function listPlaylistsCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
-  validatePrivacyFilter(options.privacy);
+  try { validatePrivacyFilter(options.privacy); } catch (e) { error((e as Error).message); process.exit(1); }
 
   let limit: number;
-  try { limit = parsePositiveInt(options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { limit = parsePositiveInt('--limit', options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching channel playlists...', 'Failed to fetch playlists', async (spinner) => {
     const channel = await requireChannel(options.channel);

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -1,16 +1,15 @@
 import chalk from 'chalk';
 import { getChannelVideos } from '../lib/youtube';
-import { formatDate, error, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter } from '../lib/utils';
+import { formatDate, parsePositiveInt, debug, initCommand, withSpinner, validatePrivacyFilter, runOrExit } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatPrivacyStatus } from '../lib/formatters';
 import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOption, PrivacyFilterOption } from '../types';
 
 async function channelVideosCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & TypeFilterOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
-  try { validatePrivacyFilter(options.privacy); } catch (e) { error((e as Error).message); process.exit(1); }
+  runOrExit(() => validatePrivacyFilter(options.privacy));
 
-  let limit: number;
-  try { limit = parsePositiveInt('--limit', options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
+  const limit = runOrExit(() => parsePositiveInt('--limit', options.limit, 50));
 
   await withSpinner('Fetching channel videos...', 'Failed to fetch videos', async (spinner) => {
     const channel = await requireChannel(options.channel);

--- a/commands/list-videos.ts
+++ b/commands/list-videos.ts
@@ -7,10 +7,10 @@ import { ChannelOption, OutputOption, LimitOption, VerboseOption, TypeFilterOpti
 
 async function channelVideosCommand(options: ChannelOption & OutputOption & LimitOption & VerboseOption & TypeFilterOption & PrivacyFilterOption): Promise<void> {
   initCommand(options);
-  validatePrivacyFilter(options.privacy);
+  try { validatePrivacyFilter(options.privacy); } catch (e) { error((e as Error).message); process.exit(1); }
 
   let limit: number;
-  try { limit = parsePositiveInt(options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { limit = parsePositiveInt('--limit', options.limit, 50); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner('Fetching channel videos...', 'Failed to fetch videos', async (spinner) => {
     const channel = await requireChannel(options.channel);

--- a/commands/search-videos.ts
+++ b/commands/search-videos.ts
@@ -65,7 +65,7 @@ async function searchVideosCommand(options: SearchVideosOptions & QueryOption): 
     : `Searching ${targetChannel} for "${query}"...`;
 
   let limit: number;
-  try { limit = parsePositiveInt(options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
+  try { limit = parsePositiveInt('--limit', options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
 
   await withSpinner(spinnerMessage, 'Search failed', async (spinner) => {
     debug(`Search mode: ${searchMode}, query: "${query}", limit: ${limit}`);

--- a/commands/search-videos.ts
+++ b/commands/search-videos.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { searchVideos } from '../lib/youtube';
-import { formatDate, error, parsePositiveInt, debug, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, error, parsePositiveInt, debug, initCommand, withSpinner, runOrExit } from '../lib/utils';
 import { getConfigValue, getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchVideosOptions, QueryOption } from '../types';
@@ -64,8 +64,7 @@ async function searchVideosCommand(options: SearchVideosOptions & QueryOption): 
     ? `Searching YouTube for "${query}"...`
     : `Searching ${targetChannel} for "${query}"...`;
 
-  let limit: number;
-  try { limit = parsePositiveInt('--limit', options.limit, 25); } catch (e) { error((e as Error).message); process.exit(1); }
+  const limit = runOrExit(() => parsePositiveInt('--limit', options.limit, 25));
 
   await withSpinner(spinnerMessage, 'Search failed', async (spinner) => {
     debug(`Search mode: ${searchMode}, query: "${query}", limit: ${limit}`);

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,7 +9,6 @@ import {
   CREDENTIALS_PATH,
   TOKEN_PATH,
   ensureConfigDir,
-  error,
   info,
 } from './utils';
 import { OAuth2Credentials, OAuth2Token } from '../types';
@@ -80,6 +79,34 @@ async function createOAuth2Client(): Promise<OAuth2Client> {
 }
 
 /**
+ * Error thrown when the OAuth2 credentials file is missing.
+ * Carries the setup-instruction message so the caller's catch block can
+ * decide whether (and how) to print it before exiting.
+ */
+class CredentialsMissingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CredentialsMissingError';
+  }
+}
+
+/**
+ * Print the multi-line setup instructions for obtaining OAuth2 credentials.
+ * Used by `authenticate()` (via a thrown CredentialsMissingError) and by the
+ * `auth` command's catch block to surface the same UX in one place.
+ */
+function printCredentialsSetupInstructions(): void {
+  info('To set up authentication:');
+  console.log('1. Go to: ' + chalk.cyan('https://console.cloud.google.com/apis/credentials'));
+  console.log('2. Create OAuth 2.0 Client ID (Desktop application)');
+  console.log('3. Download the credentials JSON file');
+  console.log('4. Save it as: ' + chalk.cyan(CREDENTIALS_PATH));
+  console.log('');
+  info('Required OAuth scopes:');
+  SCOPES.forEach(scope => console.log('  - ' + scope));
+}
+
+/**
  * Get authenticated OAuth2 client
  */
 async function getAuthenticatedClient(): Promise<OAuth2Client> {
@@ -113,17 +140,11 @@ async function authenticate(): Promise<OAuth2Client> {
   const credentials = await loadCredentials();
 
   if (!credentials) {
-    error('Credentials file not found!');
-    console.log('');
-    info('To set up authentication:');
-    console.log('1. Go to: ' + chalk.cyan('https://console.cloud.google.com/apis/credentials'));
-    console.log('2. Create OAuth 2.0 Client ID (Desktop application)');
-    console.log('3. Download the credentials JSON file');
-    console.log('4. Save it as: ' + chalk.cyan(CREDENTIALS_PATH));
-    console.log('');
-    info('Required OAuth scopes:');
-    SCOPES.forEach(scope => console.log('  - ' + scope));
-    process.exit(1);
+    // Throw instead of exiting — the caller (commands/auth.ts) decides how
+    // to surface the message and exit. The setup instructions live in a
+    // shared helper so the caller's catch block can print them in the same
+    // shape as the old direct-exit path.
+    throw new CredentialsMissingError('Credentials file not found!');
   }
 
   const oauth2Client = await createOAuth2Client();
@@ -194,4 +215,6 @@ export {
   loadCredentials,
   loadToken,
   saveToken,
+  CredentialsMissingError,
+  printCredentialsSetupInstructions,
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -315,9 +315,9 @@ function chunkDateRange(startDate: string, endDate: string): { start: string; en
  * type is PrivacyStatus[], but at runtime the values are unvalidated strings
  * until this function confirms them.
  */
-function parsePositiveInt(limitOpt: string | undefined, defaultValue: number): number {
-  const n = limitOpt ? parseInt(limitOpt, 10) : defaultValue;
-  if (isNaN(n) || n < 1) throw new Error('--limit must be a positive integer');
+function parsePositiveInt(flag: string, opt: string | undefined, defaultValue: number): number {
+  const n = opt ? parseInt(opt, 10) : defaultValue;
+  if (isNaN(n) || n < 1) throw new Error(`${flag} must be a positive integer`);
   return n;
 }
 
@@ -351,8 +351,7 @@ function validatePrivacyFilter(privacy: string[] | undefined): void {
   const valid = ['public', 'private', 'unlisted'];
   const invalid = privacy.filter(s => !valid.includes(s));
   if (invalid.length > 0) {
-    error(`Invalid privacy value(s): ${invalid.join(', ')}. Valid values: public, private, unlisted`);
-    process.exit(1);
+    throw new Error(`Invalid privacy value(s): ${invalid.join(', ')}. Valid values: public, private, unlisted`);
   }
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -356,6 +356,27 @@ function validatePrivacyFilter(privacy: string[] | undefined): void {
 }
 
 /**
+ * Run a throwing validator (or any void/value function) and catch-and-die on
+ * failure: print the error message via `error()` and exit(1). This is the
+ * caller side of the project's throw-and-catch helper contract — validators
+ * throw, the command decides to exit via this wrapper. Keeps every command's
+ * `try { validate() } catch (e) { error(...); process.exit(1); }` boilerplate
+ * in one place.
+ *
+ * For async work wrapped in a spinner, prefer `withSpinner` (it owns its own
+ * catch-and-die). Use `runOrExit` for the synchronous validation calls that
+ * run at the top of a command before any spinner starts.
+ */
+function runOrExit<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (e) {
+    error((e as Error).message);
+    process.exit(1);
+  }
+}
+
+/**
  * Initialize a command: enable verbose mode if requested.
  * Call at the top of every command before any async work.
  */
@@ -705,4 +726,5 @@ export {
   validateDateOption,
   validateDateRange,
   validatePrivacyFilter,
+  runOrExit,
 };


### PR DESCRIPTION
Closes #76, #77, #78.

The project documents the helper pattern as 'validation helpers throw; callers catch-and-die' (lib/utils.ts validates it via parsePositiveInt, validateDateOption, validateDateRange) but three helpers broke that pattern by exiting the process directly. This made unit testing impossible and created silent inconsistencies.

### Changes

- **#76** `parsePositiveInt(flag, opt, default)` — now takes the flag name as a parameter so the thrown error names the actual failing flag (no longer hardcoded as `--limit`). All six call sites updated.
- **#78** `validatePrivacyFilter()` — now throws instead of calling `error()` + `process.exit(1)`. Both call sites (`list-videos`, `list-playlists`) wrap it in try/catch.
- **#77** `authenticate()` — now throws a typed `CredentialsMissingError` when the credentials file is missing. The multi-line setup instructions were factored into `printCredentialsSetupInstructions()` (also exported) so the caller's catch block in `commands/auth.ts` can print them in the exact same shape as before. The library function no longer owns the exit decision.

### Smoke tests (post-build)

- `list-videos --limit abc` → `✗ --limit must be a positive integer` ✓
- `search-videos --limit -5` → same clean error from a different command ✓
- `list-videos --privacy bogus` → `✗ Invalid privacy value(s): bogus. Valid values: public, private, unlisted` ✓
- `auth` (no creds path) — exercised via the build; runtime check requires no credentials file, which the dev environment has.

`npm run type-check`, `npm run lint` (0 errors; 11 pre-existing `any` warnings unrelated), `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication failures by showing clear setup instructions when credentials are missing.
  * Validation and parsing errors now report more specific command names, making limit and filter issues easier to understand.
  * Invalid privacy settings are now handled more consistently across listing commands, with clearer error messages and cleaner exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->