### PR TITLE
refactor(#107): standardize lock file paths in lib/lock.ts

### DIFF
--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import os from 'os';
 import { debug, CACHE_DIR } from './utils';
+import { DATA_DIR } from './cache';
 
 export interface LockOptions {
   timeout?: number;        // Max wait time (ms) before giving up
@@ -130,11 +130,22 @@ async function isProcessAlive(pid: number): Promise<boolean> {
 }
 
 /**
- * Get lock file path for a given resource
+ * Get lock file path for a given resource.
+ *
+ * Lock file naming convention (issue #107):
+ *   - Each lock file lives next to the resource it protects
+ *     (in the resource's parent directory, not inside it).
+ *   - File name = "{resource-basename}.lock"
+ *     where resource-basename is the file/dir the lock guards.
+ *   - Hidden leading dot is NOT used (POSIX hidden files can confuse
+ *     completion, ls -l defaults, etc.).
+ *
+ * Resulting paths:
+ *   - completion →  ~/.staqan-yt-cli/cache/{channelId}/completion_cache.json.lock
+ *   - handles    →  ~/.staqan-yt-cli/cache/handle-to-channel-id.json.lock
+ *   - reports    →  ~/.staqan-yt-cli/data/{channelId}/reports.lock
  */
 export function getLockPath(type: 'completion' | 'handles' | 'reports', channelId?: string): string {
-  const dataDir = path.join(os.homedir(), '.staqan-yt-cli', 'data');
-
   switch (type) {
     case 'completion':
       if (!channelId) throw new Error('channelId required for completion lock');
@@ -143,6 +154,6 @@ export function getLockPath(type: 'completion' | 'handles' | 'reports', channelI
       return path.join(CACHE_DIR, 'handle-to-channel-id.json.lock');
     case 'reports':
       if (!channelId) throw new Error('channelId required for reports lock');
-      return path.join(dataDir, channelId, 'reports', '.lock');
+      return path.join(DATA_DIR, channelId, 'reports.lock');
   }
 }


### PR DESCRIPTION
The three `getLockPath()` cases used two different conventions: completion and handles used `{parent}/{resource-basename}.lock`, but reports used `{parent}/{dir}/.lock` (a bare hidden file inside the resource directory). New lock types would have to pick between two existing styles — easy to drift further.

Standardizes on one rule (documented in the new header): each lock lives next to its resource and is named `{resource-basename}.lock`. The reports lock moves from `~/.staqan-yt-cli/data/{channelId}/reports/.lock` to `~/.staqan-yt-cli/data/{channelId}/reports.lock`.

Also drops the local `dataDir` constant and imports `DATA_DIR` from `lib/cache.ts` so the two paths can't drift apart. Removes the now-unused `os` import.

## Diff

```
 lib/lock.ts | 21 ++++++++++++++++-----
 1 file changed, 16 insertions(+), 5 deletions(-)
```

## Verification

- `bun run type-check` ✓
- `bun run lint` ✓ (0 errors; 11 pre-existing `any` warnings, unchanged)
- `bun run build` ✓
- Smoke-tested `getLockPath()` at runtime — returns the expected paths and throws on missing channelId where required:
  ```
  completion: ~/.staqan-yt-cli/cache/{channelId}/completion_cache.json.lock
  handles:    ~/.staqan-yt-cli/cache/handle-to-channel-id.json.lock
  reports:    ~/.staqan-yt-cli/data/{channelId}/reports.lock
  ```

## Migration note

Any in-flight `fetch-reports` at upgrade time leaves its old `reports/.lock` orphaned; stale-lock detection (30 min default) will clean it up. No data loss.

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated lock-file handling for reports to use the new storage layout, improving consistency when generating and reading lock paths.
  * Clarified lock-file naming behavior so paths are handled more predictably across channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->