### PR TITLE
feat(#124): implement --output on config + mutation commands; remove auth's dead flag

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -178,11 +178,11 @@ program
     program.help();
   });
 
-// Auth command
+// Auth command. No --output flag: the interactive OAuth flow produces no
+// data to format (the flag was advertised but never read — issue #124).
 program
   .command('auth')
   .description('Authenticate with YouTube API using OAuth 2.0')
-  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(authCommand);
 

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk';
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { getConfig, getConfigValue, setConfigValue, DEFAULT_LOCK_TIMEOUT_MS } from '../lib/config';
+import { getConfig, getConfigValue, setConfigValue, getOutputFormat, DEFAULT_LOCK_TIMEOUT_MS } from '../lib/config';
 import { success, info, CACHE_DIR } from '../lib/utils';
-import { ConfigKey, CONFIG_KEYS, CONFIG_KEY_HELP } from '../types';
+import { formatData } from '../lib/formatters';
+import { ConfigKey, CONFIG_KEYS, CONFIG_KEY_HELP, OutputFormat } from '../types';
 import { installCompletion, detectShell } from '../lib/completion';
 
 function availableConfigKeysHelp(): string {
@@ -30,6 +31,7 @@ interface ConfigOptions {
   show?: boolean;
   install?: boolean;
   print?: boolean;
+  output?: OutputFormat;
 }
 
 /**
@@ -42,16 +44,28 @@ async function configCommand(
   value?: string,
   options?: ConfigOptions
 ): Promise<void> {
+  const outputFormat = await getOutputFormat(options?.output);
+
   // Handle --show flag (list all settings)
   if (options?.show || action === 'list' || !action) {
     const config = await getConfig();
+    // getConfigValue returns undefined when lock.timeout was never explicitly
+    // stored, so we correctly show "(default)" only when the user hasn't set it.
+    const explicitLockTimeout = await getConfigValue('lock.timeout');
+
+    if (outputFormat !== 'pretty') {
+      console.log(formatData([
+        { key: 'default.channel', value: config.default?.channel ?? null },
+        { key: 'default.output', value: config.default?.output ?? 'pretty' },
+        { key: 'lock.timeout', value: explicitLockTimeout !== undefined ? Number(explicitLockTimeout) : DEFAULT_LOCK_TIMEOUT_MS },
+      ], outputFormat));
+      return;
+    }
+
     console.log(chalk.bold('\nCurrent Configuration:'));
     console.log('');
     console.log(chalk.cyan('default.channel:') + '  ' + (config.default?.channel || chalk.dim('(not set)')));
     console.log(chalk.cyan('default.output:') + '   ' + (config.default?.output || chalk.dim('pretty')));
-    // getConfigValue returns undefined when lock.timeout was never explicitly
-    // stored, so we correctly show "(default)" only when the user hasn't set it.
-    const explicitLockTimeout = await getConfigValue('lock.timeout');
     const lockTimeoutDisplay = explicitLockTimeout === undefined
       ? chalk.dim(`${DEFAULT_LOCK_TIMEOUT_MS}ms (default)`)
       : `${explicitLockTimeout}ms`;
@@ -75,6 +89,9 @@ async function configCommand(
     if (key === 'default.channel') {
       await invalidateChannelCache();
     }
+    if (outputFormat !== 'pretty') {
+      console.log(formatData([{ key, value }], outputFormat));
+    }
     const displayValue = key === 'lock.timeout' ? `${value}ms` : value;
     success(`Set ${chalk.cyan(key)} = ${chalk.yellow(displayValue)}`);
     return;
@@ -91,6 +108,13 @@ async function configCommand(
     }
 
     const currentValue = await getConfigValue(key as ConfigKey);
+
+    // 'text' and 'pretty' keep the raw-value contract (`config get x` has
+    // always printed just the value — scripts depend on it).
+    if (outputFormat !== 'pretty' && outputFormat !== 'text') {
+      console.log(formatData([{ key, value: currentValue ?? null }], outputFormat));
+      return;
+    }
 
     if (currentValue !== undefined) {
       console.log(key === 'lock.timeout' ? `${currentValue}ms` : currentValue);

--- a/commands/put-video-localization.ts
+++ b/commands/put-video-localization.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import { putVideoLocalization } from '../lib/youtube';
 import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { normalizeLanguage, getLanguageName } from '../lib/language';
+import { getOutputFormat } from '../lib/config';
+import { formatData } from '../lib/formatters';
 import { PutLocalizationOptions } from '../types';
 
 async function putVideoLocalizationCommand(options: PutLocalizationOptions): Promise<void> {
@@ -34,6 +36,8 @@ async function putVideoLocalizationCommand(options: PutLocalizationOptions): Pro
   debug(`Title length: ${title.length} chars`);
   debug(`Description length: ${description.length} chars`);
 
+  const outputFormat = await getOutputFormat(options.output);
+
   await withSpinner(`Creating ${langName} localization...`, 'Failed to create localization', async (spinner) => {
     debug(`Video ID input: ${videoId}`);
     const parsedId = parseVideoId(videoId);
@@ -41,7 +45,21 @@ async function putVideoLocalizationCommand(options: PutLocalizationOptions): Pro
 
     await putVideoLocalization(parsedId, language, title, description);
 
+    // Spinner output goes to stderr, so machine formats stay pipeable.
     spinner.succeed(chalk.green(`Successfully created ${langName} (${langCode}) localization`));
+
+    if (outputFormat !== 'pretty') {
+      console.log(formatData([{
+        videoId: parsedId,
+        language: langCode,
+        languageName: langName,
+        title,
+        description,
+        action: 'created',
+      }], outputFormat));
+      return;
+    }
+
     console.log('');
     console.log(chalk.gray(`Video ID: ${parsedId}`));
     const titlePreview = title.length > 60 ? title.substring(0, 60) + '...' : title;

--- a/commands/update-video-localization.ts
+++ b/commands/update-video-localization.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import { updateVideoLocalization } from '../lib/youtube';
 import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { normalizeLanguage, getLanguageName } from '../lib/language';
+import { getOutputFormat } from '../lib/config';
+import { formatData } from '../lib/formatters';
 import { UpdateLocalizationOptions } from '../types';
 
 async function updateVideoLocalizationCommand(options: UpdateLocalizationOptions): Promise<void> {
@@ -31,6 +33,8 @@ async function updateVideoLocalizationCommand(options: UpdateLocalizationOptions
   if (title) debug(`New title length: ${title.length} chars`);
   if (description) debug(`New description length: ${description.length} chars`);
 
+  const outputFormat = await getOutputFormat(options.output);
+
   await withSpinner(`Updating ${langName} localization...`, 'Failed to update localization', async (spinner) => {
     debug(`Video ID input: ${videoId}`);
     const parsedId = parseVideoId(videoId);
@@ -38,7 +42,21 @@ async function updateVideoLocalizationCommand(options: UpdateLocalizationOptions
 
     await updateVideoLocalization(parsedId, language, title || null, description || null);
 
+    // Spinner output goes to stderr, so machine formats stay pipeable.
     spinner.succeed(chalk.green(`Successfully updated ${langName} (${langCode}) localization`));
+
+    if (outputFormat !== 'pretty') {
+      console.log(formatData([{
+        videoId: parsedId,
+        language: langCode,
+        languageName: langName,
+        title: title ?? null,
+        description: description ?? null,
+        action: 'updated',
+      }], outputFormat));
+      return;
+    }
+
     console.log('');
     console.log(chalk.gray(`Video ID: ${parsedId}`));
     if (title) {

--- a/commands/update-video-tags.ts
+++ b/commands/update-video-tags.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
 import { parseVideoId, confirm, success, warning, info, debug, initCommand, createSpinner } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatData } from '../lib/formatters';
 import { UpdateTagsOptions } from '../types';
 
 async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void> {
@@ -50,7 +52,8 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     const title = video.snippet?.title || 'Untitled';
 
     spinner.succeed('Current tags retrieved');
-    console.log('');
+
+    const outputFormat = await getOutputFormat(options.output);
 
     // Calculate new tags
     let newTags: string[] = [];
@@ -79,50 +82,57 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
       }
     }
 
-    // Show current state
-    console.log(chalk.bold.cyan(title));
-    console.log(chalk.gray('Video ID: ') + chalk.yellow(parsedId));
-    console.log('');
-
-    console.log(chalk.bold('Current tags:'));
-    if (currentTags.length === 0) {
-      console.log(chalk.gray('  (No tags)'));
-    } else {
-      currentTags.forEach(tag => {
-        console.log(`  ${tag}`);
-      });
-    }
-    console.log('');
-
-    // Show proposed changes
-    console.log(chalk.bold('New tags:'));
-    if (newTags.length === 0) {
-      console.log(chalk.gray('  (No tags)'));
-    } else {
-      newTags.forEach(tag => {
-        const isNew = !currentTags.includes(tag);
-        if (isNew) {
-          console.log(chalk.green(`  + ${tag}`));
-        } else {
-          console.log(`  ${tag}`);
-        }
-      });
-    }
-
-    // Show removed tags
     const removedTags = currentTags.filter(tag => !newTags.includes(tag));
-    if (removedTags.length > 0) {
-      console.log('');
-      console.log(chalk.bold('Removed tags:'));
-      removedTags.forEach(tag => {
-        console.log(chalk.red(`  - ${tag}`));
-      });
-    }
+    const addedTags = newTags.filter(tag => !currentTags.includes(tag));
 
-    console.log('');
+    // Human preview only in pretty mode — machine formats keep stdout as
+    // pure data (spinner/success/info/confirm all write to stderr).
+    if (outputFormat === 'pretty') {
+      console.log('');
+      console.log(chalk.bold.cyan(title));
+      console.log(chalk.gray('Video ID: ') + chalk.yellow(parsedId));
+      console.log('');
+
+      console.log(chalk.bold('Current tags:'));
+      if (currentTags.length === 0) {
+        console.log(chalk.gray('  (No tags)'));
+      } else {
+        currentTags.forEach(tag => {
+          console.log(`  ${tag}`);
+        });
+      }
+      console.log('');
+
+      console.log(chalk.bold('New tags:'));
+      if (newTags.length === 0) {
+        console.log(chalk.gray('  (No tags)'));
+      } else {
+        newTags.forEach(tag => {
+          const isNew = !currentTags.includes(tag);
+          if (isNew) {
+            console.log(chalk.green(`  + ${tag}`));
+          } else {
+            console.log(`  ${tag}`);
+          }
+        });
+      }
+
+      if (removedTags.length > 0) {
+        console.log('');
+        console.log(chalk.bold('Removed tags:'));
+        removedTags.forEach(tag => {
+          console.log(chalk.red(`  - ${tag}`));
+        });
+      }
+
+      console.log('');
+    }
 
     // Dry run mode
     if (options.dryRun) {
+      if (outputFormat !== 'pretty') {
+        console.log(formatData([{ videoId: parsedId, title, previousTags: currentTags, newTags, addedTags, removedTags, dryRun: true }], outputFormat));
+      }
       info('Dry run mode - no changes will be applied');
       success('Preview complete');
       return;
@@ -153,7 +163,12 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     });
 
     updateSpinner.succeed('Tags updated successfully');
-    console.log('');
+
+    if (outputFormat !== 'pretty') {
+      console.log(formatData([{ videoId: parsedId, title, previousTags: currentTags, newTags, addedTags, removedTags, dryRun: false }], outputFormat));
+    } else {
+      console.log('');
+    }
     success(`Video updated: https://youtube.com/watch?v=${parsedId}`);
   } catch (err) {
     const errorMessage = (err as Error).message;

--- a/commands/update-video-tags.ts
+++ b/commands/update-video-tags.ts
@@ -15,6 +15,11 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     throw new Error('Required: --video-id');
   }
 
+  // Resolve output format before the try block and any API call: an invalid
+  // --output fails fast without spending quota or being re-wrapped by the
+  // catch below as "Failed to update tags" (CodeRabbit on #140).
+  const outputFormat = await getOutputFormat(options.output);
+
   try {
     const parsedId = parseVideoId(videoId);
     debug(`Parsed video ID: ${parsedId}`);
@@ -52,8 +57,6 @@ async function updateVideoTagsCommand(options: UpdateTagsOptions): Promise<void>
     const title = video.snippet?.title || 'Untitled';
 
     spinner.succeed('Current tags retrieved');
-
-    const outputFormat = await getOutputFormat(options.output);
 
     // Calculate new tags
     let newTags: string[] = [];

--- a/commands/update-video.ts
+++ b/commands/update-video.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
 import { getVideoInfo, updateVideoMetadata } from '../lib/youtube';
 import { parseVideoId, confirm, success, warning, info, debug, initCommand, createSpinner } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
+import { formatData } from '../lib/formatters';
 import { UpdateVideoOptions, VideoIdOption } from '../types';
 
 async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption): Promise<void> {
@@ -18,6 +20,8 @@ async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption
     throw new Error('Please provide at least one of --title or --description');
   }
 
+  const outputFormat = await getOutputFormat(options.output);
+
   try {
     debug(`Video ID input: ${videoId}`);
     const parsedId = parseVideoId(videoId);
@@ -27,38 +31,42 @@ async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption
     const spinner = createSpinner('Fetching current video metadata...').start();
     const [currentVideo] = await getVideoInfo([parsedId]);
     spinner.succeed('Current metadata retrieved');
-    console.log('');
 
-    // Show current state
-    console.log(chalk.bold('Current metadata:'));
-    console.log(chalk.gray('Title:       ') + currentVideo.title);
-    console.log(chalk.gray('Description: ') + (currentVideo.description.substring(0, 100) + '...'));
-    console.log('');
-
-    // Show proposed changes
-    console.log(chalk.bold('Proposed changes:'));
     const updates: { title?: string; description?: string } = {};
+    if (options.title) updates.title = options.title;
+    if (options.description) updates.description = options.description;
 
-    if (options.title) {
-      updates.title = options.title;
-      console.log(chalk.gray('Title:       ') + chalk.green(options.title));
-    } else {
-      console.log(chalk.gray('Title:       ') + chalk.dim('(no change)'));
-    }
+    // Human preview only in pretty mode — machine formats keep stdout as
+    // pure data (spinner/success/info/confirm all write to stderr).
+    if (outputFormat === 'pretty') {
+      console.log('');
+      console.log(chalk.bold('Current metadata:'));
+      console.log(chalk.gray('Title:       ') + currentVideo.title);
+      console.log(chalk.gray('Description: ') + (currentVideo.description.substring(0, 100) + '...'));
+      console.log('');
 
-    if (options.description) {
-      updates.description = options.description;
-      const preview = options.description.length > 100
-        ? options.description.substring(0, 100) + '...'
-        : options.description;
-      console.log(chalk.gray('Description: ') + chalk.green(preview));
-    } else {
-      console.log(chalk.gray('Description: ') + chalk.dim('(no change)'));
+      console.log(chalk.bold('Proposed changes:'));
+      if (updates.title) {
+        console.log(chalk.gray('Title:       ') + chalk.green(updates.title));
+      } else {
+        console.log(chalk.gray('Title:       ') + chalk.dim('(no change)'));
+      }
+      if (updates.description) {
+        const preview = updates.description.length > 100
+          ? updates.description.substring(0, 100) + '...'
+          : updates.description;
+        console.log(chalk.gray('Description: ') + chalk.green(preview));
+      } else {
+        console.log(chalk.gray('Description: ') + chalk.dim('(no change)'));
+      }
+      console.log('');
     }
-    console.log('');
 
     // Dry run mode
     if (options.dryRun) {
+      if (outputFormat !== 'pretty') {
+        console.log(formatData([{ videoId: parsedId, ...updates, dryRun: true }], outputFormat));
+      }
       info('Dry run mode - no changes will be applied');
       success('Preview complete');
       return;
@@ -77,10 +85,19 @@ async function updateMetadataCommand(options: UpdateVideoOptions & VideoIdOption
     const updateSpinner = createSpinner('Updating video metadata...').start();
     await updateVideoMetadata(parsedId, updates);
     updateSpinner.succeed('Metadata updated successfully');
-    console.log('');
+
+    if (outputFormat !== 'pretty') {
+      console.log(formatData([{
+        videoId: parsedId,
+        ...updates,
+        url: `https://youtube.com/watch?v=${parsedId}`,
+        dryRun: false,
+      }], outputFormat));
+    } else {
+      console.log('');
+    }
     success(`Video updated: https://youtube.com/watch?v=${parsedId}`);
   } catch (err) {
-    console.log('');
     throw new Error(`Failed to update metadata: ${(err as Error).message}`);
   }
 }

--- a/docs/commands/configuration.md
+++ b/docs/commands/configuration.md
@@ -14,7 +14,6 @@ staqan-yt auth
 
 ### Options
 
-- `--output <format>` - Output format: json, table, text, pretty, csv
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
 
@@ -92,7 +91,7 @@ staqan-yt config [action] [key] [value]
 - `--show` - Show all configuration settings (same as `show` action)
 - `--install` - Install shell completion to appropriate location (for `completion` action)
 - `--print` - Print completion script to stdout (for `completion` action)
-- `--output <format>` - Output format: json, table, text, pretty, csv
+- `--output <format>` - Output format: json, table, text, pretty, csv. Machine formats emit `{key, value}` rows for `list`/`get`/`set` (`get` keeps its raw-value output for `text` and `pretty`, so scripts using `config get` are unaffected)
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
 

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -3,13 +3,27 @@
  */
 
 import chalk from 'chalk';
-import { PrivacyStatus } from '../types';
+import { PrivacyStatus, OutputFormat } from '../types';
 
 /**
  * Format data as JSON
  */
 export function formatJson(data: unknown): string {
   return JSON.stringify(data, null, 2);
+}
+
+/**
+ * Dispatch to the matching machine formatter. 'pretty' is excluded on
+ * purpose: pretty output is command-specific and handled by each command's
+ * own rendering, while the four machine formats share generic renderers.
+ */
+export function formatData(data: unknown, format: Exclude<OutputFormat, 'pretty'>): string {
+  switch (format) {
+    case 'json': return formatJson(data);
+    case 'table': return formatTable(data);
+    case 'csv': return formatCsv(data);
+    case 'text': return formatText(data);
+  }
 }
 
 /**

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -23,6 +23,12 @@ export function formatData(data: unknown, format: Exclude<OutputFormat, 'pretty'
     case 'table': return formatTable(data);
     case 'csv': return formatCsv(data);
     case 'text': return formatText(data);
+    default: {
+      // Exhaustiveness guard: a new OutputFormat member fails compilation
+      // here instead of silently falling through.
+      const unreachable: never = format;
+      throw new Error(`Unhandled output format: ${unreachable}`);
+    }
   }
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -199,9 +199,11 @@ function info(message: string): void {
  * Prompt user for confirmation
  */
 async function confirm(message: string): Promise<boolean> {
+  // Prompt goes to stderr so machine-readable stdout (--output json/csv/…)
+  // stays clean when the caller pipes it.
   const readline = createInterface({
     input: process.stdin,
-    output: process.stdout,
+    output: process.stderr,
   });
 
   return new Promise((resolve) => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -158,7 +158,7 @@ export interface ChannelOption {
   channel?: string;
 }
 
-export interface UpdateVideoOptions extends VerboseOption {
+export interface UpdateVideoOptions extends VerboseOption, OutputOption {
   title?: string;
   description?: string;
   dryRun?: boolean;
@@ -170,13 +170,13 @@ export interface LocalizationOptions extends VerboseOption, OutputOption, VideoI
   languages?: string;
 }
 
-export interface PutLocalizationOptions extends VerboseOption, VideoIdOption {
+export interface PutLocalizationOptions extends VerboseOption, OutputOption, VideoIdOption {
   language: string;
   title: string;
   description: string;
 }
 
-export interface UpdateLocalizationOptions extends VerboseOption, VideoIdOption {
+export interface UpdateLocalizationOptions extends VerboseOption, OutputOption, VideoIdOption {
   language: string;
   title?: string;
   description?: string;
@@ -201,7 +201,7 @@ export interface RetentionOptions extends OutputOption, VerboseOption, VideoIdOp
 // Tags command options
 export interface GetTagsOptions extends OutputOption, VerboseOption, VideoIdOption {}
 
-export interface UpdateTagsOptions extends VerboseOption, VideoIdOption {
+export interface UpdateTagsOptions extends VerboseOption, OutputOption, VideoIdOption {
   replace?: string;
   add?: string;
   remove?: string;


### PR DESCRIPTION
Closes #124 (final half — the config-bypass half merged in #133).

## Value proposition

Six commands advertised `--output` and silently ignored it. Now five of them honor it — which turns the mutation commands into scriptable building blocks: `update-video-tags … --yes --output json | jq .newTags` works, and the localization pair returns machine-readable results ready for the #111 batch-localization workflow. The sixth (`auth`) loses the flag: an interactive OAuth flow has no data to format, and advertising a no-op flag is the bug this issue is about.

## Contract

- **`pretty` (default): byte-identical to current behavior.** Previews, colors, confirmation — untouched.
- **Machine formats (`json`/`table`/`text`/`csv`): stdout carries only the result object.** Spinners/success/info already write to stderr; previews become pretty-only; and `confirm()` prompts now go to **stderr** (lib/utils.ts) so a piped stdout stays parseable even when the user forgets `--yes`.
- `config get` keeps its raw-value output for `text`/`pretty` — existing scripts (`config get default.channel`) are unaffected; `json`/`table`/`csv` get `{key, value}` rows.
- Result shapes: update-video → `{videoId, title?, description?, url, dryRun}`; tags → `{videoId, title, previousTags, newTags, addedTags, removedTags, dryRun}`; localization → `{videoId, language, languageName, title, description, action}`.
- `--dry-run` in machine formats emits the proposed change with `dryRun: true` — a preview API for scripts.
- **Breaking (tiny)**: `auth --output x` now errors as an unknown option (it previously did nothing).

## Verification (live on @staqan, zero mutations)

- `config list/get/set --output json` → correct rows; raw `config get` unchanged (`pretty`)
- `update-video --dry-run --output json` and `update-video-tags --dry-run --output json` → clean JSON only on stdout (verified with 2>/dev/null), `addedTags`/`dryRun` correct; pretty dry-run byte-identical
- `auth --output json` → `unknown option`, exit 1
- Localization commands exercised to the API boundary via nonexistent video ID → exit 1, **empty stdout** on failure in machine mode
- No unlisted videos exist on the channel, so the final `videos.update` write wasn't live-fired (public-video writes are off-limits); the post-update emission is the same `formatData` call shape as the verified dry-run path
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓

Docs: `configuration.md` updated (auth flag removed, config semantics noted); the metadata-management docs already listed `--output` for these commands — they were aspirational, now they're true.

Note: GitHub Actions quota exhausted until end of month — no status checks; verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable machine-readable output formats for configuration, video metadata updates, localization creation/update, and tag updates.
  * Non-`pretty` modes now emit structured, pipeable results (including dry-run details where applicable).
* **Documentation**
  * Updated the configuration command docs to explain `--output` behavior and `get` formatting.
  * Removed the unsupported `--output` flag from authentication command docs.
* **Bug Fixes**
  * Progress indicators and confirmation prompts now write to stderr to keep stdout clean for piped output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->