### PR TITLE
fix(#123): channel URLs no longer misclassified as channel IDs

### DIFF
--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -54,40 +54,37 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     let channelTitle = '';
     let actualChannelId = parsedChannel.value;
 
-    try {
-      // Resolve channel handle to ID if needed
-      if (parsedChannel.type === 'handle') {
-        debug('Looking up channel by handle:', parsedChannel.value);
-        const channelResponse = await youtube.channels.list({
-          part: ['id', 'snippet'],
-          forHandle: parsedChannel.value.replace('@', ''),
-        });
+    // Resolve channel handle to ID if needed. A not-found channel fails the
+    // command here — previously the ID branch swallowed the empty response
+    // (and any lookup error) into a debug-only catch and proceeded, so the
+    // Analytics query failed later with an opaque message (#123).
+    if (parsedChannel.type === 'handle') {
+      debug('Looking up channel by handle:', parsedChannel.value);
+      const channelResponse = await youtube.channels.list({
+        part: ['id', 'snippet'],
+        forHandle: parsedChannel.value.replace('@', ''),
+      });
 
-        if (channelResponse.data.items && channelResponse.data.items.length > 0) {
-          actualChannelId = channelResponse.data.items[0].id!;
-          channelTitle = channelResponse.data.items[0].snippet?.title || '';
-        } else {
-          spinner.fail('Channel not found');
-          error(`Channel not found: ${channelId}`);
-          process.exit(1);
-        }
-      } else {
-        // Get channel by ID
-        const channelResponse = await youtube.channels.list({
-          part: ['snippet'],
-          id: [parsedChannel.value],
-        });
-
-        if (channelResponse.data.items && channelResponse.data.items.length > 0) {
-          channelTitle = channelResponse.data.items[0].snippet?.title || '';
-        }
+      if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
+        throw new Error(`Channel not found: ${channelId}`);
       }
+      actualChannelId = channelResponse.data.items[0].id!;
+      channelTitle = channelResponse.data.items[0].snippet?.title || '';
+    } else {
+      // Get channel by ID
+      const channelResponse = await youtube.channels.list({
+        part: ['snippet'],
+        id: [parsedChannel.value],
+      });
 
-      debug('Resolved channel ID:', actualChannelId);
-      debug('Channel title:', channelTitle);
-    } catch (err) {
-      debug('Error fetching channel info:', err);
+      if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
+        throw new Error(`Channel not found: ${channelId}`);
+      }
+      channelTitle = channelResponse.data.items[0].snippet?.title || '';
     }
+
+    debug('Resolved channel ID:', actualChannelId);
+    debug('Channel title:', channelTitle);
 
     spinner.succeed('Channel information retrieved');
 

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -89,10 +89,13 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
         part: channelParts,
         id: [parsedChannel.value],
       });
-      if (channelResponse.data.items && channelResponse.data.items.length > 0) {
-        channelTitle = channelResponse.data.items[0].snippet?.title || '';
-        uploadsPlaylistId = channelResponse.data.items[0].contentDetails?.relatedPlaylists?.uploads || '';
+      if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
+        // Previously this silently proceeded with the unresolved input as the
+        // channel ID, producing an opaque Analytics failure downstream (#123).
+        throw new Error(`Channel not found: ${channelArg}`);
       }
