### PR TITLE
fix(#110): finish the migration — throw instead of process.exit in all remaining commands

### DIFF
--- a/commands/auth.ts
+++ b/commands/auth.ts
@@ -1,6 +1,10 @@
 import { authenticate, CredentialsMissingError, printCredentialsSetupInstructions } from '../lib/auth';
 import { success, error } from '../lib/utils';
 
+// NOTE (#110): auth deliberately keeps its process.exit calls. It is an
+// interactive-only command (never reachable from the MCP server), and the
+// OAuth loopback callback server can keep the event loop alive after the
+// flow finishes — exiting is the reliable way to terminate the process.
 async function authCommand(): Promise<void> {
   try {
     console.log('Starting authentication process...\n');

--- a/commands/cache.ts
+++ b/commands/cache.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import chalk from 'chalk';
-import { CACHE_DIR, error, success, info, initCommand, confirm } from '../lib/utils';
+import { CACHE_DIR, success, info, initCommand, confirm } from '../lib/utils';
 
 interface CacheOptions {
   yes?: boolean;
@@ -76,11 +76,11 @@ async function cacheCommand(action?: string, options: CacheOptions = {}): Promis
     return;
   }
 
-  error(`Unknown action: ${action}`);
-  console.log('');
-  console.log('Available actions:');
-  console.log('  clean   Remove all cached data');
-  process.exit(1);
+  throw new Error(
+    `Unknown action: ${action}\n` +
+    'Available actions:\n' +
+    '  clean   Remove all cached data'
+  );
 }
 
 export = cacheCommand;

--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -61,7 +61,10 @@ const VALID_TYPES: CompletionType[] = ['video-id', 'playlist-id', 'report-type']
 
 async function completeCommand(options: { type: string }): Promise<void> {
   try {
-    if (!VALID_TYPES.includes(options.type as CompletionType)) process.exit(0);
+    // Shell completion must always terminate quietly with status 0 — a loud
+    // failure here would garble the user's tab-completion. `return` keeps
+    // that contract without process.exit (issue #110).
+    if (!VALID_TYPES.includes(options.type as CompletionType)) return;
     const type = options.type as CompletionType;
 
     let items: Array<{ id: string; title: string }> | undefined;
@@ -74,7 +77,7 @@ async function completeCommand(options: { type: string }): Promise<void> {
       if (type === 'video-id' || type === 'playlist-id') {
         // Video/playlist completions are channel-specific — require configured channel
         const channel = await getConfigValue('default.channel');
-        if (!channel) process.exit(0);
+        if (!channel) return;
 
         const channelId = await getChannelId(channel);
         const cachePath = getChannelCachePath(channelId);
@@ -144,7 +147,9 @@ async function completeCommand(options: { type: string }): Promise<void> {
       }
     }
   } catch {
-    process.exit(0);
+    // Swallow everything: completion failures must be silent successes
+    // (see note at the top of the function). Return, don't exit (#110).
+    return;
   }
 }
 

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -42,108 +42,100 @@ async function configCommand(
   value?: string,
   options?: ConfigOptions
 ): Promise<void> {
-  try {
-    // Handle --show flag (list all settings)
-    if (options?.show || action === 'list' || !action) {
-      const config = await getConfig();
-      console.log(chalk.bold('\nCurrent Configuration:'));
-      console.log('');
-      console.log(chalk.cyan('default.channel:') + '  ' + (config.default?.channel || chalk.dim('(not set)')));
-      console.log(chalk.cyan('default.output:') + '   ' + (config.default?.output || chalk.dim('pretty')));
-      // getConfigValue returns undefined when lock.timeout was never explicitly
-      // stored, so we correctly show "(default)" only when the user hasn't set it.
-      const explicitLockTimeout = await getConfigValue('lock.timeout');
-      const lockTimeoutDisplay = explicitLockTimeout === undefined
-        ? chalk.dim(`${DEFAULT_LOCK_TIMEOUT_MS}ms (default)`)
-        : `${explicitLockTimeout}ms`;
-      console.log(chalk.cyan('lock.timeout:') + '     ' + lockTimeoutDisplay);
-      console.log('');
-      return;
-    }
-
-    // Handle 'set' action
-    if (action === 'set') {
-      if (!key || !value) {
-        throw new Error(`Usage: staqan-yt config set <key> <value>\n${availableConfigKeysHelp()}`);
-      }
-
-      // Validate key
-      if (!CONFIG_KEYS.includes(key as ConfigKey)) {
-        throw new Error(`Invalid config key: ${key}\n${availableConfigKeysHelp()}`);
-      }
-
-      await setConfigValue(key as ConfigKey, value);
-      if (key === 'default.channel') {
-        await invalidateChannelCache();
-      }
-      const displayValue = key === 'lock.timeout' ? `${value}ms` : value;
-      success(`Set ${chalk.cyan(key)} = ${chalk.yellow(displayValue)}`);
-      return;
-    }
-
-    // Handle 'get' action
-    if (action === 'get') {
-      if (!key) {
-        throw new Error('Usage: staqan-yt config get <key>');
-      }
-
-      if (!CONFIG_KEYS.includes(key as ConfigKey)) {
-        throw new Error(`Invalid config key: ${key}\n${availableConfigKeysHelp()}`);
-      }
-
-      const currentValue = await getConfigValue(key as ConfigKey);
-
-      if (currentValue !== undefined) {
-        console.log(key === 'lock.timeout' ? `${currentValue}ms` : currentValue);
-      } else {
-        info(`${key} is not set`);
-      }
-      return;
-    }
-
-    // Handle 'completion' action
-    if (action === 'completion') {
-      // Determine shell type
-      let shell: 'bash' | 'zsh';
-      if (key && ['bash', 'zsh'].includes(key)) {
-        shell = key as 'bash' | 'zsh';
-      } else if (key === 'auto' || !key) {
-        const detected = detectShell();
-        if (detected === 'auto') {
-          throw new Error('Could not detect shell type. Please specify bash or zsh.');
-        }
-        shell = detected;
-        info(`Auto-detected shell: ${shell}`);
-      } else {
-        throw new Error(
-          `Invalid shell type: ${key}\n` +
-          'Usage: staqan-yt config completion <bash|zsh|auto> [--install|--print]'
-        );
-      }
-
-      const install = options?.install || false;
-      options?.print || false; // Reserved for future use
-
-      try {
-        await installCompletion(shell, !install);
-      } catch (err) {
-        throw new Error((err as Error).message);
-      }
-      return;
-    }
-
-    // Invalid action
-    throw new Error(
-      `Unknown action: ${action}\n` +
-      'Usage:\n' +
-      '  staqan-yt config list              - Show all configuration\n' +
-      '  staqan-yt config set <key> <value> - Set a configuration value\n' +
-      '  staqan-yt config get <key>         - Get a configuration value\n' +
-      '  staqan-yt config completion <bash|zsh|auto> [--install|--print]'
-    );
-  } catch (err) {
-    throw new Error((err as Error).message);
+  // Handle --show flag (list all settings)
+  if (options?.show || action === 'list' || !action) {
+    const config = await getConfig();
+    console.log(chalk.bold('\nCurrent Configuration:'));
+    console.log('');
+    console.log(chalk.cyan('default.channel:') + '  ' + (config.default?.channel || chalk.dim('(not set)')));
+    console.log(chalk.cyan('default.output:') + '   ' + (config.default?.output || chalk.dim('pretty')));
+    // getConfigValue returns undefined when lock.timeout was never explicitly
+    // stored, so we correctly show "(default)" only when the user hasn't set it.
+    const explicitLockTimeout = await getConfigValue('lock.timeout');
+    const lockTimeoutDisplay = explicitLockTimeout === undefined
+      ? chalk.dim(`${DEFAULT_LOCK_TIMEOUT_MS}ms (default)`)
+      : `${explicitLockTimeout}ms`;
+    console.log(chalk.cyan('lock.timeout:') + '     ' + lockTimeoutDisplay);
+    console.log('');
+    return;
   }
+
+  // Handle 'set' action
+  if (action === 'set') {
+    if (!key || !value) {
+      throw new Error(`Usage: staqan-yt config set <key> <value>\n${availableConfigKeysHelp()}`);
+    }
+
+    // Validate key
+    if (!CONFIG_KEYS.includes(key as ConfigKey)) {
+      throw new Error(`Invalid config key: ${key}\n${availableConfigKeysHelp()}`);
+    }
+
+    await setConfigValue(key as ConfigKey, value);
+    if (key === 'default.channel') {
+      await invalidateChannelCache();
+    }
+    const displayValue = key === 'lock.timeout' ? `${value}ms` : value;
+    success(`Set ${chalk.cyan(key)} = ${chalk.yellow(displayValue)}`);
+    return;
+  }
+
+  // Handle 'get' action
+  if (action === 'get') {
+    if (!key) {
+      throw new Error('Usage: staqan-yt config get <key>');
+    }
+
+    if (!CONFIG_KEYS.includes(key as ConfigKey)) {
+      throw new Error(`Invalid config key: ${key}\n${availableConfigKeysHelp()}`);
+    }
+
+    const currentValue = await getConfigValue(key as ConfigKey);
+
+    if (currentValue !== undefined) {
+      console.log(key === 'lock.timeout' ? `${currentValue}ms` : currentValue);
+    } else {
+      info(`${key} is not set`);
+    }
+    return;
+  }
+
+  // Handle 'completion' action
+  if (action === 'completion') {
+    // Determine shell type
+    let shell: 'bash' | 'zsh';
+    if (key && ['bash', 'zsh'].includes(key)) {
+      shell = key as 'bash' | 'zsh';
+    } else if (key === 'auto' || !key) {
+      const detected = detectShell();
+      if (detected === 'auto') {
+        throw new Error('Could not detect shell type. Please specify bash or zsh.');
+      }
+      shell = detected;
+      info(`Auto-detected shell: ${shell}`);
+    } else {
+      throw new Error(
+        `Invalid shell type: ${key}\n` +
+        'Usage: staqan-yt config completion <bash|zsh|auto> [--install|--print]'
+      );
+    }
+
+    const install = options?.install || false;
+    options?.print || false; // Reserved for future use
+
+    await installCompletion(shell, !install);
+    return;
+  }
+
+  // Invalid action
+  throw new Error(
+    `Unknown action: ${action}\n` +
+    'Usage:\n' +
+    '  staqan-yt config list              - Show all configuration\n' +
+    '  staqan-yt config set <key> <value> - Set a configuration value\n' +
+    '  staqan-yt config get <key>         - Get a configuration value\n' +
+    '  staqan-yt config completion <bash|zsh|auto> [--install|--print]'
+  );
 }
 
 export = configCommand;

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -2,15 +2,12 @@ import chalk from 'chalk';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { getConfig, getConfigValue, setConfigValue, DEFAULT_LOCK_TIMEOUT_MS } from '../lib/config';
-import { success, error, info, CACHE_DIR } from '../lib/utils';
+import { success, info, CACHE_DIR } from '../lib/utils';
 import { ConfigKey, CONFIG_KEYS, CONFIG_KEY_HELP } from '../types';
 import { installCompletion, detectShell } from '../lib/completion';
 
-function printAvailableConfigKeys(): void {
-  console.log('Available keys:');
-  CONFIG_KEYS.forEach(k => {
-    console.log(`  ${k.padEnd(18)} - ${CONFIG_KEY_HELP[k]}`);
-  });
+function availableConfigKeysHelp(): string {
+  return 'Available keys:\n' + CONFIG_KEYS.map(k => `  ${k.padEnd(18)} - ${CONFIG_KEY_HELP[k]}`).join('\n');
 }
 
 async function invalidateChannelCache(): Promise<void> {
@@ -67,18 +64,12 @@ async function configCommand(
     // Handle 'set' action
     if (action === 'set') {
       if (!key || !value) {
-        error('Usage: staqan-yt config set <key> <value>');
-        console.log('');
-        printAvailableConfigKeys();
-        process.exit(1);
+        throw new Error(`Usage: staqan-yt config set <key> <value>\n${availableConfigKeysHelp()}`);
       }
 
       // Validate key
       if (!CONFIG_KEYS.includes(key as ConfigKey)) {
-        error(`Invalid config key: ${key}`);
-        console.log('');
-        printAvailableConfigKeys();
-        process.exit(1);
+        throw new Error(`Invalid config key: ${key}\n${availableConfigKeysHelp()}`);
       }
 
       await setConfigValue(key as ConfigKey, value);
@@ -93,15 +84,11 @@ async function configCommand(
     // Handle 'get' action
     if (action === 'get') {
       if (!key) {
-        error('Usage: staqan-yt config get <key>');
-        process.exit(1);
+        throw new Error('Usage: staqan-yt config get <key>');
       }
 
       if (!CONFIG_KEYS.includes(key as ConfigKey)) {
-        error(`Invalid config key: ${key}`);
-        console.log('');
-        printAvailableConfigKeys();
-        process.exit(1);
+        throw new Error(`Invalid config key: ${key}\n${availableConfigKeysHelp()}`);
       }
 
       const currentValue = await getConfigValue(key as ConfigKey);
@@ -123,16 +110,15 @@ async function configCommand(
       } else if (key === 'auto' || !key) {
         const detected = detectShell();
         if (detected === 'auto') {
-          error('Could not detect shell type. Please specify bash or zsh.');
-          process.exit(1);
+          throw new Error('Could not detect shell type. Please specify bash or zsh.');
         }
         shell = detected;
         info(`Auto-detected shell: ${shell}`);
       } else {
-        error(`Invalid shell type: ${key}`);
-        console.log('');
-        console.log('Usage: staqan-yt config completion <bash|zsh|auto> [--install|--print]');
-        process.exit(1);
+        throw new Error(
+          `Invalid shell type: ${key}\n` +
+          'Usage: staqan-yt config completion <bash|zsh|auto> [--install|--print]'
+        );
       }
 
       const install = options?.install || false;
@@ -141,24 +127,22 @@ async function configCommand(
       try {
         await installCompletion(shell, !install);
       } catch (err) {
-        error((err as Error).message);
-        process.exit(1);
+        throw new Error((err as Error).message);
       }
       return;
     }
 
     // Invalid action
-    error(`Unknown action: ${action}`);
-    console.log('');
-    console.log('Usage:');
-    console.log('  staqan-yt config list              - Show all configuration');
-    console.log('  staqan-yt config set <key> <value> - Set a configuration value');
-    console.log('  staqan-yt config get <key>         - Get a configuration value');
-    console.log('  staqan-yt config completion <bash|zsh|auto> [--install|--print]');
-    process.exit(1);
+    throw new Error(
+      `Unknown action: ${action}\n` +
+      'Usage:\n' +
+      '  staqan-yt config list              - Show all configuration\n' +
+      '  staqan-yt config set <key> <value> - Set a configuration value\n' +
+      '  staqan-yt config get <key>         - Get a configuration value\n' +
+      '  staqan-yt config completion <bash|zsh|auto> [--install|--print]'
+    );
   } catch (err) {
-    error((err as Error).message);
-    process.exit(1);
+    throw new Error((err as Error).message);
   }
 }
 

--- a/commands/download-thumbnail.ts
+++ b/commands/download-thumbnail.ts
@@ -7,7 +7,7 @@ import { randomUUID } from 'crypto';
 import path from 'path';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson } from '../lib/formatters';
 import { DownloadThumbnailOptions } from '../types';
@@ -63,14 +63,12 @@ async function downloadThumbnailCommand(options: DownloadThumbnailOptions): Prom
   initCommand(options);
 
   if (!options.videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   const quality: Quality = (options.quality as Quality) || 'maxres';
   if (!VALID_QUALITIES.has(quality)) {
-    error(`Invalid --quality "${quality}". Valid values: ${QUALITY_ORDER.join(', ')}`);
-    process.exit(1);
+    throw new Error(`Invalid --quality "${quality}". Valid values: ${QUALITY_ORDER.join(', ')}`);
   }
 
   const outputDir = options.path ? path.resolve(options.path) : process.cwd();
@@ -89,16 +87,12 @@ async function downloadThumbnailCommand(options: DownloadThumbnailOptions): Prom
     });
 
     if (!response.data.items || response.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const thumbnails = response.data.items[0].snippet?.thumbnails;
     if (!thumbnails) {
-      spinner.fail('No thumbnails available');
-      error('No thumbnail data returned for this video');
-      process.exit(1);
+      throw new Error('No thumbnail data returned for this video');
     }
 
     // Find the best available quality, falling back down the order if not present
@@ -121,9 +115,7 @@ async function downloadThumbnailCommand(options: DownloadThumbnailOptions): Prom
     }
 
     if (!resolvedQuality || !thumbnailUrl) {
-      spinner.fail('No thumbnail available');
-      error(`No thumbnail found for video: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No thumbnail found for video: ${parsedId}`);
     }
 
     if (resolvedQuality !== quality) {

--- a/commands/get-caption.ts
+++ b/commands/get-caption.ts
@@ -1,6 +1,5 @@
-import chalk from 'chalk';
 import { downloadCaption } from '../lib/youtube';
-import { error, debug, initCommand, createSpinner } from '../lib/utils';
+import { debug, initCommand, createSpinner } from '../lib/utils';
 import { GetCaptionOptions, CAPTION_FORMATS } from '../types';
 
 async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
@@ -9,13 +8,11 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
   // Extract caption ID from options
   const captionId = options.captionId;
   if (!captionId) {
-    error('Required: --caption-id');
-    process.exit(1);
+    throw new Error('Required: --caption-id');
   }
 
   if (options.format && !(CAPTION_FORMATS as readonly string[]).includes(options.format)) {
-    error(`Invalid format '${options.format}'. Valid: ${CAPTION_FORMATS.join(', ')}`);
-    process.exit(1);
+    throw new Error(`Invalid format '${options.format}'. Valid: ${CAPTION_FORMATS.join(', ')}`);
   }
 
   // Note: For caption metadata, use list-captions --video-id <videoId>
@@ -33,27 +30,24 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
     console.log(content);
   } catch (err) {
     spinner.fail('Failed to download caption');
-    console.log('');
     const errMessage = (err as Error).message;
+    const tip =
+      '\nTip: Use list-captions <videoId> to see available captions\n' +
+      '     Use get-video <videoId> to check video details';
 
-    // Provide helpful context for common API limitations
+    // Provide helpful context for common API limitations; the throw
+    // propagates to withHelpWrapper for the exit(1) (issue #110).
     if (errMessage.includes('permissions') || errMessage.includes('not sufficient')) {
-      error('Caption download not available — you can only download captions from your own videos');
-      console.log('');
-      console.log(chalk.yellow('YouTube API Limitation:'));
-      console.log(chalk.gray('The captions.download API only works for videos on your authenticated channel.'));
-      console.log(chalk.gray('Downloading captions from other channels\' videos is not permitted.'));
-      console.log('');
-      console.log(chalk.gray('To get the transcript of a video you don\'t own, use a third-party tool or'));
-      console.log(chalk.gray('the YouTube website\'s subtitle/transcript feature instead.'));
-    } else {
-      error(errMessage);
+      throw new Error(
+        'Caption download not available — you can only download captions from your own videos\n' +
+        'YouTube API Limitation:\n' +
+        'The captions.download API only works for videos on your authenticated channel.\n' +
+        "Downloading captions from other channels' videos is not permitted.\n" +
+        "To get the transcript of a video you don't own, use a third-party tool or\n" +
+        "the YouTube website's subtitle/transcript feature instead." + tip
+      );
     }
-
-    console.log('');
-    console.log(chalk.gray('Tip: Use ') + chalk.cyan('list-captions <videoId>') + chalk.gray(' to see available captions'));
-    console.log(chalk.gray('      Use ') + chalk.cyan('get-video <videoId>') + chalk.gray(' to check video details'));
-    process.exit(1);
+    throw new Error(errMessage + tip);
   }
 }
 

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, debug, formatNumber, initCommand, withSpinner, createSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { parseChannelHandle, debug, formatNumber, initCommand, withSpinner, createSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { requireChannel, getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelAnalyticsOptions } from '../types';
@@ -100,8 +100,7 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     try {
       validateDateRange(startDate, endDate);
     } catch (e) {
-      error((e as Error).message);
-      process.exit(1);
+      throw new Error((e as Error).message);
     }
     debug(`Date range: ${startDate} to ${endDate}`);
 
@@ -114,18 +113,14 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
       options.report !== undefined &&
       (options.dimensions !== undefined || options.metrics !== undefined)
     ) {
-      spinner.fail('Conflicting options');
-      error('Cannot combine --report with --dimensions or --metrics. Use one or the other.');
-      process.exit(1);
+      throw new Error('Cannot combine --report with --dimensions or --metrics. Use one or the other.');
     }
 
     if (options.report) {
       // Use predefined report type
       const reportConfig = REPORT_TYPES[options.report];
       if (!reportConfig) {
-        spinner.fail('Invalid report type');
-        error(`Unknown report type: ${options.report}`);
-        process.exit(1);
+        throw new Error(`Unknown report type: ${options.report}`);
       }
       dimensions = reportConfig.dimensions;
       metrics = reportConfig.metrics;
@@ -139,19 +134,17 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
       reportName = 'custom';
       debug('Using custom dimensions and metrics');
     } else {
-      spinner.fail('Report specification required');
-      error('Must specify either --report type or both --dimensions and --metrics');
-      console.log('');
-      console.log('Predefined report types:');
-      console.log('  demographics    - Audience age and gender');
-      console.log('  devices         - Device and OS breakdown');
-      console.log('  geography       - Top countries');
-      console.log('  traffic-sources - Traffic source types');
-      console.log('  subscription-status - Subscribed vs non-subscribed');
-      console.log('');
-      console.log('Or use custom query:');
-      console.log('  --dimensions "deviceType,operatingSystem" --metrics "views,estimatedMinutesWatched"');
-      process.exit(1);
+      throw new Error(
+        'Must specify either --report type or both --dimensions and --metrics\n' +
+        'Predefined report types:\n' +
+        '  demographics    - Audience age and gender\n' +
+        '  devices         - Device and OS breakdown\n' +
+        '  geography       - Top countries\n' +
+        '  traffic-sources - Traffic source types\n' +
+        '  subscription-status - Subscribed vs non-subscribed\n' +
+        'Or use custom query:\n' +
+        '  --dimensions "deviceType,operatingSystem" --metrics "views,estimatedMinutesWatched"'
+      );
     }
 
     // Fetch analytics
@@ -276,35 +269,35 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
       }
     } catch (analyticsErr) {
       analyticsSpinner.fail('Failed to fetch analytics');
-      console.log('');
       const errorMessage = (analyticsErr as Error).message || '';
 
-      // Handle common errors
+      // Translate common API errors into actionable messages; the throw
+      // propagates through withSpinner → withHelpWrapper for the exit(1).
       if (errorMessage.includes('403') || errorMessage.includes('insufficientPermissions')) {
-        error('YouTube Analytics API access denied. Make sure you have:');
-        console.log('  1. Enabled YouTube Analytics API in Google Cloud Console');
-        console.log('  2. Re-authenticated with: staqan-yt auth');
-        console.log('');
-        console.log('Required scope: https://www.googleapis.com/auth/yt-analytics.readonly');
-      } else if (errorMessage.includes('400')) {
-        error('Invalid analytics request. Check your date range, dimensions, and metrics.');
-        console.log('');
-        console.log('Valid report types: demographics, devices, geography, traffic-sources, subscription-status');
-      } else if (errorMessage.includes('not supported')) {
-        error('Report type not available for this channel.');
-        console.log('');
-        console.log(chalk.dim('Demographic data might be limited because:'));
-        console.log(chalk.dim('  1. Metrics do not meet certain thresholds'));
-        console.log(chalk.dim('  2. Channel has limited traffic during the time period'));
-        console.log('');
-        console.log(chalk.dim('Learn more: https://developers.google.com/youtube/analytics/data_model#data-anonymization'));
-        console.log('');
-        console.log(chalk.dim('Try other report types: devices, geography, traffic-sources, subscription-status'));
-      } else {
-        error(errorMessage);
+        throw new Error(
+          'YouTube Analytics API access denied. Make sure you have:\n' +
+          '  1. Enabled YouTube Analytics API in Google Cloud Console\n' +
+          '  2. Re-authenticated with: staqan-yt auth\n' +
+          'Required scope: https://www.googleapis.com/auth/yt-analytics.readonly'
+        );
       }
-
-      process.exit(1);
+      if (errorMessage.includes('400')) {
+        throw new Error(
+          'Invalid analytics request. Check your date range, dimensions, and metrics.\n' +
+          'Valid report types: demographics, devices, geography, traffic-sources, subscription-status'
+        );
+      }
+      if (errorMessage.includes('not supported')) {
+        throw new Error(
+          'Report type not available for this channel.\n' +
+          'Demographic data might be limited because:\n' +
+          '  1. Metrics do not meet certain thresholds\n' +
+          '  2. Channel has limited traffic during the time period\n' +
+          'Learn more: https://developers.google.com/youtube/analytics/data_model#data-anonymization\n' +
+          'Try other report types: devices, geography, traffic-sources, subscription-status'
+        );
+      }
+      throw analyticsErr;
     }
   });
 }

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -97,11 +97,7 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     const startDate = options.startDate ||
       toLocalYmd(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
 
-    try {
-      validateDateRange(startDate, endDate);
-    } catch (e) {
-      throw new Error((e as Error).message);
-    }
+    validateDateRange(startDate, endDate);
     debug(`Date range: ${startDate} to ${endDate}`);
 
     // Determine dimensions and metrics based on report type or custom

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseChannelHandle, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, parseDuration, runOrExit } from '../lib/utils';
+import { parseChannelHandle, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, parseDuration, runOrExit } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelSearchTermsOptions } from '../types';
@@ -45,8 +45,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
   // silently fall through to the 'all' branch below.
   const validContentTypes = ['all', 'video', 'shorts'];
   if (options.contentType !== undefined && !validContentTypes.includes(options.contentType)) {
-    error(`Invalid --content-type "${options.contentType}". Valid values: ${validContentTypes.join(', ')}`);
-    process.exit(1);
+    throw new Error(`Invalid --content-type "${options.contentType}". Valid values: ${validContentTypes.join(', ')}`);
   }
 
   await withSpinner('Resolving channel...', 'Failed to fetch channel search terms', async (spinner) => {
@@ -76,9 +75,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
       });
 
       if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
