### PR TITLE
feat: add put-caption command (upload caption tracks)

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -31,6 +31,7 @@ import listCommentsCommand = require('../commands/list-comments');
 import getChannelCommand = require('../commands/get-channel');
 import listCaptionsCommand = require('../commands/list-captions');
 import getCaptionCommand = require('../commands/get-caption');
+import putCaptionCommand = require('../commands/put-caption');
 import getChannelAnalyticsCommand = require('../commands/get-channel-analytics');
 import getChannelSearchTermsCommand = require('../commands/get-channel-search-terms');
 import listReportTypesCommand = require('../commands/list-report-types');
@@ -449,6 +450,19 @@ program
   .option('--format <format>', 'Caption format: srt, vtt, sbv, scc, ttml, json (default: json)', 'json')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('get-caption', getCaptionCommand));
+
+// Upload a new caption track (PUT - fails if same language+name track exists)
+program
+  .command('put-caption')
+  .description('Upload a new caption track to a video (fails if same language+name track exists)')
+  .requiredOption('--video-id <id>', 'Video ID (must be on your channel)')
+  .requiredOption('--language <lang>', 'Caption language (BCP-47 code, e.g. "ja", "en")')
+  .requiredOption('--file <path>', 'Caption file: srt, vtt, sbv, scc, or ttml')
+  .option('--name <name>', 'Track name shown in the player (default: empty)')
+  .option('--draft', 'Upload as draft (not visible to viewers)')
+  .option('--output <format>', 'Output format: json, table, text, pretty, csv')
+  .option('-v, --verbose', 'Enable verbose output with debug information')
+  .action(withHelpWrapper('put-caption', putCaptionCommand));
 
 // Channel search terms command — top keywords from YouTube Search traffic
 program

--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -460,6 +460,7 @@ program
   .requiredOption('--file <path>', 'Caption file: srt, vtt, sbv, scc, or ttml')
   .option('--name <name>', 'Track name shown in the player (default: empty)')
   .option('--draft', 'Upload as draft (not visible to viewers)')
+  .option('-f, --force', 'Replace the existing track content if one matches the language+name')
   .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('put-caption', putCaptionCommand));

--- a/commands/put-caption.ts
+++ b/commands/put-caption.ts
@@ -1,0 +1,84 @@
+import chalk from 'chalk';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { uploadCaption } from '../lib/youtube';
+import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
+import { normalizeLanguage, getLanguageName } from '../lib/language';
+import { getOutputFormat } from '../lib/config';
+import { formatData } from '../lib/formatters';
+import { PutCaptionOptions } from '../types';
+
+async function putCaptionCommand(options: PutCaptionOptions): Promise<void> {
+  initCommand(options);
+
+  const videoId = options.videoId;
+  if (!videoId) {
+    throw new Error('Required: --video-id');
+  }
+
+  const { language, file } = options;
+  if (!language) {
+    throw new Error('Required: --language');
+  }
+  if (!file) {
+    throw new Error('Required: --file');
+  }
+
+  // Fail fast on an unreadable file before spending any API quota.
+  const filePath = path.resolve(file);
+  try {
+    const stats = await fs.stat(filePath);
+    if (!stats.isFile()) {
+      throw new Error('not a regular file');
+    }
+    if (stats.size === 0) {
+      throw new Error('file is empty');
+    }
+  } catch (err) {
+    throw new Error(
+      `Cannot read caption file: ${filePath}\n${(err as Error).message}\n` +
+      'Supported formats: srt, vtt, sbv, scc, ttml'
+    );
+  }
+
+  // Normalize known languages for the display name; pass unknown codes
+  // through untouched — the API accepts any BCP-47 tag (lib/language.ts only
+  // maps en/ja/ru today, see #105).
+  const langCode = normalizeLanguage(language) || language;
+  const langName = getLanguageName(langCode) || language;
+  debug(`Language: ${language} -> ${langCode} (${langName})`);
+
+  const outputFormat = await getOutputFormat(options.output);
+
+  await withSpinner(`Uploading ${langName} caption track...`, 'Failed to upload caption', async (spinner) => {
+    const parsedId = parseVideoId(videoId);
+    debug(`Parsed video ID: ${parsedId}`);
+
+    const result = await uploadCaption(parsedId, langCode, filePath, {
+      name: options.name,
+      draft: options.draft,
+    });
+
+    // Spinner output goes to stderr, so machine formats stay pipeable.
+    spinner.succeed(chalk.green(
+      `Uploaded ${langName} (${result.language}) caption track${result.isDraft ? ' as draft' : ''}`
+    ));
+
+    if (outputFormat !== 'pretty') {
+      console.log(formatData([{ ...result, action: 'uploaded' }], outputFormat));
+      return;
+    }
+
+    console.log('');
+    console.log(chalk.gray(`Caption ID: ${result.id}`));
+    console.log(chalk.gray(`Video ID:   ${result.videoId}`));
+    if (result.name) {
+      console.log(chalk.gray(`Track name: ${result.name}`));
+    }
+    if (result.isDraft) {
+      console.log(chalk.yellow('Draft: not visible to viewers until published in YouTube Studio'));
+    }
+  });
+}
+
+export = putCaptionCommand;

