### PR TITLE
feat(#99): add --dimensions flag to get-video-analytics

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -297,6 +297,7 @@ program
   .option('--start-date <date>', 'Start date (YYYY-MM-DD), defaults to upload date')
   .option('--end-date <date>', 'End date (YYYY-MM-DD), defaults to today')
   .option('--metrics <metrics>', 'Comma-separated list of metrics to fetch')
+  .option('--dimensions <dims>', 'Comma-separated Analytics API dimensions (default: video)')
   .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('get-video-analytics', getVideoAnalytics));

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -6,6 +6,68 @@ import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
 
+/**
+ * Allowlist of Analytics API dimensions valid for video-level queries.
+ * See https://developers.google.com/youtube/v3/docs/analytics_api/dimensions/dims
+ */
+const VIDEO_DIMENSIONS: ReadonlySet<string> = new Set([
+  'video',
+  'day',
+  'month',
+  'insightTrafficSourceType',
+  'insightTrafficSourceDetail',
+  'creatorContentType',
+  'country',
+  'province',
+  'city',
+  'deviceType',
+  'operatingSystem',
+  'insightPlaybackLocationType',
+  'insightPlayerLocationType',
+  'subscribedStatus',
+]);
+
+/**
+ * Known-bad dimension combinations the Analytics API rejects at runtime.
+ * Checking up-front gives a clean error message instead of an API error.
+ */
+const INVALID_DIMENSION_COMBOS: ReadonlyArray<ReadonlyArray<string>> = [
+  // creatorContentType is not a valid dimension for traffic-source detail reports
+  // (see PR #90 — original issue: get-channel-search-terms #88).
+  ['creatorContentType', 'insightTrafficSourceDetail'],
+];
+
+/**
+ * Validate a comma-separated --dimensions string against the allowlist and
+ * known-bad combos. Returns the normalized (trimmed) string on success;
+ * throws on any invalid dimension or rejected combination.
+ */
+function validateVideoDimensions(raw: string): string {
+  const dims = raw.split(',').map(d => d.trim()).filter(d => d.length > 0);
+  if (dims.length === 0) {
+    throw new Error('--dimensions cannot be empty');
+  }
+
+  for (const d of dims) {
+    if (!VIDEO_DIMENSIONS.has(d)) {
+      throw new Error(
+        `Invalid --dimensions value: "${d}". Valid values: ${[...VIDEO_DIMENSIONS].join(', ')}`,
+      );
+    }
+  }
+
+  for (const combo of INVALID_DIMENSION_COMBOS) {
+    if (combo.every(d => dims.includes(d))) {
+      throw new Error(
+        `Invalid --dimensions combination: ${combo.join(' + ')}. ` +
+        `The Analytics API does not support this combination.`,
+      );
+    }
+  }
+
+  return dims.join(',');
+}
+
 async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void> {
   initCommand(options);
 
@@ -62,9 +124,15 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     // Default metrics
     const metrics = options.metrics || 'views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares';
 
+    // Default dimensions: 'video' preserves legacy behavior (aggregated by video).
+    // Any user-supplied --dimensions is validated against the Analytics API allowlist
+    // and known-bad combinations are rejected up-front (issue #99).
+    const dimensions = runOrExit(() => validateVideoDimensions(options.dimensions ?? 'video'));
+
     // Chunk date range into 90-day periods
     const dateChunks = chunkDateRange(startDate, endDate);
     debug(`Split into ${dateChunks.length} chunk(s) of 90 days`);
+    debug(`Dimensions: ${dimensions}, Metrics: ${metrics}`);
 
     // Fetch analytics for each chunk
     const allRows: unknown[][] = [];
@@ -80,7 +148,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
           startDate: chunk.start,
           endDate: chunk.end,
           metrics,
-          dimensions: 'video',
+          dimensions,
           filters: `video==${parsedId}`,
         });
       });

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -21,6 +21,7 @@ staqan-yt get-video-analytics --video-id <videoId>
 - `--start-date <date>` - Start date (YYYY-MM-DD), defaults to upload date
 - `--end-date <date>` - End date (YYYY-MM-DD), defaults to today
 - `--metrics <metrics>` - Comma-separated list of metrics to fetch
+- `--dimensions <dims>` - Comma-separated Analytics API dimensions (default: `video`)
 - `--output <format>` - Output format: json, table, text, pretty, csv (default: pretty)
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
@@ -39,6 +40,18 @@ staqan-yt get-video-analytics --video-id dQw4w9WgXcQ \
 # Get specific metrics only
 staqan-yt get-video-analytics --video-id dQw4w9WgXcQ \
   --metrics views,estimatedMinutesWatched,averageViewDuration
