### PR TITLE
fix(#110): throw instead of process.exit in reporting commands (MCP-critical surface)

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -38,10 +38,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     // Resolve channel handle → canonical channel ID for cache namespacing
     const channelHandle = options.channel || await getConfigValue('default.channel');
     if (!channelHandle) {
-      spinner.fail('No channel configured');
-      console.log('');
-      error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
-      process.exit(1);
+      throw new Error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
     }
 
     spinner.text = `Resolving channel ID for ${channelHandle}...`;
@@ -52,9 +49,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     try {
       await ensureCacheDir(channelId);
     } catch (err) {
-      spinner.fail('Failed to create cache directory');
-      error((err as Error).message);
-      process.exit(1);
+      throw new Error(`Failed to create cache directory: ${(err as Error).message}`);
     }
 
     // Acquire lock for entire fetch operation
@@ -87,27 +82,19 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       } else if (options.types !== undefined) {
         const requestedIds = options.types.split(',').map(s => s.trim()).filter(Boolean);
         if (requestedIds.length === 0) {
-          spinner.fail('Invalid --types');
-          error('--types cannot be empty. Provide comma-separated type IDs or omit the flag.');
-          process.exit(1);
+          throw new Error('--types cannot be empty. Provide comma-separated type IDs or omit the flag.');
         }
         const availableIds = new Set(reportTypes.map(t => t.id).filter((id): id is string => Boolean(id)));
         const invalidIds = requestedIds.filter(id => !availableIds.has(id));
         if (invalidIds.length > 0) {
-          spinner.fail('Invalid --types');
-          error(`Unknown report type ID(s): ${invalidIds.join(', ')}`);
-          process.exit(1);
+          throw new Error(`Unknown report type ID(s): ${invalidIds.join(', ')}`);
         }
         reportTypes = reportTypes.filter(t => requestedIds.includes(t.id!));
         debug(`Filtering by multiple types: ${requestedIds.join(', ')}`);
       }
 
       if (reportTypes.length === 0) {
-        spinner.fail('No report types found');
-        console.log('');
-        error('No report types found matching your criteria.');
-        if (release) await release(); release = null;
-        process.exit(1);
+        throw new Error('No report types found matching your criteria.');
       }
 
       spinner.succeed(`Found ${reportTypes.length} report type(s)`);
