### PR TITLE
refactor(#126): consolidate retry helpers — migrate to withRateLimitRetry, delete retryWithBackoff

### DIFF
--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, retryWithBackoff, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, withRateLimitRetry, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
@@ -74,7 +74,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
       const chunk = dateChunks[i];
       spinner.text = `Fetching chunk ${i + 1}/${dateChunks.length} (${chunk.start} to ${chunk.end})...`;
 
-      const analyticsResponse = await retryWithBackoff(async () => {
+      const analyticsResponse = await withRateLimitRetry(async () => {
         return await youtubeAnalytics.reports.query({
           ids: 'channel==MINE',
           startDate: chunk.start,
@@ -83,7 +83,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
           dimensions: 'video',
           filters: `video==${parsedId}`,
         });
-      });
+      }, { label: 'reports.query(video analytics)' });
 
       // Save headers from first response
       if (i === 0 && analyticsResponse.data.columnHeaders) {

--- a/commands/get-video-retention.ts
+++ b/commands/get-video-retention.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, convertToCSV, chunkDateRange, retryWithBackoff, parseDuration, formatTimestamp, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
+import { parseVideoId, error, debug, convertToCSV, chunkDateRange, withRateLimitRetry, parseDuration, formatTimestamp, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { RetentionOptions } from '../types';
@@ -65,7 +65,7 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
       const chunk = dateChunks[i];
       spinner.text = `Fetching chunk ${i + 1}/${dateChunks.length} (${chunk.start} to ${chunk.end})...`;
 
-      const retentionResponse = await retryWithBackoff(async () => {
+      const retentionResponse = await withRateLimitRetry(async () => {
         return await youtubeAnalytics.reports.query({
           ids: 'channel==MINE',
           startDate: chunk.start,
@@ -75,7 +75,7 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
           filters: `video==${parsedId}`,
           sort: 'elapsedVideoTimeRatio',
         });
-      });
+      }, { label: 'reports.query(retention)' });
 
       // Save headers from first response
       if (i === 0 && retentionResponse.data.columnHeaders) {

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -22,7 +22,7 @@ import {
 } from '../lib/youtube';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, chunkDateRange, retryWithBackoff, initCommand, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
+import { parseVideoId, chunkDateRange, withRateLimitRetry, initCommand, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
 import { requireChannel } from '../lib/config';
 
 // Tool definitions
@@ -807,7 +807,7 @@ async function handleToolCall(name: string, args: any) {
       for (let i = 0; i < dateChunks.length; i++) {
         const chunk = dateChunks[i];
 
-        const analyticsResponse = await retryWithBackoff(async () => {
+        const analyticsResponse = await withRateLimitRetry(async () => {
           return await youtubeAnalytics.reports.query({
             ids: 'channel==MINE',
             startDate: chunk.start,
@@ -816,7 +816,7 @@ async function handleToolCall(name: string, args: any) {
             dimensions: 'video',
             filters: `video==${parsedId}`,
           });
-        });
+        }, { label: 'reports.query(video analytics)' });
 
         // Save headers from first response
         if (i === 0 && analyticsResponse.data.columnHeaders) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -307,13 +307,8 @@ function chunkDateRange(startDate: string, endDate: string): { start: string; en
 }
 
 /**
- * Validate --privacy flag values before any API calls.
- * Exits with an error message if any value is not public/private/unlisted.
- *
- * Accepts string[] (not PrivacyStatus[]) because Commander.js parses option
- * values as raw strings before this validation runs. The call site's option
- * type is PrivacyStatus[], but at runtime the values are unvalidated strings
- * until this function confirms them.
+ * Parse a numeric flag value, falling back to a default when absent.
+ * Throws if the value is not a positive integer.
  */
 function parsePositiveInt(flag: string, opt: string | undefined, defaultValue: number): number {
   const n = opt ? parseInt(opt, 10) : defaultValue;
@@ -346,6 +341,15 @@ function validateDateRange(startDate: string, endDate: string): void {
   }
 }
 
+/**
+ * Validate --privacy flag values before any API calls.
+ * Throws if any value is not public/private/unlisted.
+ *
+ * Accepts string[] (not PrivacyStatus[]) because Commander.js parses option
+ * values as raw strings before this validation runs. The call site's option
+ * type is PrivacyStatus[], but at runtime the values are unvalidated strings
+ * until this function confirms them.
+ */
 function validatePrivacyFilter(privacy: string[] | undefined): void {
   if (!privacy || privacy.length === 0) return;
   const valid = ['public', 'private', 'unlisted'];
@@ -464,47 +468,20 @@ async function withSpinner<T>(
   failMessage: string,
   fn: (spinner: Ora) => Promise<T>
 ): Promise<T> {
-  // In quiet mode, create a silent spinner
-  if (isQuietEnabled) {
-    const silentSpinner = {
-      succeed: () => {}, // Do nothing
-      fail: () => {}, // Do nothing
-      info: () => {}, // Do nothing
-      warn: () => {}, // Do nothing
-      start: () => silentSpinner as unknown as Ora,
-      stop: () => {},
-      stopAndPersist: () => {},
-      clear: () => {},
-      render: () => {},
-      frame: () => '',
-      text: '',
-      indent: 0,
-      spinner: {},
-      color: 'cyan',
-      hideCursor: true,
-    } as unknown as Ora;
-
-    try {
-      return await fn(silentSpinner);
-    } catch (err) {
-      // Mirror the CLI top-level guard: if a nested helper already printed
-      // this message and marked it, don't print it again here. Prevents
-      // double-output for chains like runOrExit → withSpinner.
-      if (!isHelperFormattedError(err)) {
-        error((err as Error).message);
-      }
-      throw markFormatted(err as Error);
-    }
-  }
-
-  // Normal mode: use spinner
-  const spinner = ora(message).start();
+  // createSpinner returns a silent no-op spinner in quiet mode, so a single
+  // code path covers both modes (previously the silent-spinner literal was
+  // duplicated here).
+  const spinner = createSpinner(message).start();
   try {
     return await fn(spinner);
   } catch (err) {
     spinner.fail(failMessage);
-    console.log('');
-    // Same double-print guard as the silent-mode branch (CodeRabbit #121).
+    if (!isQuietEnabled) {
+      console.log('');
+    }
+    // Mirror the CLI top-level guard: if a nested helper already printed
+    // this message and marked it, don't print it again here. Prevents
+    // double-output for chains like runOrExit → withSpinner (CodeRabbit #121).
     if (!isHelperFormattedError(err)) {
       error((err as Error).message);
     }
@@ -559,7 +536,7 @@ function isRateLimitError(err: unknown): 'rpm' | 'daily' | null {
   for (const msg of messages) {
     const lower = msg.toLowerCase();
     if (lower.includes('per day')) return 'daily';
-    if (lower.includes('per minute') || lower.includes('per minute ')) return 'rpm';
+    if (lower.includes('per minute')) return 'rpm';
   }
   return null;
 }
@@ -594,38 +571,6 @@ function getRetryAfterMs(err: unknown): number | undefined {
     return Number.isFinite(n) && n >= 0 ? n * 1000 : undefined;
   }
   return undefined;
-}
-
-/**
- * Retry a function with exponential backoff
- */
-async function retryWithBackoff<T>(
-  fn: () => Promise<T>,
-  maxRetries = 3,
-  initialDelay = 1000
-): Promise<T> {
-  let lastError: Error | undefined;
-
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastError = err as Error;
-
-      // Check if it's a quota error
-      const errorMessage = lastError.message || '';
-      if (errorMessage.includes('quota') || errorMessage.includes('429')) {
-        const delay = initialDelay * Math.pow(2, i);
-        progress(`Quota limit hit, retrying in ${delay / 1000}s...`);
-        await sleep(delay);
-      } else {
-        // Not a quota error, throw immediately
-        throw lastError;
-      }
-    }
-  }
-
-  throw lastError || new Error('Max retries exceeded');
 }
 
 /**
@@ -762,7 +707,6 @@ export {
   convertToCSV,
   chunkDateRange,
   sleep,
-  retryWithBackoff,
   isRateLimitError,
   getRetryAfterMs,
   withRateLimitRetry,


### PR DESCRIPTION
Closes #126.

## Value proposition

Two retry helpers doing the same job means every new API call site has to pick one, and the older one picks wrong: `retryWithBackoff` string-matched `'quota'/'429'`, kept retrying even when the **daily** quota was exhausted (wasting minutes and hiding the real problem), and ignored the server's `Retry-After`. `withRateLimitRetry` (built for #84) gets all three right. One helper, one behavior.

## Changes

- `commands/get-video-analytics.ts`, `commands/get-video-retention.ts`, `commands/mcp.ts` (video-analytics tool): migrate to `withRateLimitRetry` with per-call labels so backoff logs say what they're retrying.
- `lib/utils.ts`: delete `retryWithBackoff` (+ export). While in the file, three hygiene fixes flagged in #126:
  - The JSDoc block that described `validatePrivacyFilter` sat above `parsePositiveInt` (and still said helpers "exit" — they throw since #121). Each function now carries its own accurate doc.
  - `isRateLimitError`: dropped the dead duplicate condition (`'per minute'` OR-ed with `'per minute '`).
  - `withSpinner`: the quiet-mode silent-spinner object literal duplicated `createSpinner`'s — now one code path via `createSpinner`, −40 lines, identical output in both modes (double-print guard preserved).

**Deliberate behavior change**: quota errors that don't carry YouTube's per-minute wording are no longer blindly retried — RPM errors back off (honoring `Retry-After`), daily-quota errors abort immediately with a clear message, everything else surfaces at once instead of after 3 silent retries.

## Verification (live on @staqan)

- `get-video-analytics --video-id eeYl2dxv57g --output json` → valid payload (videoId/title/dateRange/columnHeaders/rows), exit 0
- `get-video-retention --video-id eeYl2dxv57g --output json` → 100 retention rows, exit 0
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓

Note: GitHub Actions quota exhausted until end of month — no status checks; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for video analytics and retention requests when rate limits occur.
  * Added clearer request identification during retry operations to improve error reporting.
  * Improved command progress indicators and failure behavior, including quieter output in quiet mode.
  * Tightened detection of rate-limit responses to avoid unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->