### PR TITLE
docs(analytics): document search-terms API limitation (#23)

### DIFF
--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -182,6 +182,14 @@ staqan-yt get-search-terms --video-id dQw4w9WgXcQ --output csv > search_terms.cs
 - **Content ideas** - Find related search terms for new videos
 - **Title optimization** - Align titles with successful search terms
 
+### Limitations
+
+The YouTube Analytics API's `insightTrafficSourceDetail` dimension has intermittent data availability: search terms are not consistently returned even when `get-traffic-sources` confirms traffic from YouTube Search. In practice, individual search-term rows are often empty or sparse.
+
+This is an **API limitation**, not a code issue — see #23 for the original investigation and reproduction.
+
+**Workaround:** use [`get-traffic-sources`](#get-traffic-sources), which queries the `insightTrafficSourceType` dimension and reliably returns aggregated traffic-source categories (YouTube Search, Suggested Videos, External, Subscriber Feed, etc.). For actionable search-traffic insight, prefer the aggregated categories over per-term rows.
+
 ---
 
 ## get-traffic-sources


### PR DESCRIPTION
Documents the YouTube Analytics API limitation investigated in #23: `insightTrafficSourceDetail` has intermittent data availability for per-term search rows.

Adds a **Limitations** subsection under `get-search-terms` in `docs/commands/analytics.md` (line 185) that:
- States the limitation is API-level, not a code issue
- References #23 as the investigation record
- Points users at `get-traffic-sources` (aggregated `insightTrafficSourceType`) as the reliable workaround

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Limitations” note to the search terms command documentation.
  * Clarified that per-search-term traffic source details may sometimes be sparse or empty.
  * Recommended using the traffic sources command for more reliable aggregated source categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->