### PR TITLE
fix(#127): single version source shared by CLI and MCP server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,4 +453,4 @@ async function getVideo() { /* API only */ }
 
 ## Version
 
-Current version: **2.0.7** (see `package.json` for source of truth)
+See `package.json` for the current version (single source of truth — the number is not duplicated here because it drifts).

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -2,8 +2,8 @@
 
 import { program, Command } from 'commander';
 import chalk from 'chalk';
-import * as path from 'path';
 import { GroupedHelp } from '../lib/customHelp';
+import { getVersion } from '../lib/version';
 import { setQuiet, setVerbose, error, isHelperFormattedError } from '../lib/utils';
 import authCommand = require('../commands/auth');
 import listVideosCommand = require('../commands/list-videos');
@@ -93,14 +93,7 @@ function withHelpWrapper(commandName: string, actionFn: (...args: any[]) => Prom
   };
 }
 
-// Get version - try to read from package.json, fallback to hardcoded version for compiled binaries
-let version = '2.0.11'; // Fallback version for compiled binaries
-try {
-  const packageJson = require(path.join(__dirname, '../../package.json'));
-  version = packageJson.version;
-} catch {
-  // Running as compiled binary - use hardcoded version
-}
+const version = getVersion();
 
 program
   .name('staqan-yt')

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -24,6 +24,7 @@ import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
 import { parseVideoId, chunkDateRange, retryWithBackoff, initCommand, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
 import { requireChannel } from '../lib/config';
+import { getVersion } from '../lib/version';
 
 // Tool definitions
 const TOOLS: Tool[] = [
@@ -1415,7 +1416,7 @@ async function mcpCommand(options: { verbose?: boolean } = {}): Promise<void> {
   const server = new Server(
     {
       name: 'staqan-yt-mcp',
-      version: '1.3.0',
+      version: getVersion(),
     },
     {
       capabilities: {

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -9,12 +9,23 @@ export const FALLBACK_VERSION = '2.0.11'; // synced by scripts/version.ts
  * install, FALLBACK_VERSION when running as a compiled binary.
  * Single source shared by the CLI entry point and the MCP server so the
  * two can never drift apart (issue #127 — MCP reported a stale 1.3.0).
+ *
+ * Both layouts are probed because __dirname differs by how we run:
+ * dist/lib/ when built (root is ../../), lib/ when executed from source
+ * via tsx/bun (root is ../) — CodeRabbit on #135.
  */
 export function getVersion(): string {
-  try {
-    const packageJson = require(path.join(__dirname, '../../package.json'));
-    return packageJson.version;
-  } catch {
-    return FALLBACK_VERSION;
+  for (const rel of ['../../package.json', '../package.json']) {
+    try {
+      const packageJson = require(path.join(__dirname, rel));
+      // Name check so a stray package.json in a parent directory can't
+      // hijack the version (one layout's correct path is the other's parent).
+      if (packageJson?.name === 'staqan-yt-cli' && packageJson.version) {
+        return packageJson.version;
+      }
+    } catch {
+      // try next layout
+    }
   }
+  return FALLBACK_VERSION;
 }

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,0 +1,20 @@
+import * as path from 'path';
+
+// Fallback for compiled binaries where package.json isn't on disk.
+// Do not edit by hand: scripts/version.ts rewrites this line on `bun pm version`.
+export const FALLBACK_VERSION = '2.0.11'; // synced by scripts/version.ts
+
+/**
+ * Resolve the CLI version: package.json when running from the repo/npm
+ * install, FALLBACK_VERSION when running as a compiled binary.
+ * Single source shared by the CLI entry point and the MCP server so the
+ * two can never drift apart (issue #127 — MCP reported a stale 1.3.0).
+ */
+export function getVersion(): string {
+  try {
+    const packageJson = require(path.join(__dirname, '../../package.json'));
+    return packageJson.version;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+}

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -26,15 +26,19 @@ const version = packageJson.version;
 
 console.log(`📦 Syncing version ${version} to all files...\n`);
 
-// 1. Update bin/staqan-yt.ts fallback version
-const binFilePath = join(rootDir, 'bin/staqan-yt.ts');
-let binContent = readFileSync(binFilePath, 'utf-8');
-binContent = binContent.replace(
-  /let version = '[^']+'; \/\/ Fallback version for compiled binaries/,
-  `let version = '${version}'; // Fallback version for compiled binaries`
+// 1. Update lib/version.ts fallback version (shared by the CLI entry point
+// and the MCP server via getVersion())
+const versionFilePath = join(rootDir, 'lib/version.ts');
+const versionContent = readFileSync(versionFilePath, 'utf-8');
+const updatedVersionContent = versionContent.replace(
+  /export const FALLBACK_VERSION = '[^']+'; \/\/ synced by scripts\/version\.ts/,
+  `export const FALLBACK_VERSION = '${version}'; // synced by scripts/version.ts`
 );
-writeFileSync(binFilePath, binContent, 'utf-8');
-console.log(`  ✓ Updated bin/staqan-yt.ts`);
+if (updatedVersionContent === versionContent) {
+  throw new Error('FALLBACK_VERSION marker not found in lib/version.ts — sync regex needs updating');
+}
+writeFileSync(versionFilePath, updatedVersionContent, 'utf-8');
+console.log(`  ✓ Updated lib/version.ts`);
 
 // 2. Update homebrew-tap/Formula/staqan-yt.rb version (tap clone)
 const tapFormulaPath = join(tapDir, 'Formula/staqan-yt.rb');
@@ -47,7 +51,7 @@ writeFileSync(tapFormulaPath, formulaContent, 'utf-8');
 console.log(`  ✓ Updated homebrew-tap/Formula/staqan-yt.rb`);
 
 // 3. Add files to npm's commit (tap formula is committed separately by postversion)
-git('git add bin/staqan-yt.ts package.json');
+git('git add lib/version.ts package.json');
 console.log('  ✓ Added files to npm commit');
 
 console.log(`\n✅ Version ${version} synced! npm will now commit and tag.\n`);


### PR DESCRIPTION
Closes #127.

## Value proposition

Three version strings, three answers: the CLI said 2.0.11, the MCP server introduced itself to clients as **1.3.0** (hardcoded since it was written), and CLAUDE.md's footer said **2.0.7**. Any debugging session that cross-references MCP client logs against releases starts from a lie. One `getVersion()` makes drift structurally impossible rather than a thing to remember.

## Changes

- **`lib/version.ts` (new)**: `getVersion()` — package.json at runtime, `FALLBACK_VERSION` for compiled binaries. The fallback line carries a `// synced by scripts/version.ts` marker.
- **`bin/staqan-yt.ts`**: replaces its inline version block with `getVersion()` (also drops the now-unused `path` import).
- **`commands/mcp.ts`**: MCP server registers with `getVersion()` instead of `'1.3.0'`.
- **`scripts/version.ts`**: syncs `lib/version.ts` instead of `bin/staqan-yt.ts`, and now **throws if the marker line is missing** — previously a silent no-op regex miss would ship a stale fallback.
- **`CLAUDE.md`**: footer no longer duplicates the number; points at package.json (it already called package.json the source of truth while contradicting it two words earlier).

## Verification

- `staqan-yt --version` → `2.0.11` (built from this branch)
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓
- Sync regex dry-run: replacing the marker line with a new version string matches exactly once; deleting it makes `scripts/version.ts` throw as intended.

Note: GitHub Actions quota exhausted until end of month — no status checks; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CLI and MCP server versions now stay synchronized automatically with the package version.
  * Added a fallback version for bundled or compiled CLI usage when package metadata is unavailable.
* **Documentation**
  * Updated version documentation to direct readers to `package.json` as the authoritative source.
* **Maintenance**
  * Improved the release process for updating and staging version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->