@@ -224,10 +211,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
         try {
           validateDateRange(filteredStart, filteredEnd);
         } catch (e) {
-          error((e as Error).message);
-          console.log(chalk.gray('Provided:') + ` start-date=${filteredStart}, end-date=${filteredEnd}`);
-          console.log('');
-          process.exit(1);
+          throw new Error(`${(e as Error).message}\nProvided: start-date=${filteredStart}, end-date=${filteredEnd}`);
         }
 
         reports = reports.filter((report: typeof reports[0]) => {
@@ -351,20 +335,19 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
 
     success('Fetch complete!');
     } catch (err) {
+      // release === null means acquireLock itself failed (it's the first
+      // await in this try) — translate to an actionable message. Any later
+      // error propagates as-is; the finally below releases the lock and
+      // withSpinner prints the message and rethrows for the CLI top-level
+      // catch to exit(1). No process.exit here — this code path must be
+      // survivable when invoked from the MCP server (issue #110).
       if (!release) {
-        // Lock acquisition failed
-        const lockPath = getLockPath('reports', channelId);
-        spinner.fail('Could not acquire lock for reports');
-        console.log('');
-        error('Another fetch operation is in progress. Wait for it to complete, or remove the lock:');
-        error(`  rm ${lockPath}`);
-      } else {
-        // Lock was acquired, error occurred during operation
-        await release();  // Release lock before exiting
-        spinner.fail('Failed while fetching reports');
-        error((err as Error).message);
+        throw new Error(
+          'Another fetch operation is in progress. Wait for it to complete, or remove the lock:\n' +
+          `  rm ${getLockPath('reports', channelId)}`
+        );
       }
-      process.exit(1);
+      throw err;
     } finally {
       if (release) await release();
     }

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -335,13 +335,15 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
 
     success('Fetch complete!');
     } catch (err) {
-      // release === null means acquireLock itself failed (it's the first
-      // await in this try) — translate to an actionable message. Any later
-      // error propagates as-is; the finally below releases the lock and
-      // withSpinner prints the message and rethrows for the CLI top-level
-      // catch to exit(1). No process.exit here — this code path must be
-      // survivable when invoked from the MCP server (issue #110).
-      if (!release) {
+      // Translate lock *contention* into an actionable message. acquireLock
+      // throws "Failed to acquire lock <path> after <ms>ms" only when the
+      // lock stayed held past the timeout; permission/filesystem failures
+      // propagate unchanged so they aren't misreported as a concurrent run
+      // (CodeRabbit on #132). Everything rethrows — the finally below
+      // releases the lock and withSpinner prints and rethrows for the CLI
+      // top-level catch to exit(1). No process.exit here: this code path
+      // must be survivable when invoked from the MCP server (issue #110).
+      if (!release && (err as Error).message?.startsWith('Failed to acquire lock')) {
         throw new Error(
           'Another fetch operation is in progress. Wait for it to complete, or remove the lock:\n' +
           `  rm ${getLockPath('reports', channelId)}`

--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { error, warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { getOutputFormat, getConfigValue } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 import {
@@ -42,10 +42,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     // Resolve channel handle → canonical channel ID for cache namespacing
     const channelHandle = options.channel || await getConfigValue('default.channel');
     if (!channelHandle) {
-      spinner.fail('No channel configured');
-      console.log('');
-      error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
-      process.exit(1);
+      throw new Error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
     }
 
     spinner.text = `Resolving channel ID for ${channelHandle}...`;
@@ -56,9 +53,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     try {
       await ensureCacheDir(channelId);
     } catch (err) {
-      spinner.fail('Failed to create cache directory');
-      error((err as Error).message);
-      process.exit(1);
+      throw new Error(`Failed to create cache directory: ${(err as Error).message}`);
     }
 
     const auth = await getAuthenticatedClient();
@@ -101,7 +96,9 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       console.log(chalk.yellow('Run this command again after:') + ' ' + chalk.cyan(`${formatted.local} (${formatted.timezone})`));
       console.log('');
 
-      process.exit(0);
+      // Nothing to fetch yet — successful no-op, not an error. `return`
+      // instead of process.exit(0) so an MCP-server caller survives (issue #110).
+      return;
     }
 
     // Step 2: Check if reports are available
@@ -138,7 +135,8 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       console.log(chalk.yellow('Wait:') + ' ' + chalk.cyan(`${hoursUntilReady} hours remaining`));
       console.log('');
 
-      process.exit(0);
+      // Successful no-op (reports not ready yet) — see note above about #110.
+      return;
     }
 
     // Step 3: Validate date range (API returns timestamps, compare date portions only)
@@ -150,21 +148,13 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     // Check if requested range is available
     if (!minDate || !maxDate || !requestedStart || !requestedEnd) {
-      spinner.fail('Unable to determine date range');
-      console.log('');
-      error('Unable to determine date range');
-      process.exit(1);
+      throw new Error('Unable to determine date range');
     }
 
     try {
       validateDateRange(requestedStart, requestedEnd);
     } catch (e) {
-      spinner.fail('Invalid date range');
-      console.log('');
-      error((e as Error).message);
-      console.log(chalk.gray('Provided:') + ` start-date=${requestedStart}, end-date=${requestedEnd}`);
-      console.log('');
-      process.exit(1);
+      throw new Error(`${(e as Error).message}\nProvided: start-date=${requestedStart}, end-date=${requestedEnd}`);
     }
 
     // Adjust date range to available data if needed.
@@ -202,13 +192,11 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     // Validate that adjusted range has overlap (i.e., requested range is not entirely before/after available data)
     if (adjustedStart > adjustedEnd) {
-      spinner.fail('No overlap between requested range and available data');
-      process.stderr.write('\n');
-      process.stderr.write(chalk.red('Error:') + ' Requested date range has no overlap with available data\n');
-      process.stderr.write(chalk.gray('Requested:') + ` ${requestedStart} to ${requestedEnd}\n`);
-      process.stderr.write(chalk.gray('Available:') + ` ${effectiveMinDate} to ${effectiveMaxDate}\n`);
-      process.stderr.write('\n');
-      process.exit(1);
+      throw new Error(
+        'Requested date range has no overlap with available data\n' +
+        `Requested: ${requestedStart} to ${requestedEnd}\n` +
+        `Available: ${effectiveMinDate} to ${effectiveMaxDate}`
+      );
     }
 
     // Warn if range was adjusted
@@ -248,10 +236,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     // It's okay if no API reports match — data may still be available from cache
     // (e.g. expired from API but present in local archive).
     if (reports.length === 0 && cacheEntries.length === 0) {
-      spinner.fail('No reports match the specified date range');
-      console.log('');
-      error('No reports match the specified date range.');
-      process.exit(1);
+      throw new Error('No reports match the specified date range.');
     }
 
     // Step 5: Analyze cache coverage
@@ -405,20 +390,13 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       filteredData = allData.filter(row => row.video_id === options.videoId);
 
       if (filteredData.length === 0) {
-        spinner.fail('No data found for video ID');
-        console.log('');
-        error(`No data found for video ID: ${options.videoId}`);
-        console.log('');
-        console.log(chalk.gray('Available video IDs in this date range:'));
         const uniqueVideoIds = [...new Set(allData.map(row => row.video_id))];
-        uniqueVideoIds.forEach((vid, i) => {
-          if (i < 10) console.log('  ' + chalk.cyan(vid));
-        });
-        if (uniqueVideoIds.length > 10) {
-          console.log(chalk.gray(`  ... and ${uniqueVideoIds.length - 10} more`));
-        }
-        console.log('');
-        process.exit(1);
+        const shown = uniqueVideoIds.slice(0, 10).map(vid => `  ${vid}`).join('\n');
+        const more = uniqueVideoIds.length > 10 ? `\n  ... and ${uniqueVideoIds.length - 10} more` : '';
+        throw new Error(
+          `No data found for video ID: ${options.videoId}\n` +
+          `Available video IDs in this date range:\n${shown}${more}`
+        );
       }
     }
 


### PR DESCRIPTION
Part of #110 (see my status comment there for full remaining scope).

## Value proposition

#121 fixed the *helpers*; this fixes the highest-blast-radius *commands*. `fetch-reports` (7 exits) and `get-report-data` (9 exits) are the only commands the MCP server calls as functions in-process — every one of those `process.exit()` calls was a landmine that killed the entire MCP server mid-session. Two were even on **success** paths (`exit(0)` after "job created, come back in 48h"), so a healthy no-op response also killed the server.

## Changes

- All `error(msg); process.exit(1)` sites → `throw new Error(msg)`. `withSpinner` prints the message once and rethrows; `withHelpWrapper`'s top-level catch exits 1 — CLI behavior unchanged, MCP survivable.
- The two `process.exit(0)` early-successes in `get-report-data` → plain `return` (they print their guidance first, exactly as before).
- `fetch-reports`' outer catch no longer does the release-then-exit dance: it rethrows (with the actionable "another fetch is in progress, rm <lockpath>" message when lock acquisition itself failed) and lets `finally` release the lock.
- Multi-line context that used to be separate `console.log` lines (available video IDs, provided dates, requested-vs-available ranges) is folded into the thrown message, so MCP callers see it too instead of just the CLI.

## Verification (live, ~4 Reporting-API calls, no Data-API quota)

- `fetch-reports --types bogus_type_xyz` → `✗ Unknown report type ID(s): bogus_type_xyz`, **exit 1**
- `get-report-data --type channel_reach_basic_a1 --start-date 2019-01-01 --end-date 2019-01-02` → no-overlap error with requested/available ranges in the message, **exit 1**
- Success path: `get-report-data --type channel_reach_basic_a1 --start-date 2026-06-25 --end-date 2026-06-30 --output json` → 135 rows of valid JSON, **exit 0**
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓

Follow-ups for the rest of #110: the remaining ~74 exit sites across 24 command files are CLI-only today (not reachable from MCP), so they can be batched at leisure using this same pattern.

Note: GitHub Actions quota is exhausted until end of month — no status checks will appear; verified locally per CLAUDE.md checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report-fetching error messages for missing configuration, invalid report types, cache issues, date-range problems, and concurrent operations.
  * Improved report-data retrieval feedback for unavailable reports, invalid date ranges, missing data, and unmatched video IDs.
  * Report commands now handle failures more reliably without abruptly terminating the application.
  * “Nothing to fetch” scenarios now complete gracefully without displaying an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->