### PR TITLE
refactor(#110): throw instead of exit in runOrExit/withSpinner

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -385,7 +385,7 @@ program
 program
   .command('mcp')
   .description('Start MCP server for AI assistant integration')
-  .action(mcpCommand);
+  .action(withHelpWrapper('mcp', mcpCommand));
 
 // Playlist commands
 // Get single playlist command (singular)

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -4,7 +4,7 @@ import { program, Command } from 'commander';
 import chalk from 'chalk';
 import * as path from 'path';
 import { GroupedHelp } from '../lib/customHelp';
-import { setQuiet, setVerbose } from '../lib/utils';
+import { setQuiet, setVerbose, error, isHelperFormattedError } from '../lib/utils';
 import authCommand = require('../commands/auth');
 import listVideosCommand = require('../commands/list-videos');
 import getVideoCommand = require('../commands/get-video');
@@ -74,8 +74,22 @@ function withHelpWrapper(commandName: string, actionFn: (...args: any[]) => Prom
       }
     }
 
-    // Otherwise, execute the original action
-    return actionFn(...args);
+    // Otherwise, execute the original action. If the action throws (issue #110 —
+    // helpers like runOrExit/withSpinner used to call process.exit(1) directly,
+    // which killed the process and any long-running caller such as the MCP
+    // server), catch the error here, log it, and exit with code 1.
+    try {
+      return await actionFn(...args);
+    } catch (err) {
+      // Helpers (runOrExit, withSpinner) mark their errors so we don't
+      // double-print. A fresh throw from a command's own code (no helper
+      // wrap) needs printing here.
+      if (!isHelperFormattedError(err)) {
+        const message = err instanceof Error ? err.message : String(err);
+        error(message);
+      }
+      process.exit(1);
+    }
   };
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -356,24 +356,56 @@ function validatePrivacyFilter(privacy: string[] | undefined): void {
 }
 
 /**
- * Run a throwing validator (or any void/value function) and catch-and-die on
- * failure: print the error message via `error()` and exit(1). This is the
- * caller side of the project's throw-and-catch helper contract — validators
- * throw, the command decides to exit via this wrapper. Keeps every command's
+ * Run a throwing validator (or any void/value function) and on failure:
+ * print the error message via `error()` and re-throw. This is the caller
+ * side of the project's throw-and-catch helper contract — validators
+ * throw, the command catches via this wrapper, formats the error, then
+ * propagates it so a single CLI top-level catch (in `withHelpWrapper`)
+ * can decide to exit. Keeps every command's
  * `try { validate() } catch (e) { error(...); process.exit(1); }` boilerplate
  * in one place.
  *
  * For async work wrapped in a spinner, prefer `withSpinner` (it owns its own
- * catch-and-die). Use `runOrExit` for the synchronous validation calls that
- * run at the top of a command before any spinner starts.
+ * catch-and-rethrow). Use `runOrExit` for the synchronous validation calls
+ * that run at the top of a command before any spinner starts.
+ *
+ * Note: this used to call `process.exit(1)` directly (issue #110). That made
+ * it impossible to use the helpers from any context that must survive an
+ * error path (e.g. an MCP server running multiple tools in one process).
+ * Throwing is strictly safer and the CLI top-level handler keeps exit
+ * semantics unchanged.
  */
 function runOrExit<T>(fn: () => T): T {
   try {
     return fn();
   } catch (e) {
-    error((e as Error).message);
-    process.exit(1);
+    const err = e as Error;
+    error(err.message);
+    throw markFormatted(err);
   }
+}
+
+/**
+ * Wrap an error to signal "already printed to the user by a helper layer".
+ * The CLI top-level catch in `withHelpWrapper` checks for this marker and
+ * skips re-printing. The original error is preserved on `cause` (and the
+ * marker itself chains the same message so the surface behavior is
+ * unchanged for callers that don't care).
+ */
+function markFormatted(original: Error): Error {
+  const marked = new Error(original.message);
+  marked.name = original.name || 'Error';
+  (marked as Error & { cause?: unknown }).cause = original;
+  (marked as Error & { __helperFormatted?: boolean }).__helperFormatted = true;
+  return marked;
+}
+
+/**
+ * True if `err` was already printed by a helper layer (`runOrExit` or
+ * `withSpinner`). The CLI top-level catch uses this to avoid double-printing.
+ */
+export function isHelperFormattedError(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { __helperFormatted?: boolean }).__helperFormatted === true;
 }
 
 /**
@@ -418,9 +450,14 @@ function createSpinner(message: string): Ora {
 /**
  * Run an async function wrapped in an ora spinner.
  * On success the caller is responsible for calling spinner.succeed() inside fn.
- * On error: stops the spinner with failMessage, prints the error, and exits 1.
+ * On error: stops the spinner with failMessage, prints the error, and re-throws
+ * so a single CLI top-level catch (in `withHelpWrapper`) can exit 1.
  *
  * When quiet mode is enabled, uses a silent spinner that does nothing.
+ *
+ * Note: this used to call `process.exit(1)` directly (issue #110). That
+ * killed the entire process — including any long-running caller such as the
+ * MCP server. Throwing lets the caller decide whether to exit.
  */
 async function withSpinner<T>(
   message: string,
@@ -451,7 +488,7 @@ async function withSpinner<T>(
       return await fn(silentSpinner);
     } catch (err) {
       error((err as Error).message);
-      process.exit(1);
+      throw markFormatted(err as Error);
     }
   }
 
