### PR TITLE
refactor(#102): shared video-analytics data layer for CLI + MCP (phase 1)

### DIFF
--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,72 +1,9 @@
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
-import { google } from 'googleapis';
-import { parseVideoId, debug, formatNumber, convertToCSV, chunkDateRange, withRateLimitRetry, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { parseVideoId, debug, formatNumber, convertToCSV, initCommand, withSpinner, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { fetchVideoAnalytics } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
-
-/**
- * Allowlist of Analytics API dimensions valid for video-level queries.
- * See https://developers.google.com/youtube/v3/docs/analytics_api/dimensions/dims
- */
-const VIDEO_DIMENSIONS: ReadonlySet<string> = new Set([
-  'video',
-  'day',
-  'month',
-  'insightTrafficSourceType',
-  'insightTrafficSourceDetail',
-  'creatorContentType',
-  'country',
-  'province',
-  'city',
-  'deviceType',
-  'operatingSystem',
-  'insightPlaybackLocationType',
-  'insightPlayerLocationType',
-  'subscribedStatus',
-]);
-
-/**
- * Known-bad dimension combinations the Analytics API rejects at runtime.
- * Checking up-front gives a clean error message instead of an API error.
- */
-const INVALID_DIMENSION_COMBOS: ReadonlyArray<ReadonlyArray<string>> = [
-  // creatorContentType is not a valid dimension for traffic-source detail reports
-  // (see PR #90 — original issue: get-channel-search-terms #88).
-  ['creatorContentType', 'insightTrafficSourceDetail'],
-];
-
-/**
- * Validate a comma-separated --dimensions string against the allowlist and
- * known-bad combos. Returns the normalized (trimmed) string on success;
- * throws on any invalid dimension or rejected combination.
- */
-function validateVideoDimensions(raw: string): string {
-  const dims = raw.split(',').map(d => d.trim()).filter(d => d.length > 0);
-  if (dims.length === 0) {
-    throw new Error('--dimensions cannot be empty');
-  }
-
-  for (const d of dims) {
-    if (!VIDEO_DIMENSIONS.has(d)) {
-      throw new Error(
-        `Invalid --dimensions value: "${d}". Valid values: ${[...VIDEO_DIMENSIONS].join(', ')}`,
-      );
-    }
-  }
-
-  for (const combo of INVALID_DIMENSION_COMBOS) {
-    if (combo.every(d => dims.includes(d))) {
-      throw new Error(
-        `Invalid --dimensions combination: ${combo.join(' + ')}. ` +
-        `The Analytics API does not support this combination.`,
-      );
-    }
-  }
-
-  return dims.join(',');
-}
 
 async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void> {
   initCommand(options);
@@ -81,88 +18,28 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
   runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
   runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
+  const outputFormat = await getOutputFormat(options.output);
+
   await withSpinner('Fetching video information...', 'Failed to fetch analytics', async (spinner) => {
     const parsedId = parseVideoId(videoId);
     debug('Parsed video ID', parsedId);
 
-    const auth = await getAuthenticatedClient();
-    const youtube = google.youtube({ version: 'v3', auth });
-    const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
-
-    // Get video info for title and publish date
-    const videoResponse = await youtube.videos.list({
-      part: ['snippet'],
-      id: [parsedId],
+    // Data layer (lib/analytics.ts, shared with the MCP server — #102):
+    // resolves the date range from the upload date, validates dimensions,
+    // chunks into 90-day windows, aggregates rows.
+    const result = await fetchVideoAnalytics({
+      videoId: parsedId,
+      startDate: options.startDate,
+      endDate: options.endDate,
+      metrics: options.metrics,
+      dimensions: options.dimensions,
+      onProgress: (message) => { spinner.text = message; },
     });
 
-    if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      throw new Error(`No video found with ID: ${parsedId}`);
-    }
-
-    const video = videoResponse.data.items[0];
-    const title = video.snippet?.title || 'Untitled';
-    const publishedAt = video.snippet?.publishedAt;
-
-    if (!publishedAt) {
-      throw new Error('Video publish date is missing');
-    }
-
-    // Calculate date range
-    // Default: full historical data from upload date to today
-    const endDate = options.endDate || toLocalYmd(new Date());
-    const startDate = options.startDate || publishedAt.split('T')[0];
-
-    // validateDateRange throws on bad ranges; withSpinner's catch handles it.
-    validateDateRange(startDate, endDate);
-    debug(`Date range: ${startDate} to ${endDate}`);
-
-    // Default metrics
-    const metrics = options.metrics || 'views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares';
-
-    // Default dimensions: 'video' preserves legacy behavior (aggregated by video).
-    // Any user-supplied --dimensions is validated against the Analytics API allowlist
-    // and known-bad combinations are rejected up-front (issue #99).
-    const dimensions = runOrExit(() => validateVideoDimensions(options.dimensions ?? 'video'));
-
-    // Chunk date range into 90-day periods
-    const dateChunks = chunkDateRange(startDate, endDate);
-    debug(`Split into ${dateChunks.length} chunk(s) of 90 days`);
-    debug(`Dimensions: ${dimensions}, Metrics: ${metrics}`);
-
-    // Fetch analytics for each chunk
-    const allRows: unknown[][] = [];
-    let columnHeaders: { name?: string | null }[] = [];
-
-    for (let i = 0; i < dateChunks.length; i++) {
-      const chunk = dateChunks[i];
-      spinner.text = `Fetching chunk ${i + 1}/${dateChunks.length} (${chunk.start} to ${chunk.end})...`;
-
-      const analyticsResponse = await withRateLimitRetry(async () => {
-        return await youtubeAnalytics.reports.query({
-          ids: 'channel==MINE',
-          startDate: chunk.start,
-          endDate: chunk.end,
-          metrics,
-          dimensions,
-          filters: `video==${parsedId}`,
-        });
-      }, { label: 'reports.query(video analytics)' });
-
-      // Save headers from first response
-      if (i === 0 && analyticsResponse.data.columnHeaders) {
-        columnHeaders = analyticsResponse.data.columnHeaders;
-      }
-
-      // Aggregate rows
-      if (analyticsResponse.data.rows && analyticsResponse.data.rows.length > 0) {
-        allRows.push(...analyticsResponse.data.rows);
-      }
-    }
+    const { title, dateRange, columnHeaders, rows: allRows } = result;
+    const { startDate, endDate } = dateRange;
 
     spinner.succeed(`Retrieved ${allRows.length} row(s) of analytics data`);
-
-    // Output results
-    const outputFormat = await getOutputFormat(options.output);
 
     // Prepare aggregated data for structured formats
     const aggregated: { [key: string]: number } = {};
@@ -205,7 +82,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
         }));
         break;
 
-      case 'table':
+      case 'table': {
         // Convert aggregated metrics to table format
         const tableData = Object.entries(aggregated).map(([name, value]) => ({
           metric: name,
@@ -213,6 +90,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
         }));
         console.log(formatTable(tableData));
         break;
+      }
 
       case 'text':
         // Tab-delimited output of aggregated metrics

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -22,7 +22,8 @@ import {
 } from '../lib/youtube';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, chunkDateRange, withRateLimitRetry, initCommand, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
+import { parseVideoId, initCommand, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
+import { fetchVideoAnalytics } from '../lib/analytics';
 import { requireChannel } from '../lib/config';
 import { getVersion } from '../lib/version';
 
@@ -259,6 +260,10 @@ const TOOLS: Tool[] = [
         metrics: {
           type: 'string',
           description: 'Comma-separated list of metrics (default: views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares)',
+        },
+        dimensions: {
+          type: 'string',
+          description: 'Comma-separated Analytics API dimensions to break results out by (default: video = aggregate). E.g. "day", "insightTrafficSourceType", "country,deviceType". See docs/dimension-compatibility.md for valid combinations.',
         },
       },
       required: ['videoId'],
@@ -768,73 +773,25 @@ async function handleToolCall(name: string, args: any) {
     }
 
     case 'youtube_get_video_analytics': {
-      const parsedId = parseVideoId(args.videoId);
-
-      // Get video info for publish date
-      const videoResponse = await youtube.videos.list({
-        part: ['snippet'],
-        id: [parsedId],
-      });
-
-      if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-        throw new Error(`Video not found: ${parsedId}`);
-      }
-
-      const video = videoResponse.data.items[0];
-      const publishedAt = video.snippet?.publishedAt;
-
-      if (!publishedAt) {
-        throw new Error('Video publish date is missing');
-      }
-
+      // Shared data layer (lib/analytics.ts, #102) — same code path as the
+      // get-video-analytics CLI command, so features like --dimensions can't
+      // drift between the two surfaces again.
       if (args.startDate) validateDateOption('startDate', args.startDate);
       if (args.endDate) validateDateOption('endDate', args.endDate);
 
-      // Calculate date range
-      const endDate = args.endDate || toLocalYmd(new Date());
-      const startDate = args.startDate || publishedAt.split('T')[0];
-      validateDateRange(startDate, endDate);
-
-      // Default metrics
-      const metrics = args.metrics || 'views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares';
-
-      // Chunk date range into 90-day periods
-      const dateChunks = chunkDateRange(startDate, endDate);
-
-      // Fetch analytics for each chunk
-      const allRows: unknown[][] = [];
-      let columnHeaders: { name?: string | null }[] = [];
-
-      for (let i = 0; i < dateChunks.length; i++) {
-        const chunk = dateChunks[i];
-
-        const analyticsResponse = await withRateLimitRetry(async () => {
-          return await youtubeAnalytics.reports.query({
-            ids: 'channel==MINE',
-            startDate: chunk.start,
-            endDate: chunk.end,
-            metrics,
-            dimensions: 'video',
-            filters: `video==${parsedId}`,
-          });
-        }, { label: 'reports.query(video analytics)' });
-
-        // Save headers from first response
-        if (i === 0 && analyticsResponse.data.columnHeaders) {
-          columnHeaders = analyticsResponse.data.columnHeaders;
-        }
-
-        // Aggregate rows
-        if (analyticsResponse.data.rows && analyticsResponse.data.rows.length > 0) {
-          allRows.push(...analyticsResponse.data.rows);
-        }
-      }
+      const result = await fetchVideoAnalytics({
+        videoId: parseVideoId(args.videoId),
+        startDate: args.startDate,
+        endDate: args.endDate,
+        metrics: args.metrics,
+        dimensions: args.dimensions,
+      });
 
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify({ columnHeaders, rows: allRows }, null, 2),
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,185 @@
+/**
+ * YouTube Analytics API data layer (issue #102).
+ *
+ * Commands and the MCP server both consume these functions: commands add
+ * spinners and output formatting on top, the MCP server serializes the
+ * returned data directly. Business logic lives here exactly once — before
+ * this file, commands/mcp.ts re-implemented each analytics query inline and
+ * the copies drifted (e.g. the MCP video-analytics tool never gained
+ * --dimensions support when #120 shipped it in the CLI).
+ */
+
+import { google } from 'googleapis';
+import { getAuthenticatedClient } from './auth';
+import { chunkDateRange, debug, toLocalYmd, validateDateRange, withRateLimitRetry } from './utils';
+
+/**
+ * Allowlist of Analytics API dimensions valid for video-level queries.
+ * See https://developers.google.com/youtube/v3/docs/analytics_api/dimensions/dims
+ * and docs/dimension-compatibility.md for the live-tested combination matrix.
+ */
+export const VIDEO_DIMENSIONS: ReadonlySet<string> = new Set([
+  'video',
+  'day',
+  'month',
+  'insightTrafficSourceType',
+  'insightTrafficSourceDetail',
+  'creatorContentType',
+  'country',
+  'province',
+  'city',
+  'deviceType',
+  'operatingSystem',
+  'insightPlaybackLocationType',
+  'insightPlayerLocationType',
+  'subscribedStatus',
+]);
+
+/**
+ * Known-bad dimension combinations the Analytics API rejects at runtime.
+ * Checking up-front gives a clean error message instead of an API error.
+ */
+export const INVALID_DIMENSION_COMBOS: ReadonlyArray<ReadonlyArray<string>> = [
+  // creatorContentType is not a valid dimension for traffic-source detail reports
+  // (see PR #90 — original issue: get-channel-search-terms #88).
+  ['creatorContentType', 'insightTrafficSourceDetail'],
+];
+
+/**
+ * Validate a comma-separated dimensions string against the allowlist and
+ * known-bad combos. Returns the normalized (trimmed) string on success;
+ * throws on any invalid dimension or rejected combination.
+ */
+export function validateVideoDimensions(raw: string): string {
+  const dims = raw.split(',').map(d => d.trim()).filter(d => d.length > 0);
+  if (dims.length === 0) {
+    throw new Error('--dimensions cannot be empty');
+  }
+
+  for (const d of dims) {
+    if (!VIDEO_DIMENSIONS.has(d)) {
+      throw new Error(
+        `Invalid --dimensions value: "${d}". Valid values: ${[...VIDEO_DIMENSIONS].join(', ')}`,
+      );
+    }
+  }
+
+  for (const combo of INVALID_DIMENSION_COMBOS) {
+    if (combo.every(d => dims.includes(d))) {
+      throw new Error(
+        `Invalid --dimensions combination: ${combo.join(' + ')}. ` +
+        `The Analytics API does not support this combination.`,
+      );
+    }
+  }
+
+  return dims.join(',');
+}
+
+export interface VideoAnalyticsParams {
+  /** Parsed 11-character video ID (callers run parseVideoId first). */
+  videoId: string;
+  /** YYYY-MM-DD; defaults to the video's upload date. */
+  startDate?: string;
+  /** YYYY-MM-DD; defaults to today (local). */
+  endDate?: string;
+  /** Comma-separated metrics; defaults to the standard engagement set. */
+  metrics?: string;
+  /** Comma-separated dimensions; defaults to 'video' (aggregate). Validated here. */
+  dimensions?: string;
+  /** Progress hook — commands wire this to the spinner; MCP omits it. */
+  onProgress?: (message: string) => void;
+}
+
+export interface VideoAnalyticsResult {
+  videoId: string;
+  title: string;
+  dateRange: { startDate: string; endDate: string };
+  dimensions: string;
+  metrics: string;
+  columnHeaders: { name?: string | null }[];
+  rows: unknown[][];
+}
+
+export const DEFAULT_VIDEO_METRICS =
+  'views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares';
+
+/**
+ * Fetch analytics for one video: resolves the date range from the upload
+ * date, validates dimensions, chunks the range into the API's 90-day
+ * windows, and aggregates the rows. Throws on unknown video, invalid
+ * dimensions, or an inverted date range.
+ */
+export async function fetchVideoAnalytics(params: VideoAnalyticsParams): Promise<VideoAnalyticsResult> {
+  const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
+  const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+
+  // Video lookup: title for display, publishedAt for the default start date.
+  const videoResponse = await youtube.videos.list({
+    part: ['snippet'],
+    id: [params.videoId],
+  });
+
+  if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
+    throw new Error(`No video found with ID: ${params.videoId}`);
+  }
+
+  const video = videoResponse.data.items[0];
+  const title = video.snippet?.title || 'Untitled';
+  const publishedAt = video.snippet?.publishedAt;
+
+  if (!publishedAt) {
+    throw new Error('Video publish date is missing');
+  }
+
+  // Default: full historical data from upload date to today.
+  const endDate = params.endDate || toLocalYmd(new Date());
+  const startDate = params.startDate || publishedAt.split('T')[0];
+  validateDateRange(startDate, endDate);
+  debug(`Date range: ${startDate} to ${endDate}`);
+
+  const metrics = params.metrics || DEFAULT_VIDEO_METRICS;
+  const dimensions = validateVideoDimensions(params.dimensions ?? 'video');
+
+  const dateChunks = chunkDateRange(startDate, endDate);
+  debug(`Split into ${dateChunks.length} chunk(s) of 90 days`);
+  debug(`Dimensions: ${dimensions}, Metrics: ${metrics}`);
+
+  const allRows: unknown[][] = [];
+  let columnHeaders: { name?: string | null }[] = [];
+
+  for (let i = 0; i < dateChunks.length; i++) {
+    const chunk = dateChunks[i];
+    params.onProgress?.(`Fetching chunk ${i + 1}/${dateChunks.length} (${chunk.start} to ${chunk.end})...`);
+
+    const analyticsResponse = await withRateLimitRetry(async () => {
+      return await youtubeAnalytics.reports.query({
+        ids: 'channel==MINE',
+        startDate: chunk.start,
+        endDate: chunk.end,
+        metrics,
+        dimensions,
+        filters: `video==${params.videoId}`,
+      });
+    }, { label: 'reports.query(video analytics)' });
+
+    if (i === 0 && analyticsResponse.data.columnHeaders) {
+      columnHeaders = analyticsResponse.data.columnHeaders;
+    }
+
+    if (analyticsResponse.data.rows && analyticsResponse.data.rows.length > 0) {
+      allRows.push(...analyticsResponse.data.rows);
+    }
+  }
+
+  return {
+    videoId: params.videoId,
+    title,
+    dateRange: { startDate, endDate },
+    dimensions,
+    metrics,
+    columnHeaders,
+    rows: allRows,
+  };
+}


### PR DESCRIPTION
Part of #102 — the pattern-setting first phase of the structured-returns migration.

## Value proposition

`commands/mcp.ts` re-implemented each analytics query inline, and the copies drift: the MCP video-analytics tool **never gained `--dimensions` support** when #120 shipped it in the CLI, and never returned the video title. This PR creates the shape #102 calls for — business logic in a lib function returning typed data; the command adds spinner + formatting; MCP serializes the result — and applies it to the first command. The MCP tool gets `dimensions` and `title` for free, purely by deleting its copy.

## Changes

- **`lib/analytics.ts` (new)**: `fetchVideoAnalytics(params) → VideoAnalyticsResult` — video lookup, upload-date defaulting, dimension validation (allowlist + known-bad combos moved here, exported for tests), 90-day chunking with `withRateLimitRetry`, row aggregation. Optional `onProgress` hook so commands can drive spinners without the lib knowing about ora.
- **`commands/get-video-analytics.ts`**: −80 lines of business logic; keeps flag validation, spinner, and all five output formats byte-identical.
- **`commands/mcp.ts`**: `youtube_get_video_analytics` is now ~15 lines calling the shared function; tool schema gains the `dimensions` parameter.

## Verification (live)

- CLI: `--dimensions day --output csv` → identical daily rows as pre-refactor; invalid dimension → exit 1
- MCP over real JSON-RPC (`initialize` → `tools/call`): `{videoId, dimensions: "day", metrics: "views"}` → typed payload with title, `dimensions: day`, 12 rows — **both new capabilities confirmed through the protocol**
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓

## Next phases (same pattern)

traffic-sources + search-terms + retention (small), then channel-analytics and channel-search-terms (deletes the two big mcp.ts inline blocks), then the reporting tools (replaces the console monkey-patching entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved video analytics retrieval with support for date ranges, metrics, dimensions, and large reporting periods.
  * Enhanced analytics tool guidance for valid dimension combinations.
  * Added progress updates while analytics reports are being generated.

* **Bug Fixes**
  * Improved validation for invalid dates and unsupported dimension combinations.
  * Standardized analytics results and handling across command-line and MCP interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->