--- a/commands/put-caption.ts
+++ b/commands/put-caption.ts
@@ -50,22 +50,26 @@ async function putCaptionCommand(options: PutCaptionOptions): Promise<void> {
 
   const outputFormat = await getOutputFormat(options.output);
 
-  await withSpinner(`Uploading ${langName} caption track...`, 'Failed to upload caption', async (spinner) => {
-    const parsedId = parseVideoId(videoId);
-    debug(`Parsed video ID: ${parsedId}`);
+  // Parse before the spinner so a malformed ID fails with an accurate
+  // message rather than "Failed to upload caption" (CodeRabbit on #148).
+  const parsedId = parseVideoId(videoId);
+  debug(`Parsed video ID: ${parsedId}`);
 
+  await withSpinner(`Uploading ${langName} caption track...`, 'Failed to upload caption', async (spinner) => {
     const result = await uploadCaption(parsedId, langCode, filePath, {
       name: options.name,
       draft: options.draft,
+      force: options.force,
     });
 
+    const verb = result.replaced ? 'Replaced' : 'Uploaded';
     // Spinner output goes to stderr, so machine formats stay pipeable.
     spinner.succeed(chalk.green(
-      `Uploaded ${langName} (${result.language}) caption track${result.isDraft ? ' as draft' : ''}`
+      `${verb} ${langName} (${result.language}) caption track${result.isDraft ? ' as draft' : ''}`
     ));
 
     if (outputFormat !== 'pretty') {
-      console.log(formatData([{ ...result, action: 'uploaded' }], outputFormat));
+      console.log(formatData([{ ...result, action: result.replaced ? 'replaced' : 'uploaded' }], outputFormat));
       return;
     }
 
@@ -74,6 +78,9 @@ async function putCaptionCommand(options: PutCaptionOptions): Promise<void> {
     console.log(chalk.gray(`Video ID:   ${result.videoId}`));
     if (result.name) {
       console.log(chalk.gray(`Track name: ${result.name}`));
+    }
+    if (result.replaced) {
+      console.log(chalk.yellow('Existing track content was overwritten (--force)'));
     }
     if (result.isDraft) {
       console.log(chalk.yellow('Draft: not visible to viewers until published in YouTube Studio'));

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -220,6 +220,39 @@ staqan-yt get-caption --caption-id <caption-id> --format json | \
 
 ---
 
+
+## put-caption
+
+Upload a new caption track to a video on your channel.
+
+### Usage
+
+```bash
+staqan-yt put-caption --video-id <videoId> --language <lang> --file <path>
+```
+
+### Options
+
+- `--video-id <id>` - Video ID (must be on your authenticated channel) (required)
+- `--language <lang>` - Caption language as a BCP-47 code, e.g. `ja`, `en`, `ko` (required)
+- `--file <path>` - Caption file: srt, vtt, sbv, scc, or ttml (required)
+- `--name <name>` - Track name shown in the player (default: empty)
+- `--draft` - Upload as a draft (not visible to viewers until published in YouTube Studio)
+- `--output <format>` - Output format: json, table, text, pretty, csv (default: pretty). Machine formats emit the created track (`id`, `videoId`, `language`, `name`, `isDraft`)
+- `-v, --verbose` - Enable verbose output with debug information
+
+### Examples
+
+```bash
+# Upload Japanese subtitles
+staqan-yt put-caption --video-id dQw4w9WgXcQ --language ja --file ./subs/ja.srt
+
+# Upload as a draft for review in Studio, get the caption ID for scripting
+staqan-yt put-caption --video-id dQw4w9WgXcQ --language en --file en.vtt --draft --output json
+```
+
+> **PUT semantics:** like `put-video-localization`, this creates a new track and the API rejects the upload if a track with the same language and name already exists. Use `list-captions` to check what exists first.
+
 ## Common Patterns
 
 ### Analyze Comment Sentiment

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -238,6 +238,7 @@ staqan-yt put-caption --video-id <videoId> --language <lang> --file <path>
 - `--file <path>` - Caption file: srt, vtt, sbv, scc, or ttml (required)
 - `--name <name>` - Track name shown in the player (default: empty)
 - `--draft` - Upload as a draft (not visible to viewers until published in YouTube Studio)
+- `-f, --force` - If a track with the same language and name already exists, replace its content (via `captions.update`) instead of failing
 - `--output <format>` - Output format: json, table, text, pretty, csv (default: pretty). Machine formats emit the created track (`id`, `videoId`, `language`, `name`, `isDraft`)
 - `-v, --verbose` - Enable verbose output with debug information
 
@@ -251,7 +252,7 @@ staqan-yt put-caption --video-id dQw4w9WgXcQ --language ja --file ./subs/ja.srt
 staqan-yt put-caption --video-id dQw4w9WgXcQ --language en --file en.vtt --draft --output json
 ```
 
-> **PUT semantics:** like `put-video-localization`, this creates a new track and the API rejects the upload if a track with the same language and name already exists. Use `list-captions` to check what exists first.
+> **PUT semantics:** like `put-video-localization`, this creates a new track and the API rejects the upload if a track with the same language and name already exists. Use `list-captions` to check what exists first, or pass `--force` to overwrite the existing track's content.
 
 ## Common Patterns
 

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -140,7 +140,7 @@ export function getCommandOptions(command: string): string[] {
     'list-playlists': ['--channel', '--limit', '-l', '--privacy', ...outputOptions, ...verboseOption],
     'list-captions': [...outputOptions, ...verboseOption],
     'get-caption': ['--format', ...verboseOption],
-    'put-caption': ['--language', '--file', '--name', '--draft', ...outputOptions, ...verboseOption],
+    'put-caption': ['--language', '--file', '--name', '--draft', '--force', '-f', ...outputOptions, ...verboseOption],
     'list-report-types': ['--output', 'json', 'table', 'text', ...verboseOption],
     'list-report-jobs': ['--type', '--output', 'json', 'table', 'text', ...verboseOption],
     'get-report-data': ['--type', '--video-id', '--start-date', '--end-date', '--output', 'json', 'csv', ...verboseOption],
@@ -357,7 +357,7 @@ _staqa_nyt_completion() {
       COMPREPLY=( \$(compgen -W "--caption-id --format --verbose" -- "\${cur}") )
       ;;
     put-caption)
-      COMPREPLY=( \$(compgen -W "--video-id --language --file --name --draft --output --verbose" -- "\${cur}") )
+      COMPREPLY=( \$(compgen -W "--video-id --language --file --name --draft --force --output --verbose" -- "\${cur}") )
       ;;
     get-channel)
       COMPREPLY=( \$(compgen -W "--channel --output --verbose" -- "\${cur}") )
@@ -799,6 +799,7 @@ ${commandList}
         '--file[Caption file]:file:_files' \\
         '--name[Track name]:name:' \\
         '--draft[Upload as draft]' \\
+        '--force[Replace existing matching track]' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -48,6 +48,7 @@ export function getCommands(): string[] {
     'get-thumbnail',
     'list-captions',
     'get-caption',
+    'put-caption',
     // Playlists
     'get-playlist',
     'get-playlists',
@@ -98,6 +99,7 @@ export function getRequiredFlags(command: string): string[] {
     'list-comments': ['--video-id'],
     'list-captions': ['--video-id'],
     'get-caption': ['--caption-id'],
+    'put-caption': ['--video-id', '--language', '--file'],
   };
 
   return requiredFlagMap[command] || [];
@@ -138,6 +140,7 @@ export function getCommandOptions(command: string): string[] {
     'list-playlists': ['--channel', '--limit', '-l', '--privacy', ...outputOptions, ...verboseOption],
     'list-captions': [...outputOptions, ...verboseOption],
     'get-caption': ['--format', ...verboseOption],
+    'put-caption': ['--language', '--file', '--name', '--draft', ...outputOptions, ...verboseOption],
     'list-report-types': ['--output', 'json', 'table', 'text', ...verboseOption],
     'list-report-jobs': ['--type', '--output', 'json', 'table', 'text', ...verboseOption],
     'get-report-data': ['--type', '--video-id', '--start-date', '--end-date', '--output', 'json', 'csv', ...verboseOption],
@@ -353,6 +356,9 @@ _staqa_nyt_completion() {
     get-caption)
       COMPREPLY=( \$(compgen -W "--caption-id --format --verbose" -- "\${cur}") )
       ;;
+    put-caption)
+      COMPREPLY=( \$(compgen -W "--video-id --language --file --name --draft --output --verbose" -- "\${cur}") )
+      ;;
     get-channel)
       COMPREPLY=( \$(compgen -W "--channel --output --verbose" -- "\${cur}") )
       ;;
@@ -440,6 +446,7 @@ function generateZshCompletion(): string {
     'list-playlists': 'List channel playlists',
     'list-captions': 'List caption tracks',
     'get-caption': 'Download caption content',
+    'put-caption': 'Upload a caption track',
     'list-report-types': 'List available report types',
     'list-report-jobs': 'List report jobs',
     'get-report-data': 'Get report data',
@@ -781,6 +788,18 @@ ${commandList}
       _arguments \\
         '--caption-id[Caption ID]:id:( )' \\
         '--format[Caption format]:format:(srt vtt sbv scc ttml json)' \\
+        '--verbose[Enable verbose output]'
+      ;;
+    put-caption)
+      local words=(\$words[1] \$words[3,-1])
+      local CURRENT=\$((\$CURRENT - 1))
+      _arguments \\
+        '--video-id[Video ID]: :_staqan_yt_video_ids' \\
+        '--language[Caption language (BCP-47)]:lang:' \\
+        '--file[Caption file]:file:_files' \\
+        '--name[Track name]:name:' \\
+        '--draft[Upload as draft]' \\
+        '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;
     get-channel)

--- a/lib/customHelp.ts
+++ b/lib/customHelp.ts
@@ -57,6 +57,7 @@ const COMMAND_GROUPS: Record<string, string[]> = {
     'list-comments',
     'list-captions',
     'get-caption',
+    'put-caption',
   ],
 };
 

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1,5 +1,5 @@
 import { google, youtube_v3 } from 'googleapis';
-import { promises as fs } from 'fs';
+import { promises as fs, createReadStream } from 'fs';
 import path from 'path';
 import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName } from './language';
@@ -931,6 +931,54 @@ async function downloadCaption(captionId: string, format: CaptionFormat = 'json'
   return content;
 }
 
+export interface UploadedCaption {
+  id: string;
+  videoId: string;
+  language: string;
+  name: string;
+  isDraft: boolean;
+}
+
+/**
+ * Upload a new caption track for a video (captions.insert).
+ * The API rejects the upload if a track with the same language+name already
+ * exists on the video — matching the put-* "create, fail if exists" contract.
+ * Requires ownership of the video (youtube.force-ssl scope).
+ */
+async function uploadCaption(
+  videoId: string,
+  language: string,
+  filePath: string,
+  options: { name?: string; draft?: boolean } = {}
+): Promise<UploadedCaption> {
+  debug(`Uploading caption for video ${videoId} (${language}) from ${filePath}`);
+  const youtube = await getYouTubeClient();
+
+  const response = await youtube.captions.insert({
+    part: ['snippet'],
+    requestBody: {
+      snippet: {
+        videoId,
+        language,
+        name: options.name ?? '',
+        isDraft: options.draft ?? false,
+      },
+    },
+    media: {
+      body: createReadStream(filePath),
+    },
+  });
+
+  const snippet = response.data.snippet;
+  return {
+    id: response.data.id!,
+    videoId: snippet?.videoId || videoId,
+    language: snippet?.language || language,
+    name: snippet?.name ?? '',
+    isDraft: snippet?.isDraft ?? false,
+  };
+}
+
 export {
   getYouTubeClient,
   getChannelId,
@@ -950,4 +998,5 @@ export {
   listVideoComments,
   listCaptions,
   downloadCaption,
+  uploadCaption,
 };

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -937,46 +937,96 @@ export interface UploadedCaption {
   language: string;
   name: string;
   isDraft: boolean;
+  /** True when --force replaced an existing track's content instead of creating one. */
+  replaced: boolean;
 }
 
 /**
- * Upload a new caption track for a video (captions.insert).
- * The API rejects the upload if a track with the same language+name already
- * exists on the video — matching the put-* "create, fail if exists" contract.
- * Requires ownership of the video (youtube.force-ssl scope).
+ * Upload a caption track for a video.
+ *
+ * Default (put-* contract): captions.insert — the API rejects the upload if
+ * a track with the same language+name already exists. With `force: true`,
+ * an existing matching track is looked up first and its content replaced
+ * via captions.update instead (the only way the API offers to overwrite
+ * subtitles). Requires ownership of the video (youtube.force-ssl scope).
  */
 async function uploadCaption(
   videoId: string,
   language: string,
   filePath: string,
-  options: { name?: string; draft?: boolean } = {}
+  options: { name?: string; draft?: boolean; force?: boolean } = {}
 ): Promise<UploadedCaption> {
   debug(`Uploading caption for video ${videoId} (${language}) from ${filePath}`);
   const youtube = await getYouTubeClient();
+  const trackName = options.name ?? '';
 
-  const response = await youtube.captions.insert({
-    part: ['snippet'],
-    requestBody: {
-      snippet: {
-        videoId,
-        language,
-        name: options.name ?? '',
-        isDraft: options.draft ?? false,
+  if (options.force) {
+    const list = await youtube.captions.list({ part: ['snippet'], videoId });
+    const existing = (list.data.items || []).find(
+      item => item.snippet?.language === language && (item.snippet?.name ?? '') === trackName
+    );
+
+    if (existing?.id) {
+      debug(`--force: replacing existing caption track ${existing.id}`);
+      // Retain the stream so it can be destroyed if the API call fails —
+      // otherwise the file descriptor leaks until GC (matters for the
+      // long-running MCP server case).
+      const media = createReadStream(filePath);
+      try {
+        const response = await youtube.captions.update({
+          part: ['snippet'],
+          requestBody: {
+            id: existing.id,
+            snippet: { isDraft: options.draft ?? false },
+          },
+          media: { body: media },
+        });
+
+        const snippet = response.data.snippet;
+        return {
+          id: response.data.id || existing.id,
+          videoId,
+          language: snippet?.language || language,
+          name: snippet?.name ?? trackName,
+          isDraft: snippet?.isDraft ?? false,
+          replaced: true,
+        };
+      } catch (err) {
+        media.destroy();
+        throw err;
+      }
+    }
+    debug('--force: no matching track found, falling through to insert');
+  }
+
+  const media = createReadStream(filePath);
+  try {
+    const response = await youtube.captions.insert({
+      part: ['snippet'],
+      requestBody: {
+        snippet: {
+          videoId,
+          language,
+          name: trackName,
+          isDraft: options.draft ?? false,
+        },
       },
-    },
-    media: {
-      body: createReadStream(filePath),
-    },
-  });
+      media: { body: media },
+    });
 
-  const snippet = response.data.snippet;
-  return {
-    id: response.data.id!,
-    videoId: snippet?.videoId || videoId,
-    language: snippet?.language || language,
-    name: snippet?.name ?? '',
-    isDraft: snippet?.isDraft ?? false,
-  };
+    const snippet = response.data.snippet;
+    return {
+      id: response.data.id!,
+      videoId: snippet?.videoId || videoId,
+      language: snippet?.language || language,
+      name: snippet?.name ?? '',
+      isDraft: snippet?.isDraft ?? false,
+      replaced: false,
+    };
+  } catch (err) {
+    media.destroy();
+    throw err;
+  }
 }
 
 export {

--- a/types/index.ts
+++ b/types/index.ts
@@ -311,6 +311,13 @@ export interface GetCaptionOptions extends OutputOption, VerboseOption, CaptionI
   format?: CaptionFormat;
 }
 
+export interface PutCaptionOptions extends OutputOption, VerboseOption, VideoIdOption {
+  language: string;
+  file: string;
+  name?: string;
+  draft?: boolean;
+}
+
 // Channel analytics command options
 export interface ChannelAnalyticsOptions extends ChannelOption, OutputOption, VerboseOption {
   report?: 'demographics' | 'devices' | 'geography' | 'traffic-sources' | 'subscription-status';

--- a/types/index.ts
+++ b/types/index.ts
@@ -316,6 +316,7 @@ export interface PutCaptionOptions extends OutputOption, VerboseOption, VideoIdO
   file: string;
   name?: string;
   draft?: boolean;
+  force?: boolean;
 }
 
 // Channel analytics command options


### PR DESCRIPTION
## Value proposition

The caption surface was read-only: `list-captions` and `get-caption` exist, but uploading subtitles meant YouTube Studio. `put-caption` completes the workflow — directly relevant to the localization pipeline (upload ja/en/ru subtitle files from the CLI, scriptable via `--output json`). Named `put-caption` per the house `put-*` convention (`put-video-localization`): create-new, API fails if a track with the same language+name exists.

## Command

```bash
staqan-yt put-caption --video-id ID --language ja --file ./subs/ja.srt [--name NAME] [--draft] [--output json]
```

- **`lib/youtube.ts`**: `uploadCaption()` via `captions.insert` with a file stream; requires the `youtube.force-ssl` scope (already granted — same scope `get-caption` uses).
- **Language**: any BCP-47 code passes through (known codes normalized for the display name — the en/ja/ru map limitation is #105's scope, not repeated here).
- **File validation before quota**: existence, regular-file, non-empty — with the supported-formats hint in the error.
- **Output contract per #140**: pretty shows caption ID/track info; machine formats emit `{id, videoId, language, name, isDraft, action}`.
- Registered in bin + help grouping (Engagement) + bash/zsh completions (6 regions, `--file` completes filesystem paths in zsh) + `docs/commands/engagement.md` section.

## Verification

- Help grouping renders; missing/empty file fails fast with exit 1 and **zero API spend**
- Full upload plumbing exercised to the API boundary with a bogus video ID → clean API error, exit 1, no mutation (channel has no unlisted videos and public-video writes are off-limits, so the happy path awaits the next unlisted upload or an explicit go-ahead — the code path difference is only the API's accept vs reject)
- Generated completion scripts contain the new entries and pass `bash -n`/`zsh -n`
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓ · `bun test` 61 pass

Follow-up candidates (not in scope): `update-caption` (captions.update — replace track content by ID) and `delete-caption`. Say the word and I'll file them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `put-caption` command for uploading caption or subtitle tracks to videos.
  * Supports language, file, track name, draft uploads, output formatting, and verbose mode.
  * Added human-readable and machine-friendly upload results.
  * Added Bash and Zsh tab-completion support.

* **Documentation**
  * Added command usage, options, examples, and upload behavior details to the engagement documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->