### PR TITLE
fix(#124): validate --output centrally; make get-channel-analytics honor default.output

### DIFF
--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
 import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
-import { requireChannel } from '../lib/config';
+import { requireChannel, getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelAnalyticsOptions } from '../types';
 
@@ -36,6 +36,10 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
   runOrExit(() => { if (options.startDate) validateDateOption('--start-date', options.startDate); });
   runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
   runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
+
+  // Resolve output format up front: honors `default.output` from config and
+  // rejects invalid values before any API call is spent.
+  const outputFormat = await getOutputFormat(options.output);
 
   await withSpinner('Fetching channel analytics...', 'Failed to fetch channel analytics', async (spinner) => {
     // Determine channel ID
@@ -184,8 +188,6 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
       debug('Column headers:', columnHeaders);
 
       // Format output
-      const outputFormat = options.output;
-
       if (outputFormat === 'json') {
         const jsonData = {
           channelId: actualChannelId,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -193,8 +193,13 @@ export async function requireChannel(provided?: string): Promise<string> {
  * CLI flag takes precedence over config
  */
 export async function getOutputFormat(formatFlag?: OutputFormat): Promise<OutputFormat> {
-  // If flag is explicitly set, use it
+  // If flag is explicitly set, validate and use it. Commander passes the raw
+  // string through, so without this check an unknown value (--output yaml)
+  // would silently fall through to each command's default/pretty branch.
   if (formatFlag !== undefined) {
+    if (!VALID_OUTPUT_FORMATS.includes(formatFlag)) {
+      throw new Error(`Invalid output format: ${formatFlag}. Must be one of: ${VALID_OUTPUT_FORMATS.join(', ')}`);
+    }
     return formatFlag;
   }
 


### PR DESCRIPTION
Part of #124 (the config-bypass half; the dead-flag half stays open — see below).

## Value proposition

Two silent-fallback bugs, one fix point:

1. `get-channel-analytics` was the only `--output`-consuming command reading `options.output` raw instead of `await getOutputFormat(...)` — so `config set default.output csv` was silently ignored by this one command.
2. `getOutputFormat` itself never validated the flag, so `--output yaml` silently pretty-printed in **every** command. This is the same bug class #85 stamped out for `--sort`/`config get`; putting the check inside `getOutputFormat` fixes all 23 callers at once instead of per-command validation.

The format is now resolved **before** the spinner starts, so an invalid value costs zero API quota.

## Changes

- `lib/config.ts`: `getOutputFormat` rejects values outside `VALID_OUTPUT_FORMATS` with the same message `config set default.output` already uses.
- `commands/get-channel-analytics.ts`: resolve `outputFormat` via `getOutputFormat` at the top of the command; use it in the output switch.

## Verification (live)

- `get-channel-analytics --report geography --output yaml` → `✗ Invalid output format: yaml. Must be one of: json, table, text, pretty, csv`, exit 1, **no API call made**
- `config set default.output csv` then `get-channel-analytics --report geography` (no flag) → emits CSV (`country,views,estimatedMinutesWatched` / `JP,13,81`) — previously pretty-printed, ignoring config. Config reverted to `pretty` after the test.
- `bun run type-check` ✓ · `bun run lint` ✓ · `bun run build` ✓

## Remaining scope of #124

Six commands (`auth`, `config`, `update-video`, `update-video-tags`, `put-video-localization`, `update-video-localization`) advertise `--output` but never read it. Removing the flag would break scripts that pass it (Commander errors on unknown options); implementing it is real feature work per command. Left #124 open for that decision.

Note: GitHub Actions quota exhausted until end of month — no status checks; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved output format handling for channel analytics.
  - Invalid output formats are now rejected with a clear error before analytics data is retrieved.
  - Supported formats and configured defaults are applied consistently across JSON, CSV, table, text, and pretty output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->