### PR TITLE
test(#108): first wave — 61 bun tests for the pure lib layer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "ora": "^5.4.1",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "@types/chalk": "^0.4.31",
         "@types/commander": "^2.12.0",
         "@types/node": "^25.0.3",
@@ -114,6 +115,8 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/chalk": ["@types/chalk@0.4.31", "", {}, "sha512-nF0fisEPYMIyfrFgabFimsz9Lnuu9MwkNrrlATm2E4E46afKDyeelT+8bXfw1VSc7sLBxMxRgT7PxTC2JcqN4Q=="],
 
     "@types/commander": ["@types/commander@2.12.0", "", { "dependencies": { "commander": "*" } }, "sha512-DDmRkovH7jPjnx7HcbSnqKg2JeNANyxNZeUvB0iE+qKBLN+vzN5iSIwt+J2PFSmBuYEut4mgQvI/fTX9YQH/vw=="],
@@ -181,6 +184,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -602,11 +607,7 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -614,13 +615,9 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
-    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -637,10 +634,6 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/docs/development/testing-guide.md
+++ b/docs/development/testing-guide.md
@@ -2,6 +2,23 @@
 
 This guide covers testing strategies and patterns for the staqan-yt-cli project.
 
+## Automated Tests (`bun test`)
+
+Unit tests live in `tests/` and run with the built-in bun runner — no extra framework:
+
+```bash
+bun test              # run everything (fast: pure functions + tmpdir-scoped lock tests)
+bun test utils        # run a single file by fragment
+```
+
+Current coverage (first wave, issue #108): the pure `lib/` functions — ID/URL/duration parsing, date chunking and validation, CSV/table/text/JSON formatters and the `formatData` dispatch, quota-error classification (`isRateLimitError`/`getRetryAfterMs`), language normalization, `getVersion` (including the release-sync marker contract), and `acquireLock` semantics (contention timeout, dead-PID steal, stale-age steal) against temp directories — tests never touch `~/.staqan-yt-cli`.
+
+Conventions:
+
+- `tests/tsconfig.json` extends the root config with bun types; `bun run type-check` covers both projects, and the build tsconfig excludes `tests/` so nothing lands in `dist/`.
+- Write TZ-independent date assertions (parse with `Date.parse`/UTC): the dev machine is UTC+9, CI is UTC — both must pass.
+- No YouTube API calls in unit tests. API-touching behavior is verified manually (below) or against live data during PR review.
+
 ## Manual Testing
 
 ### Test Authentication

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,9 @@ export default [
       parserOptions: {
         ecmaVersion: 2020,
         sourceType: 'module',
-        project: './tsconfig.json',
+        // tests/ has its own tsconfig (bun types, noEmit) — both projects
+        // are listed so typed linting covers test files too.
+        project: ['./tsconfig.json', './tests/tsconfig.json'],
       },
       globals: {
         console: 'readonly',

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tests --noEmit",
     "lint": "eslint .",
     "dev": "bunx tsx bin/staqan-yt.ts",
     "prepublishOnly": "bun run build",
     "start": "bun run dist/bin/staqan-yt.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "bun test",
     "preversion": "bun run scripts/preversion.ts",
     "version": "bun run scripts/version.ts",
     "postversion": "bun run scripts/postversion.ts"
@@ -41,6 +41,7 @@
     "bun": ">=1.0.0"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/chalk": "^0.4.31",
     "@types/commander": "^2.12.0",
     "@types/node": "^25.0.3",

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'bun:test';
+import { formatJson, formatText, formatTable, formatCsv, formatData } from '../lib/formatters';
+
+const rows = [
+  { key: 'default.channel', value: '@staqan' },
+  { key: 'default.output', value: 'pretty' },
+];
+
+describe('formatJson', () => {
+  it('pretty-prints with 2-space indent', () => {
+    expect(formatJson({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+});
+
+describe('formatText', () => {
+  it('tab-joins object values, one row per line', () => {
+    expect(formatText(rows)).toBe('default.channel\t@staqan\ndefault.output\tpretty');
+  });
+
+  it('JSON-encodes nested values', () => {
+    expect(formatText([{ a: [1, 2] }])).toBe('[1,2]');
+  });
+
+  it('passes primitives through', () => {
+    expect(formatText('hello')).toBe('hello');
+  });
+});
+
+describe('formatTable', () => {
+  it('renders header, separator, and aligned rows', () => {
+    const out = formatTable(rows).split('\n');
+    expect(out[0]).toMatch(/^key\s+\| value\s*$/);
+    expect(out[1]).toMatch(/^-+-\+-+$/);
+    expect(out[2]).toContain('@staqan');
+    expect(out).toHaveLength(4);
+  });
+
+  it('unions keys across heterogeneous rows', () => {
+    const out = formatTable([{ a: 1 }, { b: 2 }]);
+    expect(out).toContain('a');
+    expect(out).toContain('b');
+  });
+});
+
+describe('formatCsv', () => {
+  it('emits RFC 4180 rows', () => {
+    expect(formatCsv(rows)).toBe('key,value\ndefault.channel,@staqan\ndefault.output,pretty');
+  });
+
+  it('escapes commas and quotes', () => {
+    expect(formatCsv([{ v: 'a,b' }])).toBe('v\n"a,b"');
+    expect(formatCsv([{ v: 'say "hi"' }])).toBe('v\n"say ""hi"""');
+  });
+
+  it('JSON-encodes arrays (tag lists survive round trips)', () => {
+    expect(formatCsv([{ tags: ['a', 'b'] }])).toBe('tags\n"[""a"",""b""]"');
+  });
+
+  it('renders null/undefined as empty fields', () => {
+    expect(formatCsv([{ a: null, b: 1 }])).toBe('a,b\n,1');
+  });
+});
+
+describe('formatData dispatch', () => {
+  it('routes each machine format to its formatter', () => {
+    expect(formatData(rows, 'json')).toBe(formatJson(rows));
+    expect(formatData(rows, 'text')).toBe(formatText(rows));
+    expect(formatData(rows, 'table')).toBe(formatTable(rows));
+    expect(formatData(rows, 'csv')).toBe(formatCsv(rows));
+  });
+});

--- a/tests/language.test.ts
+++ b/tests/language.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'bun:test';
+import { normalizeLanguage, isValidLanguage, getLanguageName, getSupportedLanguages } from '../lib/language';
+
+describe('normalizeLanguage', () => {
+  it('normalizes names and codes case-insensitively', () => {
+    expect(normalizeLanguage('JAPANESE')).toBe('ja');
+    expect(normalizeLanguage('jp')).toBe('ja');
+    expect(normalizeLanguage('english')).toBe('en');
+    expect(normalizeLanguage(' ru ')).toBe('ru');
+  });
+
+  it('returns null for unsupported input', () => {
+    // NOTE: this pins the current hardcoded en/ja/ru limitation — when #105
+    // (accept any BCP-47) lands, this expectation must flip.
+    expect(normalizeLanguage('ko')).toBeNull();
+    expect(normalizeLanguage('')).toBeNull();
+    expect(normalizeLanguage(null)).toBeNull();
+    expect(normalizeLanguage(undefined)).toBeNull();
+  });
+});
+
+describe('isValidLanguage / getLanguageName / getSupportedLanguages', () => {
+  it('agree with each other', () => {
+    for (const code of getSupportedLanguages()) {
+      expect(isValidLanguage(code)).toBe(true);
+      expect(getLanguageName(code)).toBeTruthy();
+    }
+    expect(isValidLanguage('klingon')).toBe(false);
+    expect(getLanguageName('klingon')).toBeNull();
+  });
+});

--- a/tests/lock.test.ts
+++ b/tests/lock.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdtemp, readFile, writeFile, rm, stat } from 'fs/promises';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import { acquireLock } from '../lib/lock';
+
+async function scratchLockPath(): Promise<{ dir: string; lockPath: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'staqan-lock-test-'));
+  return { dir, lockPath: path.join(dir, 'test.lock') };
+}
+
+describe('acquireLock', () => {
+  it('creates a lock file with our PID and removes it on release', async () => {
+    const { dir, lockPath } = await scratchLockPath();
+    try {
+      const release = await acquireLock(lockPath, { timeout: 1000 });
+      const info = JSON.parse(await readFile(lockPath, 'utf-8'));
+      expect(info.pid).toBe(process.pid);
+      await release();
+      await expect(stat(lockPath)).rejects.toThrow();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('times out with the contention message when a live lock is held', async () => {
+    const { dir, lockPath } = await scratchLockPath();
+    try {
+      const release = await acquireLock(lockPath, { timeout: 1000 });
+      // Second acquire against our own live PID must wait, then fail with
+      // the distinct contention message #132's error handling keys on.
+      await expect(
+        acquireLock(lockPath, { timeout: 300, interval: 50 })
+      ).rejects.toThrow(/^Failed to acquire lock/);
+      await release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('steals a stale lock (dead PID)', async () => {
+    const { dir, lockPath } = await scratchLockPath();
+    try {
+      // PID 1 is init/launchd — process.kill(1, 0) throws EPERM for us, which
+      // reads as "alive", so use a PID from the (usually) unused high range.
+      await writeFile(lockPath, JSON.stringify({ pid: 3999999, created: new Date().toISOString() }));
+      const release = await acquireLock(lockPath, { timeout: 1000, interval: 50 });
+      const info = JSON.parse(await readFile(lockPath, 'utf-8'));
+      expect(info.pid).toBe(process.pid);
+      await release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('steals a lock older than staleAge even if the PID is alive', async () => {
+    const { dir, lockPath } = await scratchLockPath();
+    try {
+      const oldCreated = new Date(Date.now() - 60_000).toISOString();
+      await writeFile(lockPath, JSON.stringify({ pid: process.pid, created: oldCreated }));
+      const release = await acquireLock(lockPath, { timeout: 1000, interval: 50, staleAge: 10_000 });
+      expect(typeof release).toBe('function');
+      await release();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "..",
+    "types": ["node", "bun"]
+  },
+  "include": ["./**/*", "../lib/**/*", "../types/**/*"]
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  parseVideoId,
+  parsePlaylistId,
+  parseChannelHandle,
+  parseDuration,
+  formatTimestamp,
+  formatNumber,
+  chunkDateRange,
+  convertToCSV,
+  parsePositiveInt,
+  validateDateOption,
+  validateDateRange,
+  validatePrivacyFilter,
+  isRateLimitError,
+  getRetryAfterMs,
+} from '../lib/utils';
+
+describe('parseVideoId', () => {
+  it('returns 11-char IDs unchanged', () => {
+    expect(parseVideoId('dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('extracts from watch URLs', () => {
+    expect(parseVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    expect(parseVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s')).toBe('dQw4w9WgXcQ');
+  });
+
+  it('extracts from youtu.be and embed URLs', () => {
+    expect(parseVideoId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    expect(parseVideoId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+  });
+});
+
+describe('parsePlaylistId', () => {
+  it('returns raw playlist IDs unchanged', () => {
+    expect(parsePlaylistId('PLabc123')).toBe('PLabc123');
+  });
+
+  it('extracts list= from URLs', () => {
+    expect(parsePlaylistId('https://www.youtube.com/playlist?list=PLabc123')).toBe('PLabc123');
+    expect(parsePlaylistId('https://www.youtube.com/watch?v=x&list=PLabc123')).toBe('PLabc123');
+  });
+});
+
+describe('parseChannelHandle (#123 semantics)', () => {
+  it('classifies @handles as handles', () => {
+    expect(parseChannelHandle('@staqan')).toEqual({ type: 'handle', value: '@staqan' });
+  });
+
+  it('classifies @-URLs as handles, preserving the @', () => {
+    expect(parseChannelHandle('https://www.youtube.com/@staqan')).toEqual({ type: 'handle', value: '@staqan' });
+  });
+
+  it('classifies /channel/ URLs as IDs and strips query strings', () => {
+    expect(parseChannelHandle('https://youtube.com/channel/UCBQQNUsrd9mgCjsrLogKW6Q?sub=1'))
+      .toEqual({ type: 'id', value: 'UCBQQNUsrd9mgCjsrLogKW6Q' });
+  });
+
+  it('treats raw UC… strings as IDs', () => {
+    expect(parseChannelHandle('UCBQQNUsrd9mgCjsrLogKW6Q')).toEqual({ type: 'id', value: 'UCBQQNUsrd9mgCjsrLogKW6Q' });
+  });
+
+  it('rejects legacy /c/ and /user/ URLs with guidance', () => {
+    expect(() => parseChannelHandle('https://youtube.com/c/SomeName')).toThrow(/Legacy channel URL/);
+    expect(() => parseChannelHandle('https://youtube.com/user/oldname')).toThrow(/@handle/);
+  });
+});
+
+describe('parseDuration', () => {
+  it('parses full H/M/S durations', () => {
+    expect(parseDuration('PT1H2M3S')).toBe(3723);
+  });
+
+  it('parses partial durations', () => {
+    expect(parseDuration('PT59S')).toBe(59);
+    expect(parseDuration('PT15M40S')).toBe(940);
+    expect(parseDuration('PT2H')).toBe(7200);
+  });
+
+  it('returns 0 for garbage', () => {
+    expect(parseDuration('not-a-duration')).toBe(0);
+  });
+
+  it('is the Shorts boundary oracle (<60s = Short)', () => {
+    expect(parseDuration('PT59S')).toBeLessThan(60);
+    expect(parseDuration('PT1M')).toBe(60);
+  });
+});
+
+describe('formatTimestamp', () => {
+  it('formats M:SS below an hour', () => {
+    expect(formatTimestamp(75)).toBe('1:15');
+    expect(formatTimestamp(0)).toBe('0:00');
+  });
+
+  it('formats H:MM:SS at an hour and above', () => {
+    expect(formatTimestamp(3723)).toBe('1:02:03');
+  });
+});
+
+describe('formatNumber', () => {
+  it('inserts thousands separators', () => {
+    expect(formatNumber(1234567)).toBe('1,234,567');
+    expect(formatNumber(999)).toBe('999');
+  });
+});
+
+// Day-difference helper: parse as UTC so assertions hold in any test-runner TZ
+// (dev machine is UTC+9, CI is UTC).
+function daysInclusive(start: string, end: string): number {
+  return Math.round((Date.parse(end) - Date.parse(start)) / 86_400_000) + 1;
+}
+
+describe('chunkDateRange (90-day Analytics API limit)', () => {
+  it('keeps a short range as a single chunk', () => {
+    const chunks = chunkDateRange('2026-01-01', '2026-01-31');
+    expect(chunks).toEqual([{ start: '2026-01-01', end: '2026-01-31' }]);
+  });
+
+  it('covers the full range contiguously with chunks of at most 90 days', () => {
+    const chunks = chunkDateRange('2025-01-01', '2026-01-01');
+    expect(chunks[0].start).toBe('2025-01-01');
+    expect(chunks[chunks.length - 1].end).toBe('2026-01-01');
+    for (const c of chunks) {
+      expect(daysInclusive(c.start, c.end)).toBeLessThanOrEqual(90);
+    }
+    for (let i = 1; i < chunks.length; i++) {
+      // Each chunk starts the day after the previous one ends: no gaps, no overlap
+      expect(daysInclusive(chunks[i - 1].end, chunks[i].start)).toBe(2);
+    }
+  });
+});
+
+describe('convertToCSV', () => {
+  it('joins headers and rows', () => {
+    const out = convertToCSV([{ name: 'a' }, { name: 'b' }], [[1, 2], [3, 4]]);
+    expect(out).toBe('a,b\n1,2\n3,4');
+  });
+
+  it('escapes commas, quotes, and newlines per RFC 4180', () => {
+    const out = convertToCSV([{ name: 'v' }], [['say "hi", ok\nbye']]);
+    expect(out).toBe('v\n"say ""hi"", ok\nbye"');
+  });
+});
+
+describe('parsePositiveInt', () => {
+  it('falls back to the default when the flag is absent', () => {
+    expect(parsePositiveInt('--limit', undefined, 25)).toBe(25);
+  });
+
+  it('parses valid values', () => {
+    expect(parsePositiveInt('--limit', '7', 25)).toBe(7);
+  });
+
+  it('throws on zero, negatives, and non-numbers', () => {
+    expect(() => parsePositiveInt('--limit', '0', 25)).toThrow('--limit');
+    expect(() => parsePositiveInt('--limit', '-3', 25)).toThrow();
+    expect(() => parsePositiveInt('--limit', 'abc', 25)).toThrow();
+  });
+});
+
+describe('validateDateOption', () => {
+  it('accepts YYYY-MM-DD', () => {
+    expect(() => validateDateOption('--start-date', '2026-02-28')).not.toThrow();
+  });
+
+  it('rejects wrong formats', () => {
+    expect(() => validateDateOption('--start-date', '2026/02/28')).toThrow('YYYY-MM-DD');
+    expect(() => validateDateOption('--start-date', '28-02-2026')).toThrow();
+  });
+
+  it('rejects impossible calendar dates (#61 class)', () => {
+    expect(() => validateDateOption('--start-date', '2024-02-30')).toThrow('not a valid date');
+    expect(() => validateDateOption('--start-date', '2026-13-01')).toThrow();
+  });
+
+  it('accepts leap-day only in leap years', () => {
+    expect(() => validateDateOption('--d', '2024-02-29')).not.toThrow();
+    expect(() => validateDateOption('--d', '2026-02-29')).toThrow();
+  });
+});
+
+describe('validateDateRange', () => {
+  it('accepts start <= end (inclusive)', () => {
+    expect(() => validateDateRange('2026-01-01', '2026-01-01')).not.toThrow();
+    expect(() => validateDateRange('2026-01-01', '2026-06-30')).not.toThrow();
+  });
+
+  it('rejects start > end', () => {
+    expect(() => validateDateRange('2026-06-30', '2026-01-01')).toThrow('--start-date');
+  });
+});
+
+describe('validatePrivacyFilter', () => {
+  it('accepts valid statuses and empty input', () => {
+    expect(() => validatePrivacyFilter(['public', 'unlisted'])).not.toThrow();
+    expect(() => validatePrivacyFilter(undefined)).not.toThrow();
+    expect(() => validatePrivacyFilter([])).not.toThrow();
+  });
+
+  it('rejects unknown statuses', () => {
+    expect(() => validatePrivacyFilter(['public', 'hidden'])).toThrow('hidden');
+  });
+});
+
+describe('isRateLimitError (quota classification)', () => {
+  it("classifies per-minute quota as 'rpm'", () => {
+    expect(isRateLimitError({
+      message: "Quota exceeded for quota metric 'Free requests' and limit 'Free requests per minute'",
+    })).toBe('rpm');
+  });
+
+  it("classifies daily quota as 'daily'", () => {
+    expect(isRateLimitError({
+      message: "Quota exceeded for quota metric 'Free requests' and limit 'Free requests per day'",
+    })).toBe('daily');
+  });
+
+  it('reads messages nested under response.data.error.errors[]', () => {
+    expect(isRateLimitError({
+      response: { data: { error: { errors: [{ message: 'blah per minute blah' }] } } },
+    })).toBe('rpm');
+  });
+
+  it('returns null for everything else', () => {
+    expect(isRateLimitError({ message: 'Video not found' })).toBeNull();
+    expect(isRateLimitError(undefined)).toBeNull();
+    expect(isRateLimitError('string error')).toBeNull();
+  });
+});
+
+describe('getRetryAfterMs', () => {
+  it('reads gaxios Headers-like objects', () => {
+    const headers = { get: (n: string) => (n === 'retry-after' ? '7' : null) };
+    expect(getRetryAfterMs({ response: { headers } })).toBe(7000);
+  });
+
+  it('reads plain lowercase header records', () => {
+    expect(getRetryAfterMs({ response: { headers: { 'retry-after': '30' } } })).toBe(30000);
+  });
+
+  it('ignores HTTP-date and negative forms', () => {
+    expect(getRetryAfterMs({ response: { headers: { 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' } } })).toBeUndefined();
+    expect(getRetryAfterMs({ response: { headers: { 'retry-after': '-5' } } })).toBeUndefined();
+  });
+
+  it('returns undefined when absent', () => {
+    expect(getRetryAfterMs({})).toBeUndefined();
+    expect(getRetryAfterMs({ response: {} })).toBeUndefined();
+  });
+});

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'bun:test';
+import { readFile } from 'fs/promises';
+import * as path from 'path';
+import { getVersion, FALLBACK_VERSION } from '../lib/version';
+import packageJson from '../package.json';
+
+describe('getVersion (#127)', () => {
+  it('resolves the real package.json version from the source layout', () => {
+    expect(getVersion()).toBe(packageJson.version);
+  });
+
+  it('keeps FALLBACK_VERSION in sync (scripts/version.ts contract)', () => {
+    // If this fails, a release was cut without the sync script running —
+    // compiled binaries would report a stale version.
+    expect(FALLBACK_VERSION).toBe(packageJson.version);
+  });
+
+  it('keeps the sync marker line intact for scripts/version.ts', async () => {
+    const src = await readFile(path.join(__dirname, '../lib/version.ts'), 'utf-8');
+    expect(src).toMatch(/export const FALLBACK_VERSION = '[^']+'; \/\/ synced by scripts\/version\.ts/);
+  });
+});


### PR DESCRIPTION
First installment of #108 (kept open: integration tests + command-layer coverage follow after #102's structured returns make commands testable).

## Value proposition

Zero → 61 tests over the code that every command shares. These pin exactly the behaviors this month's audit fixed, so they can't silently regress: the #123 URL-classification semantics (including the legacy-URL throws), the #54-class date logic (90-day chunking contiguity, impossible-calendar-date rejection), the #89/#134 quota classification (`rpm` vs `daily`, both message nestings, both Retry-After header shapes), the #132 lock-contention message contract, and the #127/#135 version-sync marker (a test now fails if a release ships without the sync script running). Runner is **`bun test`** per the repo's bun-first rule — zero new runtime dependencies (`@types/bun` dev-only).

## What's covered (5 files)

- `tests/utils.test.ts` — parse/format/validate/classify helpers (34 tests)
- `tests/formatters.test.ts` — json/text/table/csv + `formatData` dispatch, RFC 4180 escaping
- `tests/language.test.ts` — normalization matrix (with an explicit note pinning the en/ja/ru limitation so #105 flips it consciously)
- `tests/version.test.ts` — `getVersion` source-layout resolution, `FALLBACK_VERSION` sync, marker-line integrity
- `tests/lock.test.ts` — `acquireLock` against tmpdirs: create/release, contention timeout (`Failed to acquire lock…`), dead-PID steal, stale-age steal

## Wiring

- `package.json`: `"test": "bun test"` (replaces the exit-1 placeholder); `type-check` now also checks `tests/` via its own tsconfig
- `tests/tsconfig.json`: extends root, bun types, `noEmit` — and the root build config excludes `tests/`, so `dist/` stays clean (verified)
- `eslint.config.mjs`: tests project added to typed-lint `parserOptions.project`
- `docs/development/testing-guide.md`: new "Automated Tests" section (incl. the TZ-independence convention — dev is UTC+9, CI is UTC)

## Verification

`bun test` → **61 pass, 0 fail, 114 assertions, ~360ms** · `bun run type-check` ✓ (both projects) · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓ with no test artifacts in dist

Follow-up for #130 (CI): once both merge, ci.yml gains a one-line `bun run test` step — not added here to avoid cross-PR file dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated test coverage for formatting, language handling, utility validation, locking, and version consistency.
  * Added commands for running the test suite and checking test code types.

* **Documentation**
  * Added guidance for running tests, supported coverage areas, test conventions, and restrictions on external API calls.

* **Tests**
  * Added checks for date handling, CSV output, rate-limit errors, URL parsing, retry behavior, and stale lock recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->