-        spinner.fail('Channel not found');
-        error(`Channel not found: ${channelArg}`);
-        process.exit(1);
+        throw new Error(`Channel not found: ${channelArg}`);
       }
 
       channelId = channelResponse.data.items[0].id!;
@@ -103,9 +100,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     debug('Uploads playlist ID:', uploadsPlaylistId);
 
     if (!uploadsPlaylistId) {
-      spinner.fail('Could not determine uploads playlist');
-      error('Unable to find the uploads playlist for this channel.');
-      process.exit(1);
+      throw new Error('Unable to find the uploads playlist for this channel.');
     }
 
     // Fetch video IDs from the uploads playlist.
@@ -136,9 +131,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     debug(`Collected ${videoIds.length} video IDs`);
 
     if (videoIds.length === 0) {
-      spinner.fail('No videos found');
-      error('No videos found for this channel.');
-      process.exit(1);
+      throw new Error('No videos found for this channel.');
     }
 
     // --content-type filtering is done CLIENT-SIDE by duration, because the
@@ -177,12 +170,10 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
       debug(`Content-type filter (${contentType}): ${videoIds.length} → ${filtered.length} videos`);
 
       if (filtered.length === 0) {
-        spinner.fail(`No ${wantShorts ? 'Shorts' : 'long-form videos'} found`);
-        error(
+        throw new Error(
           `No ${wantShorts ? 'Shorts' : 'long-form videos'} found for this channel. ` +
           `Try a different --content-type value or omit the flag for all videos.`
         );
-        process.exit(1);
       }
 
       // Mutate in place: subsequent filter assembly uses the trimmed list.

--- a/commands/get-channel.ts
+++ b/commands/get-channel.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getChannelInfo } from '../lib/youtube';
-import { formatDate, formatNumber, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { formatDate, formatNumber, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ChannelOption, OutputOption, VerboseOption } from '../types';
@@ -14,11 +14,11 @@ async function getChannelCommand(options: ChannelOption & OutputOption & Verbose
     handleOrId = await requireChannel(options.channel);
     debug(`Using channel: ${handleOrId}`);
   } catch (err) {
-    error((err as Error).message);
-    console.log('');
-    console.log(chalk.gray('Usage:') + ' staqan-yt get-channel --channel @yourchannel');
-    console.log(chalk.gray('Or set default:') + ' staqan-yt config set default.channel @yourchannel');
-    process.exit(1);
+    throw new Error(
+      `${(err as Error).message}\n` +
+      'Usage: staqan-yt get-channel --channel @yourchannel\n' +
+      'Or set default: staqan-yt config set default.channel @yourchannel'
+    );
   }
 
   await withSpinner('Fetching channel information...', 'Failed to fetch channel information', async (spinner) => {

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, runOrExit } from '../lib/utils';
+import { parseVideoId, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, runOrExit } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchTermsOptions } from '../types';
@@ -12,8 +12,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   const limit = runOrExit(() => parsePositiveInt('--limit', options.limit, 50));
@@ -33,9 +32,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     });
 
     if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const title = videoResponse.data.items[0].snippet?.title || 'Untitled';