+      channelTitle = channelResponse.data.items[0].snippet?.title || '';
+      uploadsPlaylistId = channelResponse.data.items[0].contentDetails?.relatedPlaylists?.uploads || '';
     }
 
     debug('Resolved channel ID:', channelId);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,30 +30,38 @@ async function ensureConfigDir(): Promise<void> {
 }
 
 /**
- * Extract channel ID from various input formats
+ * Classify channel input (handle, ID, or URL) as a handle or a channel ID.
+ * Throws on legacy /c/ and /user/ URLs — their path segment is neither a
+ * handle nor a channel ID, so no downstream lookup could succeed (issue #123).
  */
 function parseChannelHandle(input: string): ChannelHandle {
-  // Remove @ if present
   if (input.startsWith('@')) {
     return { type: 'handle', value: input };
   }
 
-  // Extract from URL
-  const urlPatterns = [
-    /youtube\.com\/@([^\/\?]+)/,
-    /youtube\.com\/channel\/([^\/\?]+)/,
-    /youtube\.com\/c\/([^\/\?]+)/,
-    /youtube\.com\/user\/([^\/\?]+)/,
-  ];
-
-  for (const pattern of urlPatterns) {
-    const match = input.match(pattern);
-    if (match) {
-      return { type: 'id', value: match[1] };
-    }
+  // @-handle URLs are handles, not IDs. The previous code returned these as
+  // type 'id' (with the @ stripped), which sent a bare handle into
+  // channels.list({ id }) and produced silent empty results (issue #123).
+  const handleUrl = input.match(/youtube\.com\/@([^/?]+)/);
+  if (handleUrl) {
+    return { type: 'handle', value: `@${handleUrl[1]}` };
   }
 
-  // Assume it's a channel ID or handle
+  const channelUrl = input.match(/youtube\.com\/channel\/([^/?]+)/);
+  if (channelUrl) {
+    return { type: 'id', value: channelUrl[1] };
+  }
+
+  const legacyUrl = input.match(/youtube\.com\/(?:c|user)\/([^/?]+)/);
+  if (legacyUrl) {
+    throw new Error(
+      `Legacy channel URL not supported: ${input}\n` +
+      `The /c/ and /user/ path segments are not channel IDs. ` +
+      `Pass the channel's @handle or its UC… channel ID instead.`
+    );
+  }
+
+  // Assume it's a raw channel ID
   return { type: 'id', value: input };
 }
 


### PR DESCRIPTION
Closes #123.

## Value proposition

Passing a channel URL (the thing you most naturally copy from a browser) to `-c` silently broke: `youtube.com/@staqan` was classified as a channel *ID* (with the `@` stripped), `channels.list({id})` returned nothing, and both analytics commands **proceeded anyway** with the bogus value — surfacing later as an opaque Analytics error or empty data. Silent-wrong becomes either correct or loudly-wrong.

## Changes

- `lib/utils.ts` `parseChannelHandle`:
  - `youtube.com/@handle` URLs → `{ type: 'handle', value: '@handle' }` (resolves correctly via `forHandle`)
  - `/channel/UC…` URLs → ID, as before
  - `/c/Name` and `/user/Name` → **throw with guidance** ("Pass the channel's @handle or its UC… channel ID"). These legacy segments are neither handles nor IDs; every downstream lookup was guaranteed to fail, just less legibly.
- `commands/get-channel-search-terms.ts` + `commands/get-channel-analytics.ts`: an empty `channels.list` response now throws `Channel not found: <input>` instead of silently continuing. In `get-channel-analytics` this also removes a debug-only catch that swallowed lookup errors entirely (a channel the Analytics query can't use is not a cosmetic failure), and converts the handle-branch `process.exit(1)` to a throw (#110 pattern).

## Verification

Parse unit cases (compiled output): `@staqan` → handle · `https://www.youtube.com/@staqan` → handle · `/channel/UC…?sub=1` → ID (query string stripped) · raw `UC…` → ID · `/user/…` and `/c/…` → clear error.

Live on @staqan:
- `get-channel-analytics -c "https://www.youtube.com/@staqan" --report geography --output json` → resolves to STAQAN, returns data (**previously silently broken**)
- `get-channel-analytics -c "https://youtube.com/user/oldname" …` → legacy-URL error, exit 1, zero API quota spent
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓

Related: #125 (consolidating the four channel-resolution implementations) would make this class of fix single-point in future.

Note: GitHub Actions quota exhausted until end of month — no status checks; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel analytics and search-term commands now clearly report an error when the requested channel cannot be found.
  * Channel lookup failures no longer continue silently or produce confusing downstream errors.
  * YouTube handle and channel URL inputs are now classified more accurately.
  * Legacy `/c/` and `/user/` URL formats now return a clear unsupported-format error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->