### PR TITLE
fix(#122): resolve channel handles via channels.list forHandle (1 unit) instead of search.list (100 units)

### DIFF
--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -108,18 +108,18 @@ async function getChannelId(handleOrId: string): Promise<string> {
   const youtube = await getYouTubeClient();
   let channelId: string | null = null;
 
-  // If it starts with @, search by handle
+  // Exact handle lookup — channels.list costs 1 quota unit vs 100 for
+  // search.list, and unlike text search it can never match a similarly-named
+  // channel (a wrong search match would be persisted to the handle cache).
   if (handleOrId.startsWith('@')) {
-    debug('Searching by handle using search endpoint');
-    const searchResponse = await youtube.search.list({
-      part: ['snippet'],
-      q: handleOrId,
-      type: ['channel'],
-      maxResults: 1,
+    debug('Looking up channel by handle via channels.list forHandle');
+    const response = await youtube.channels.list({
+      part: ['id'],
+      forHandle: handleOrId.replace('@', ''),
     });
 
-    if (searchResponse.data.items && searchResponse.data.items.length > 0) {
-      channelId = searchResponse.data.items[0].snippet!.channelId!;
+    if (response.data.items && response.data.items.length > 0) {
+      channelId = response.data.items[0].id!;
       debug(`Found channel ID: ${channelId}`);
     }
   } else {
@@ -134,26 +134,25 @@ async function getChannelId(handleOrId: string): Promise<string> {
         channelId = response.data.items[0].id!;
       }
     } catch {
-      // Continue to search
+      // Continue to legacy username lookup
     }
 
-    // Fall back to username search
+    // Fall back to legacy YouTube username (youtube.com/user/<name>) —
+    // also an exact 1-unit lookup, unlike the search.list fallback it replaces
     if (!channelId) {
-      const searchResponse = await youtube.search.list({
-        part: ['snippet'],
-        q: handleOrId,
-        type: ['channel'],
-        maxResults: 1,
+      const response = await youtube.channels.list({
+        part: ['id'],
+        forUsername: handleOrId,
       });
 
-      if (searchResponse.data.items && searchResponse.data.items.length > 0) {
-        channelId = searchResponse.data.items[0].snippet!.channelId!;
+      if (response.data.items && response.data.items.length > 0) {
+        channelId = response.data.items[0].id!;
       }
     }
   }
 
   if (!channelId) {
-    throw new Error(`Channel not found: ${handleOrId}`);
+    throw new Error(`Channel not found: ${handleOrId}. Pass an @handle or a UC… channel ID.`);
   }
 
   // Persist to FS cache so future calls skip the API


### PR DESCRIPTION
Closes #122.

## Value proposition

Every uncached `@handle` resolution was spending **100 quota units** on `search.list` when `channels.list({ forHandle })` does the same job for **1 unit** — a 100x saving on the free 10k/day quota. Worse than the cost: text search matches by *similarity*, so an impersonator or similarly-named channel could be returned, and `getChannelId` persists results to the disk handle-cache — a wrong match would be sticky until the cache is cleared. Exact lookup makes that failure mode impossible.

## Changes (`lib/youtube.ts`, +18/−19)

- `@handle` inputs → `channels.list({ forHandle })` (exact, 1 unit) — same call the rest of the codebase already uses (`get-channel-search-terms`, `get-channel-analytics`, `mcp.ts` ×2)
- Legacy-username fallback → `channels.list({ forUsername })` (exact, 1 unit) instead of a second `search.list`
- Not-found error now tells the user what to pass: `Channel not found: X. Pass an @handle or a UC… channel ID.`

**Behavior change**: free-text channel *names* (not handles, not IDs, not legacy usernames) no longer resolve via fuzzy search — they now error. That was undocumented, quota-expensive, and the source of the wrong-match risk; docs have always said "handle or ID".

## Verification

- `bun run type-check` ✓, `bun run lint` ✓ (0 errors, 11 pre-existing warnings), `bun run build` ✓
- Live test with an uncached handle: `bun dist/bin/staqan-yt.js get-channel -c @mkbhd --output json` → resolved to `UCBJycsmduvYEL83R_U4JriQ` (correct — response `customUrl` is `@mkbhd`), entry written to handle cache. Cached `@staqan` path unaffected. Total quota spent testing: ~3 units.

Note: GitHub Actions quota is exhausted until end of month, so no status checks will appear on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube channel lookup accuracy for handles and usernames.
  * Enhanced error messages with guidance on accepted channel formats when a channel cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->