--- a/commands/get-thumbnail.ts
+++ b/commands/get-thumbnail.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { GetThumbnailOptions } from '../types';
@@ -13,8 +13,7 @@ async function getThumbnailCommand(options: GetThumbnailOptions): Promise<void> 
 
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   await withSpinner('Fetching video thumbnail...', 'Failed to fetch video thumbnail', async (spinner) => {
@@ -30,9 +29,7 @@ async function getThumbnailCommand(options: GetThumbnailOptions): Promise<void> 
     });
 
     if (!response.data.items || response.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const video = response.data.items[0];

--- a/commands/get-traffic-sources.ts
+++ b/commands/get-traffic-sources.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
+import { parseVideoId, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { TrafficSourcesOptions } from '../types';
@@ -12,8 +12,7 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   await withSpinner('Fetching traffic sources...', 'Failed to fetch traffic sources', async (spinner) => {
@@ -31,9 +30,7 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
     });
 
     if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const title = videoResponse.data.items[0].snippet?.title || 'Untitled';

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, formatNumber, convertToCSV, chunkDateRange, withRateLimitRetry, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { parseVideoId, debug, formatNumber, convertToCSV, chunkDateRange, withRateLimitRetry, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
@@ -12,8 +12,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   runOrExit(() => { if (options.startDate) validateDateOption('--start-date', options.startDate); });
@@ -35,9 +34,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     });
 
     if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const video = videoResponse.data.items[0];
@@ -45,9 +42,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     const publishedAt = video.snippet?.publishedAt;
 
     if (!publishedAt) {
-      spinner.fail('Could not determine video publish date');
-      error('Video publish date is missing');
-      process.exit(1);
+      throw new Error('Video publish date is missing');
     }
 
     // Calculate date range

--- a/commands/get-video-localization.ts
+++ b/commands/get-video-localization.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getVideoLocalization } from '../lib/youtube';
-import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { LocalizationOptions } from '../types';
@@ -11,8 +11,7 @@ async function getVideoLocalizationCommand(options: LocalizationOptions): Promis
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   const language = options.language; // Can be undefined, will default to main metadata language