@@ -463,7 +500,7 @@ async function withSpinner<T>(
     spinner.fail(failMessage);
     console.log('');
     error((err as Error).message);
-    process.exit(1);
+    throw markFormatted(err as Error);
   }
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -487,7 +487,12 @@ async function withSpinner<T>(
     try {
       return await fn(silentSpinner);
     } catch (err) {
-      error((err as Error).message);
+      // Mirror the CLI top-level guard: if a nested helper already printed
+      // this message and marked it, don't print it again here. Prevents
+      // double-output for chains like runOrExit → withSpinner.
+      if (!isHelperFormattedError(err)) {
+        error((err as Error).message);
+      }
       throw markFormatted(err as Error);
     }
   }
@@ -499,7 +504,10 @@ async function withSpinner<T>(
   } catch (err) {
     spinner.fail(failMessage);
     console.log('');
-    error((err as Error).message);
+    // Same double-print guard as the silent-mode branch (CodeRabbit #121).
+    if (!isHelperFormattedError(err)) {
+      error((err as Error).message);
+    }
     throw markFormatted(err as Error);
   }
 }


### PR DESCRIPTION
First step in the #110 refactor. The two helper layers `runOrExit` (sync) and `withSpinner` (async) used to call `process.exit(1)` directly on caught errors. That kills the entire process — including any long-running caller such as the MCP server — when a tool hits an error path.

## Changes

- **`lib/utils.ts`** — `runOrExit` and both branches of `withSpinner` now:
  1. Print the error via `error()` (unchanged)
  2. Re-throw wrapped in a `__helperFormatted` marker so the CLI top-level catch can recognize "already printed"
  3. Preserve the original error on `.cause` for stack-trace debugging

  Adds two new exports: `isHelperFormattedError(err)` (consumed by the bin wrapper) and a small private `markFormatted` helper.

- **`bin/staqan-yt.ts`** — `withHelpWrapper` now wraps the action call in try/catch. On a thrown error it prints the message (if not already printed by a helper) and exits with code 1. New import: `isHelperFormattedError`.

## CLI behavior preservation

| Scenario | Before | After |
|---|---|---|
| `list-videos --limit abc` | `✗ --limit must be a positive integer`, exit 1 | Same, exit 1 |
| `list-videos --privacy bogus` | `✗ Invalid privacy value(s): bogus. Valid values: public, private, unlisted`, exit 1 | Same, exit 1 |
| `get-video-analytics --start-date=invalid` | `✗ --start-date must be in YYYY-MM-DD format (got: invalid)`, exit 1 | Same, exit 1 |
| `--version` | `2.0.11`, exit 0 | Same, exit 0 |
| `help` | Usage text, exit 0 | Same, exit 0 |

## Diff

```
 bin/staqan-yt.ts | 20 ++++++++++++++++---
 lib/utils.ts     | 59 +++++++++++++++++++++++++++++++++++++++++++++-----------
 2 files changed, 65 insertions(+), 14 deletions(-)
```

## Verification

- `bun run type-check` ✓
- `bun run lint` ✓ (0 errors; 11 pre-existing `any` warnings, unchanged)
- `bun run build` ✓
- Smoke-tested all the above scenarios — exit codes and error messages match the previous CLI behavior exactly, no double-printing.

## What this enables

Subsequent #110 PRs can convert the ~77 remaining direct `process.exit(1)` call sites in command code to `throw new Error(...)` — now safe because the helpers no longer rely on the caller to exit, and the top-level catch in `withHelpWrapper` will translate thrown errors to the same exit-1 behavior.

Closes part of #110 (helper layer only — direct exits in command code remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command error handling so failures are reported more consistently and the app exits cleanly with the correct status code.
  * Prevented duplicate error messages in help-related flows and spinner-driven operations.
  * Made validation and API errors surface clearly without causing unexpected process behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->