+
+# Break down views by day
+staqan-yt get-video-analytics --video-id dQw4w9WgXcQ \
+  --dimensions day --metrics views,estimatedMinutesWatched
+
+# Break down views by traffic source type
+staqan-yt get-video-analytics --video-id dQw4w9WgXcQ \
+  --dimensions insightTrafficSourceType --metrics views
+
+# Break down views by country
+staqan-yt get-video-analytics --video-id dQw4w9WgXcQ \
+  --dimensions country --metrics views,estimatedMinutesWatched
 
 # Export to CSV
 staqan-yt get-video-analytics --video-id dQw4w9WgXcQ --output csv > analytics.csv
@@ -77,6 +90,22 @@ Full list: [YouTube Analytics Metrics](https://developers.google.com/youtube/ana
 - **Start date only**: Start date to today
 - **Both dates**: Specified range
 - **Max range**: YouTube Analytics API limits to ~500 days
+
+### Available Dimensions
+
+By default, queries aggregate by `video` (the only dimension when `--dimensions` is omitted). Supply `--dimensions` to break results out along one or more Analytics API dimensions.
+
+Supported dimensions for video-level queries:
+
+- `day`, `month` — Time buckets
+- `insightTrafficSourceType`, `insightTrafficSourceDetail` — Traffic sources (aggregate and per-referrer)
+- `creatorContentType` — `SHORT`, `LONG_FORM`, `LIVE`
+- `country`, `province`, `city` — Geography
+- `deviceType`, `operatingSystem` — Device
+- `insightPlaybackLocationType`, `insightPlayerLocationType` — Where playback happened
+- `subscribedStatus` — Subscribed vs non-subscribed viewers
+
+Combine multiple dimensions with commas (e.g. `--dimensions day,country`). The CLI rejects unknown dimensions and known-bad combinations (e.g. `creatorContentType + insightTrafficSourceDetail` — see #88, fixed in PR #90) with a clear error before any API call.
 
 ---
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -187,6 +187,7 @@ export interface AnalyticsOptions extends OutputOption, VerboseOption, VideoIdOp
   startDate?: string;
   endDate?: string;
   metrics?: string;
+  dimensions?: string;
 }
 
 export interface SearchTermsOptions extends OutputOption, VerboseOption, VideoIdOption {


### PR DESCRIPTION
Adds `--dimensions <dims>` to `get-video-analytics` so users can break results out along any Analytics API dimension (country, day, deviceType, traffic source, etc.) instead of always aggregating per-video.

Defaults to `video` (the previous hardcoded value) so existing behavior is preserved.

## Validation

Client-side allowlist of valid video-level dimensions and a blocklist of known-bad combinations (`creatorContentType + insightTrafficSourceDetail` per #88/#90). Invalid input fails fast with a clear message instead of returning an opaque API error.

Supported dimensions: `day`, `month`, `insightTrafficSourceType`, `insightTrafficSourceDetail`, `creatorContentType`, `country`, `province`, `city`, `deviceType`, `operatingSystem`, `insightPlaybackLocationType`, `insightPlayerLocationType`, `subscribedStatus`.

## Diff

```
 bin/staqan-yt.ts                |  1 +
 commands/get-video-analytics.ts | 70 ++++++++++++++++++++++++++++++++++++++++-
 docs/commands/analytics.md      | 29 +++++++++++++++++
 types/index.ts                  |  1 +
 4 files changed, 100 insertions(+), 1 deletion(-)
```

## Verification

- `bun run type-check` ✓
- `bun run lint` ✓ (0 errors; 11 pre-existing `any` warnings, unchanged)
- `bun run build` ✓
- Smoke-tested validation logic — happy paths and all error paths return the expected results.

## What this enables

After this merges, the following open issues become small follow-ups rather than ground-up implementations:

- #97 (insightTrafficSourceDetail) — pass as `--dimensions`
- #100 (bridge analysis) — uses per-video referral IDs
- #51 (related video research) — same dimension
- #115 (compare mode) — uses dimensions for layout

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--dimensions` option to `get-video-analytics`, defaulting to `video`.
  * Analytics can now be grouped by dimensions such as day, traffic source, and country.
  * Multiple dimensions can be provided as a comma-separated list.

* **Bug Fixes**
  * Added validation for unsupported dimensions and invalid combinations before requests are sent.

* **Documentation**
  * Expanded command documentation with supported dimensions, usage examples, and validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->