--- a/commands/get-video-localizations.ts
+++ b/commands/get-video-localizations.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getAllVideoLocalizations } from '../lib/youtube';
-import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { VideoIdsOption, VideoLocalization, OutputOption, VerboseOption } from '../types';
@@ -15,8 +15,7 @@ async function getVideoLocalizations(options: GetVideoLocalizationsOptions): Pro
   // Extract video IDs from options
   const videoIds = options.videoIds;
   if (!videoIds || videoIds.length === 0) {
-    error('Required: --video-ids');
-    process.exit(1);
+    throw new Error('Required: --video-ids');
   }
 
   await withSpinner('Fetching video localizations...', 'Failed to fetch video localizations', async (spinner) => {

--- a/commands/get-video-retention.ts
+++ b/commands/get-video-retention.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, convertToCSV, chunkDateRange, withRateLimitRetry, parseDuration, formatTimestamp, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
+import { parseVideoId, debug, convertToCSV, chunkDateRange, withRateLimitRetry, parseDuration, formatTimestamp, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { RetentionOptions } from '../types';
@@ -12,8 +12,7 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   await withSpinner('Fetching video information...', 'Failed to fetch retention data', async (spinner) => {
@@ -31,9 +30,7 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
     });
 
     if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const video = videoResponse.data.items[0];
@@ -42,9 +39,7 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
     const duration = video.contentDetails?.duration || '';
 
     if (!publishedAt) {
-      spinner.fail('Could not determine video publish date');
-      error('Video publish date is missing');
-      process.exit(1);
+      throw new Error('Video publish date is missing');
     }
 
     // Calculate date range (default: full historical data)

--- a/commands/get-video-tags.ts
+++ b/commands/get-video-tags.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { GetTagsOptions } from '../types';
@@ -12,8 +12,7 @@ async function getVideoTagsCommand(options: GetTagsOptions): Promise<void> {
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   await withSpinner('Fetching video tags...', 'Failed to fetch video tags', async (spinner) => {
@@ -29,9 +28,7 @@ async function getVideoTagsCommand(options: GetTagsOptions): Promise<void> {
     });
 
     if (!response.data.items || response.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const video = response.data.items[0];

--- a/commands/list-captions.ts
+++ b/commands/list-captions.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { listCaptions } from '../lib/youtube';
-import { debug, error, initCommand, withSpinner } from '../lib/utils';
+import { debug, initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ListCaptionsOptions } from '../types';
@@ -11,8 +11,7 @@ async function listCaptionsCommand(options: ListCaptionsOptions): Promise<void> 
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   await withSpinner('Fetching captions...', 'Failed to fetch captions', async (spinner) => {

--- a/commands/list-comments.ts
+++ b/commands/list-comments.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { listVideoComments } from '../lib/youtube';
-import { formatDate, error, parsePositiveInt, debug, parseVideoId, initCommand, withSpinner, runOrExit } from '../lib/utils';
+import { formatDate, parsePositiveInt, debug, parseVideoId, initCommand, withSpinner, runOrExit } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { ListCommentsOptions } from '../types';
@@ -11,8 +11,7 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
   // Extract video ID from options
   const videoIdInput = options.videoId;
   if (!videoIdInput) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   // Parse video ID from URL or raw ID
@@ -20,15 +19,13 @@ async function listCommentsCommand(options: ListCommentsOptions): Promise<void> 
 
   // Validate video ID format (basic check)
   if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
-    error('Invalid video ID format. Video IDs should be 11 characters.');
-    process.exit(1);
+    throw new Error('Invalid video ID format. Video IDs should be 11 characters.');
   }
 
   // Determine sort order
   const validSorts = ['new', 'top'];
   if (options.sort !== undefined && !validSorts.includes(options.sort)) {
-    error(`Invalid --sort "${options.sort}". Valid values: new, top`);
-    process.exit(1);
+    throw new Error(`Invalid --sort "${options.sort}". Valid values: new, top`);
   }
   const sortOrder = options.sort === 'new' ? 'time' : 'relevance';
   const limit = runOrExit(() => parsePositiveInt('--limit', options.limit, 20));

--- a/commands/put-video-localization.ts
+++ b/commands/put-video-localization.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { putVideoLocalization } from '../lib/youtube';
-import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { normalizeLanguage, getLanguageName } from '../lib/language';
 import { PutLocalizationOptions } from '../types';
 
@@ -10,26 +10,22 @@ async function putVideoLocalizationCommand(options: PutLocalizationOptions): Pro
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   const { language, title, description } = options;
 
   // Validation: Required options
   if (!language) {
-    error('Error: --language is required');
-    process.exit(1);
+    throw new Error('Error: --language is required');
   }
 
   if (!title) {
-    error('Error: --title is required');
-    process.exit(1);
+    throw new Error('Error: --title is required');
   }
 
   if (!description) {
-    error('Error: --description is required');
-    process.exit(1);
+    throw new Error('Error: --description is required');
   }
 
   const langCode = normalizeLanguage(language);

--- a/commands/put-video-localization.ts
+++ b/commands/put-video-localization.ts
@@ -17,15 +17,15 @@ async function putVideoLocalizationCommand(options: PutLocalizationOptions): Pro
 
   // Validation: Required options
   if (!language) {
-    throw new Error('Error: --language is required');
+    throw new Error('Required: --language');
   }
 
   if (!title) {
-    throw new Error('Error: --title is required');
+    throw new Error('Required: --title');
   }
 
   if (!description) {
-    throw new Error('Error: --description is required');
+    throw new Error('Required: --description');
   }
 
   const langCode = normalizeLanguage(language);

--- a/commands/search-videos.ts
+++ b/commands/search-videos.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { searchVideos } from '../lib/youtube';
-import { formatDate, error, parsePositiveInt, debug, initCommand, withSpinner, runOrExit } from '../lib/utils';
+import { formatDate, parsePositiveInt, debug, initCommand, withSpinner, runOrExit } from '../lib/utils';
 import { getConfigValue, getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchVideosOptions, QueryOption } from '../types';
@@ -10,8 +10,7 @@ async function searchVideosCommand(options: SearchVideosOptions & QueryOption): 
 
   const query = options.query;
   if (!query) {
-    error('Required: --query');
-    process.exit(1);
+    throw new Error('Required: --query');
   }
 
   // Determine search mode
@@ -20,13 +19,13 @@ async function searchVideosCommand(options: SearchVideosOptions & QueryOption): 
 
   // Validation: can't use both --global and --channel
   if (isGlobal && explicitChannel) {
-    error('Cannot use both --global and --channel flags together');
-    console.log('');
-    console.log(chalk.yellow('Use either:'));
-    console.log('  - staqan-yt search-videos --query "<query>" --global');
-    console.log('  - staqan-yt search-videos --query "<query>" --channel @handle');
-    console.log('  - staqan-yt search-videos --query "<query>" (uses config default.channel)');
-    process.exit(1);
+    throw new Error(
+      'Cannot use both --global and --channel flags together\n' +
+      'Use either:\n' +
+      '  - staqan-yt search-videos --query "<query>" --global\n' +
+      '  - staqan-yt search-videos --query "<query>" --channel @handle\n' +
+      '  - staqan-yt search-videos --query "<query>" (uses config default.channel)'
+    );
   }
 
   let searchMode: 'global' | 'channel';
@@ -43,18 +42,17 @@ async function searchVideosCommand(options: SearchVideosOptions & QueryOption): 
     // Try to load from config
     targetChannel = await getConfigValue('default.channel');
     if (!targetChannel) {
-      error('No channel specified');
-      console.log('');
-      console.log(chalk.yellow('Options:'));
-      console.log('  1. Use --global flag to search all of YouTube');
-      console.log('  2. Use --channel @handle to search a specific channel');
-      console.log('  3. Set a default channel: staqan-yt config set default.channel @yourChannel');
-      console.log('');
-      console.log(chalk.gray('Examples:'));
-      console.log(chalk.gray('  staqan-yt search-videos --query "tutorial" --global'));
-      console.log(chalk.gray('  staqan-yt search-videos --query "tutorial" --channel @mkbhd'));
-      console.log(chalk.gray('  staqan-yt config set default.channel @mkbhd'));
-      process.exit(1);
+      throw new Error(
+        'No channel specified\n' +
+        'Options:\n' +
+        '  1. Use --global flag to search all of YouTube\n' +
+        '  2. Use --channel @handle to search a specific channel\n' +
+        '  3. Set a default channel: staqan-yt config set default.channel @yourChannel\n' +
+        'Examples:\n' +
+        '  staqan-yt search-videos --query "tutorial" --global\n' +
+        '  staqan-yt search-videos --query "tutorial" --channel @mkbhd\n' +
+        '  staqan-yt config set default.channel @mkbhd'
+      );
     }
     searchMode = 'channel';
     debug(`Channel search mode with config default: ${targetChannel}`);

--- a/commands/update-video-localization.ts
+++ b/commands/update-video-localization.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { updateVideoLocalization } from '../lib/youtube';
-import { parseVideoId, error, debug, initCommand, withSpinner } from '../lib/utils';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { normalizeLanguage, getLanguageName } from '../lib/language';
 import { UpdateLocalizationOptions } from '../types';
 
@@ -10,22 +10,19 @@ async function updateVideoLocalizationCommand(options: UpdateLocalizationOptions
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   const { language, title, description } = options;
 
   // Validation: Required language
   if (!language) {
-    error('Error: --language is required');
-    process.exit(1);
+    throw new Error('Error: --language is required');
   }
 
   // Validation: At least one of title or description must be provided
   if (!title && !description) {
-    error('Error: At least one of --title or --description must be provided');
-    process.exit(1);
+    throw new Error('Error: At least one of --title or --description must be provided');
   }
 
   const langCode = normalizeLanguage(language);

--- a/commands/update-video-localization.ts
+++ b/commands/update-video-localization.ts
@@ -17,12 +17,12 @@ async function updateVideoLocalizationCommand(options: UpdateLocalizationOptions
 
   // Validation: Required language
   if (!language) {
-    throw new Error('Error: --language is required');
+    throw new Error('Required: --language');
   }
 
   // Validation: At least one of title or description must be provided
   if (!title && !description) {
-    throw new Error('Error: At least one of --title or --description must be provided');
+    throw new Error('At least one of --title or --description must be provided');
   }
 
   const langCode = normalizeLanguage(language);

--- a/commands/update-video-tags.ts
+++ b/commands/update-video-tags.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, confirm, success, error, warning, info, debug, initCommand, createSpinner } from '../lib/utils';
+import { parseVideoId, confirm, success, warning, info, debug, initCommand, createSpinner } from '../lib/utils';
 import { UpdateTagsOptions } from '../types';
 
 async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void> {
@@ -10,8 +10,7 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
   // Extract video ID from options
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   try {
@@ -20,16 +19,16 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
 
     // Validate that at least one update is provided
     if (!options.replace && !options.add && !options.remove) {
-      error('Please provide at least one of --replace, --add, or --remove');
-      process.exit(1);
+      throw new Error('Please provide at least one of --replace, --add, or --remove');
     }
 
     // --replace is rewrite mode; --add/--remove is incremental mode — cannot mix
     if (options.replace && (options.add || options.remove)) {
-      error('--replace cannot be combined with --add or --remove');
-      console.log(chalk.gray('  Rewrite mode:      --replace "foo,bar"'));
-      console.log(chalk.gray('  Incremental mode:  --add "foo" --remove "bar"'));
-      process.exit(1);
+      throw new Error(
+        '--replace cannot be combined with --add or --remove\n' +
+        '  Rewrite mode:      --replace "foo,bar"\n' +
+        '  Incremental mode:  --add "foo" --remove "bar"'
+      );
     }
 
     // Fetch current video info
@@ -43,9 +42,7 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     });
 
     if (!response.data.items || response.data.items.length === 0) {
-      spinner.fail('Video not found');
-      error(`No video found with ID: ${parsedId}`);
-      process.exit(1);
+      throw new Error(`No video found with ID: ${parsedId}`);
     }
 
     const video = response.data.items[0];
@@ -159,20 +156,18 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     console.log('');
     success(`Video updated: https://youtube.com/watch?v=${parsedId}`);
   } catch (err) {
-    console.log('');
     const errorMessage = (err as Error).message;
+    // The throw propagates to withHelpWrapper for the exit(1) (issue #110).
     if (errorMessage.includes('invalid video keywords')) {
-      error('Cannot update video tags');
-      console.log('');
-      console.log(chalk.gray('This usually means one of two things:'));
-      console.log(chalk.gray('  1. You don\'t have permission to modify this video (not your channel)'));
-      console.log(chalk.gray('  2. Tags contain invalid characters or exceed length limits'));
-      console.log('');
-      console.log(chalk.gray('Tip: Tags use comma-separated format: --add "tokyo bar,craft beer,nightlife"'));
-    } else {
-      error(`Failed to update tags: ${errorMessage}`);
+      throw new Error(
+        'Cannot update video tags\n' +
+        'This usually means one of two things:\n' +
+        "  1. You don't have permission to modify this video (not your channel)\n" +
+        '  2. Tags contain invalid characters or exceed length limits\n' +
+        'Tip: Tags use comma-separated format: --add "tokyo bar,craft beer,nightlife"'
+      );
     }
-    process.exit(1);
+    throw new Error(`Failed to update tags: ${errorMessage}`);
   }
 }
 

--- a/commands/update-video.ts
+++ b/commands/update-video.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { getVideoInfo, updateVideoMetadata } from '../lib/youtube';
-import { parseVideoId, confirm, success, error, warning, info, debug, initCommand, createSpinner } from '../lib/utils';
+import { parseVideoId, confirm, success, warning, info, debug, initCommand, createSpinner } from '../lib/utils';
 import { UpdateVideoOptions, VideoIdOption } from '../types';
 
 async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption): Promise<void> {
@@ -8,8 +8,7 @@ async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption
 
   const videoId = options.videoId;
   if (!videoId) {
-    error('Required: --video-id');
-    process.exit(1);
+    throw new Error('Required: --video-id');
   }
 
   try {
@@ -19,8 +18,7 @@ async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption
 
     // Validate that at least one update is provided
     if (!options.title && !options.description) {
-      error('Please provide at least one of --title or --description');
-      process.exit(1);
+      throw new Error('Please provide at least one of --title or --description');
     }
 
     // Fetch current video info
@@ -81,8 +79,7 @@ async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption
     success(`Video updated: https://youtube.com/watch?v=${parsedId}`);
   } catch (err) {
     console.log('');
-    error(`Failed to update metadata: ${(err as Error).message}`);
-    process.exit(1);
+    throw new Error(`Failed to update metadata: ${(err as Error).message}`);
   }
 }
 

--- a/commands/update-video.ts
+++ b/commands/update-video.ts
@@ -11,15 +11,17 @@ async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption
     throw new Error('Required: --video-id');
   }
 
+  // Validate that at least one update is provided — before the try block so
+  // the catch below can't re-wrap this as a misleading "Failed to update
+  // metadata" (the request never leaves the client).
+  if (!options.title && !options.description) {
+    throw new Error('Please provide at least one of --title or --description');
+  }
+
   try {
     debug(`Video ID input: ${videoId}`);
     const parsedId = parseVideoId(videoId);
     debug(`Parsed video ID: ${parsedId}`);
-
-    // Validate that at least one update is provided
-    if (!options.title && !options.description) {
-      throw new Error('Please provide at least one of --title or --description');
-    }
 
     // Fetch current video info
     const spinner = createSpinner('Fetching current video metadata...').start();


### PR DESCRIPTION
Closes #110.

## Value proposition

This is the final installment of #110: after #121 (helpers) and #132 (MCP-critical reporting commands), **66 `process.exit` sites across 21 command files** remained — each one a landmine for any long-lived host process, and each one a place where error text was scattered between `error()` calls and loose `console.log`s that in-process callers never saw. Now every command communicates failure the same way: throw; `withSpinner`/`withHelpWrapper` print once and own the exit code. With this merged, `grep process.exit commands/` returns only the two documented exceptions.

## Approach

- ~52 sites were the two mechanical shapes (`error(msg); exit(1)` with or without a preceding `spinner.fail`) → converted by codemod to `throw new Error(msg)`.
- 14 sites had multi-line guidance (usage examples, API-limitation explanations, config-key listings) → guidance folded into the thrown message, same pattern CodeRabbit approved in #132. `config.ts`'s key listing kept its per-key descriptions via a string-builder helper.
- `get-channel-analytics`' catch-and-classify block (403/400/not-supported) now throws per-branch translated errors instead of printing then exiting.

## Deliberate exceptions (documented in-code)

- **`auth.ts` keeps `exit(0)`/`exit(1)`**: interactive-only (unreachable from MCP), and the OAuth loopback callback server can keep the event loop alive after the flow — exiting is the reliable termination.
- **`complete.ts`**: `exit(0)` → `return` — shell completion must remain a *silent success* on any failure, and return preserves exactly that through normal flow.
- **`bin/staqan-yt.ts`**: the CLI process boundary; its exits are the design.

## Verification (live)

| Path | Result |
|---|---|
| `cache bogus` / `config set bogus.key x` / `search-videos --global --channel` / `update-video-tags --replace+--add` / `get-caption --format bogus` | correct messages incl. folded guidance, **exit 1** |
| `get-channel-analytics` without report spec | full predefined-types guidance in message, exit 1 |
| `__complete --type bogus` | empty output, **exit 0** (completion contract preserved) |
| `config get default.output`, `list-videos -l 2 --output json` | normal output, exit 0 |
| `bun run type-check` / `lint` / `build` | ✓ / ✓ (0 errors, 11 pre-existing warnings) / ✓ |

Note: GitHub Actions quota exhausted until end of month — no status checks; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command failures so they are handled consistently without abruptly terminating the CLI; validation and API issues now surface reliably across many commands.
  * Added clearer, more complete error messages for missing/invalid options and for “no video/channel/data found” scenarios (including analytics, captions, thumbnails, traffic sources, and tags).
  * Enhanced guidance in errors for configuration, search targeting, permissions/authorization-related analytics failures, and localization flows.
  * Completion commands now remain quiet and return successfully when no completion can be generated; config-related failures show full usage/available-key help in the message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->