### PR TITLE
fix(#137): rate-limit retry parity for get-report-data

### DIFF
--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,6 +1,6 @@
 import { google } from 'googleapis';
 import { getAuthenticatedClient } from '../lib/auth';
-import { warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, runOrExit, withRateLimitRetry } from '../lib/utils';
 import { getOutputFormat, getConfigValue } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
 import {
@@ -61,9 +61,10 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
 
     // Step 1: Find or create reporting job
 
-    const jobsResponse = await youtubeReporting.jobs.list({
-      onBehalfOfContentOwner: undefined,
-    });
+    const jobsResponse = await withRateLimitRetry(
+      () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined }),
+      { label: 'jobs.list' }
+    );
 
     const jobs = jobsResponse.data.jobs || [];
     const matchingJob = jobs.find((job: typeof jobs[0]) => job.reportTypeId === options.type);
@@ -77,12 +78,15 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       // Create new job
       spinner.text = `Creating new reporting job for type: ${options.type}...`;
 
-      const createResponse = await youtubeReporting.jobs.create({
-        requestBody: {
-          reportTypeId: options.type,
-          name: `${options.type} Report Job`,
-        },
-      });
+      const createResponse = await withRateLimitRetry(
+        () => youtubeReporting.jobs.create({
+          requestBody: {
+            reportTypeId: options.type,
+            name: `${options.type} Report Job`,
+          },
+        }),
+        { label: `jobs.create(${options.type})` }
+      );
 
       jobId = createResponse.data.id!;
       const jobCreated = new Date(createResponse.data.createTime || '');
@@ -109,11 +113,14 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
     const allFetchedReports: any[] = [];
     let reportsPageToken: string | undefined;
     do {
-      const reportsResponse = await youtubeReporting.jobs.reports.list({
-        jobId,
-        onBehalfOfContentOwner: undefined,
-        pageToken: reportsPageToken,
-      });
+      const reportsResponse = await withRateLimitRetry(
+        () => youtubeReporting.jobs.reports.list({
+          jobId,
+          onBehalfOfContentOwner: undefined,
+          pageToken: reportsPageToken,
+        }),
+        { label: `jobs.reports.list(${options.type})` }
+      );
       const pageReports = reportsResponse.data.reports || [];
       allFetchedReports.push(...pageReports);
       reportsPageToken = reportsResponse.data.nextPageToken || undefined;


### PR DESCRIPTION
Closes #137.

## Value proposition

`fetch-reports` got proper RPM backoff in #89, but `get-report-data` — the command the daily CTR workflow actually reads through — kept making the same three Reporting API calls bare. One 429 at the wrong moment killed the read. Now both commands share identical retry semantics: exponential backoff with `Retry-After` honored on per-minute limits, immediate abort with a clear message on daily exhaustion.

## Changes

`commands/get-report-data.ts` only: `jobs.list`, `jobs.create`, and the `jobs.reports.list` pagination loop wrapped in `withRateLimitRetry` with per-call labels — the exact pattern `fetch-reports` uses. Mechanical now that #134 (retry consolidation) is merged.

## Verification

- Live: `get-report-data --type channel_reach_basic_a1 --start-date 2026-06-28 --end-date 2026-06-30 --output json` → valid rows, exit 0
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓

Note: GitHub Actions quota exhausted until end of month — no status checks; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary rate limits when retrieving YouTube reporting data.
  * Added automatic retries for discovering reporting jobs, creating missing jobs, and loading report pages.
  * Reduced failures caused by API backoff requirements during report retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->