### PR TITLE
refactor(#102): phase 2 — shared traffic-sources/search-terms/retention data layer

### DIFF
--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
-import { google } from 'googleapis';
 import { parseVideoId, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, runOrExit } from '../lib/utils';
+import { fetchSearchTerms } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchTermsOptions } from '../types';
@@ -21,51 +20,23 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     const parsedId = parseVideoId(videoId);
     debug('Parsed video ID', parsedId);
 
-    const auth = await getAuthenticatedClient();
-    const youtube = google.youtube({ version: 'v3', auth });
-    const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
-
-    // Get video info for title
-    const videoResponse = await youtube.videos.list({
-      part: ['snippet'],
-      id: [parsedId],
-    });
-
-    if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      throw new Error(`No video found with ID: ${parsedId}`);
-    }
-
-    const title = videoResponse.data.items[0].snippet?.title || 'Untitled';
-
-    // Date range: last 30 days
+    // CLI default: last 30 days (MCP defaults to all-time; the shared lib
+    // takes an explicit range — see lib/analytics.ts #102).
     const endDate = toLocalYmd(new Date());
     const startDate = (() => {
       const date = new Date();
       date.setDate(date.getDate() - 30);
       return toLocalYmd(date);
     })();
-
     debug(`Date range: ${startDate} to ${endDate}`);
 
-    // Fetch search terms data
-    const analyticsResponse = await youtubeAnalytics.reports.query({
-      ids: 'channel==MINE',
-      startDate,
-      endDate,
-      metrics: 'views',
-      dimensions: 'insightTrafficSourceDetail',
-      filters: `video==${parsedId};insightTrafficSourceType==YT_SEARCH`,
-      sort: '-views',
-      maxResults: limit,
-    });
+    const result = await fetchSearchTerms({ videoId: parsedId, startDate, endDate, limit });
+    const { title, rows } = result;
 
     spinner.succeed('Search terms data retrieved');
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
-
-    // Prepare data for structured formats
-    const rows = analyticsResponse.data.rows || [];
     const searchTermsData = rows.map((row, index) => ({
       rank: index + 1,
       searchTerm: row[0] as string,
@@ -78,8 +49,8 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
           videoId: parsedId,
           title,
           dateRange: { startDate, endDate },
-          columnHeaders: analyticsResponse.data.columnHeaders,
-          rows: analyticsResponse.data.rows,
+          columnHeaders: result.columnHeaders,
+          rows,
         }));
         break;
 
@@ -95,8 +66,8 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
 
       case 'csv':
         // Use convertToCSV for consistency with analytics commands
-        if (analyticsResponse.data.columnHeaders && analyticsResponse.data.rows) {
-          console.log(convertToCSV(analyticsResponse.data.columnHeaders, analyticsResponse.data.rows));
+        if (result.columnHeaders.length > 0 && rows.length > 0) {
+          console.log(convertToCSV(result.columnHeaders, rows));
         } else {
           console.log(formatCsv(searchTermsData));
         }

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { parseVideoId, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, runOrExit } from '../lib/utils';
+import { parseVideoId, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, daysAgoYmd, runOrExit } from '../lib/utils';
 import { fetchSearchTerms } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
@@ -23,11 +23,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     // CLI default: last 30 days (MCP defaults to all-time; the shared lib
     // takes an explicit range — see lib/analytics.ts #102).
     const endDate = toLocalYmd(new Date());
-    const startDate = (() => {
-      const date = new Date();
-      date.setDate(date.getDate() - 30);
-      return toLocalYmd(date);
-    })();
+    const startDate = daysAgoYmd(30);
     debug(`Date range: ${startDate} to ${endDate}`);
 
     const result = await fetchSearchTerms({ videoId: parsedId, startDate, endDate, limit });

--- a/commands/get-traffic-sources.ts
+++ b/commands/get-traffic-sources.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { parseVideoId, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
+import { parseVideoId, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, daysAgoYmd } from '../lib/utils';
 import { fetchTrafficSources } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
@@ -22,11 +22,7 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
     // shared lib takes an explicit range so neither surface's documented
     // behavior changes; see lib/analytics.ts #102).
     const endDate = toLocalYmd(new Date());
-    const startDate = (() => {
-      const date = new Date();
-      date.setDate(date.getDate() - 30);
-      return toLocalYmd(date);
-    })();
+    const startDate = daysAgoYmd(30);
     debug(`Date range: ${startDate} to ${endDate}`);
 
     const result = await fetchTrafficSources({ videoId: parsedId, startDate, endDate });
@@ -72,7 +68,7 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
 
     switch (outputFormat) {
       case 'csv':
-        if (columnHeaders && rows) {
+        if (columnHeaders.length > 0 && rows.length > 0) {
           console.log(convertToCSV(columnHeaders, rows));
         } else {
           console.log(formatCsv(trafficData));

--- a/commands/get-traffic-sources.ts
+++ b/commands/get-traffic-sources.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
-import { google } from 'googleapis';
 import { parseVideoId, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
+import { fetchTrafficSources } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { TrafficSourcesOptions } from '../types';
@@ -19,51 +18,24 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
     const parsedId = parseVideoId(videoId);
     debug('Parsed video ID', parsedId);
 
-    const auth = await getAuthenticatedClient();
-    const youtube = google.youtube({ version: 'v3', auth });
-    const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
-
-    // Get video info for title
-    const videoResponse = await youtube.videos.list({
-      part: ['snippet'],
-      id: [parsedId],
-    });
-
-    if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      throw new Error(`No video found with ID: ${parsedId}`);
-    }
-
-    const title = videoResponse.data.items[0].snippet?.title || 'Untitled';
-
-    // Date range: last 30 days
+    // CLI default: last 30 days (the MCP tool defaults to all-time — the
+    // shared lib takes an explicit range so neither surface's documented
+    // behavior changes; see lib/analytics.ts #102).
     const endDate = toLocalYmd(new Date());
     const startDate = (() => {
       const date = new Date();
       date.setDate(date.getDate() - 30);
       return toLocalYmd(date);
     })();
-
     debug(`Date range: ${startDate} to ${endDate}`);
 
-    // Fetch traffic sources data
-    const analyticsResponse = await youtubeAnalytics.reports.query({
-      ids: 'channel==MINE',
-      startDate,
-      endDate,
-      metrics: 'views',
-      dimensions: 'insightTrafficSourceType',
-      filters: `video==${parsedId}`,
-      sort: '-views',
-    });
+    const result = await fetchTrafficSources({ videoId: parsedId, startDate, endDate });
+    const { title, columnHeaders, rows } = result;
 
     spinner.succeed('Traffic sources data retrieved');
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
-
-    // Prepare data
-    const rows = analyticsResponse.data.rows || [];
-    const columnHeaders = analyticsResponse.data.columnHeaders || [];
 
     // Traffic source labels
     const sourceLabels: { [key: string]: string } = {

--- a/commands/get-video-retention.ts
+++ b/commands/get-video-retention.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
-import { google } from 'googleapis';
-import { parseVideoId, debug, convertToCSV, chunkDateRange, withRateLimitRetry, parseDuration, formatTimestamp, initCommand, withSpinner, toLocalYmd } from '../lib/utils';
+import { parseVideoId, debug, convertToCSV, parseDuration, formatTimestamp, initCommand, withSpinner } from '../lib/utils';
+import { fetchVideoRetention } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { RetentionOptions } from '../types';
@@ -19,69 +18,13 @@ async function getRetentionCommand(options: RetentionOptions): Promise<void> {
     const parsedId = parseVideoId(videoId);
     debug('Parsed video ID', parsedId);
 
-    const auth = await getAuthenticatedClient();
-    const youtube = google.youtube({ version: 'v3', auth });
-    const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
-
-    // Get video info for title, publish date, and duration
-    const videoResponse = await youtube.videos.list({
-      part: ['snippet', 'contentDetails'],
-      id: [parsedId],
-    });
-
-    if (!videoResponse.data.items || videoResponse.data.items.length === 0) {
-      throw new Error(`No video found with ID: ${parsedId}`);
-    }
-
-    const video = videoResponse.data.items[0];
-    const title = video.snippet?.title || 'Untitled';
-    const publishedAt = video.snippet?.publishedAt;
-    const duration = video.contentDetails?.duration || '';
-
-    if (!publishedAt) {
-      throw new Error('Video publish date is missing');
-    }
-
-    // Calculate date range (default: full historical data)
-    const endDate = toLocalYmd(new Date());
-    const startDate = publishedAt.split('T')[0];
-
-    debug(`Date range: ${startDate} to ${endDate}`);
-
-    // Chunk date range into 90-day periods
-    const dateChunks = chunkDateRange(startDate, endDate);
-    debug(`Split into ${dateChunks.length} chunk(s) of 90 days`);
-
-    // Fetch retention data for each chunk
-    const allRows: unknown[][] = [];
-    let columnHeaders: { name?: string | null }[] = [];
-
-    for (let i = 0; i < dateChunks.length; i++) {
-      const chunk = dateChunks[i];
-      spinner.text = `Fetching chunk ${i + 1}/${dateChunks.length} (${chunk.start} to ${chunk.end})...`;
-
-      const retentionResponse = await withRateLimitRetry(async () => {
-        return await youtubeAnalytics.reports.query({
-          ids: 'channel==MINE',
-          startDate: chunk.start,
-          endDate: chunk.end,
-          metrics: 'audienceWatchRatio,relativeRetentionPerformance',
-          dimensions: 'elapsedVideoTimeRatio',
-          filters: `video==${parsedId}`,
-          sort: 'elapsedVideoTimeRatio',
-        });
-      }, { label: 'reports.query(retention)' });
-
-      // Save headers from first response
-      if (i === 0 && retentionResponse.data.columnHeaders) {
-        columnHeaders = retentionResponse.data.columnHeaders;
-      }
-
-      // Aggregate rows
-      if (retentionResponse.data.rows && retentionResponse.data.rows.length > 0) {
-        allRows.push(...retentionResponse.data.rows);
-      }
-    }
+    // Single lifetime query — ratio-dimension reports return one complete
+    // 100-point curve per query; the previous 90-day chunking could
+    // interleave duplicate ratio points whenever more than one chunk had
+    // data (see lib/analytics.ts, #102).
+    const result = await fetchVideoRetention({ videoId: parsedId });
+    const { title, duration, dateRange, columnHeaders, rows: allRows } = result;
+    const { startDate, endDate } = dateRange;
 
     spinner.succeed(`Retrieved ${allRows.length} retention data point(s)`);
 

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -23,7 +23,7 @@ import {
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
 import { parseVideoId, initCommand, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
-import { fetchVideoAnalytics } from '../lib/analytics';
+import { fetchVideoAnalytics, fetchTrafficSources, fetchSearchTerms, fetchVideoRetention, ALL_TIME_START_DATE } from '../lib/analytics';
 import { requireChannel } from '../lib/config';
 import { getVersion } from '../lib/version';
 
@@ -798,25 +798,20 @@ async function handleToolCall(name: string, args: any) {
     }
 
     case 'youtube_get_search_terms': {
-      const parsedId = parseVideoId(args.videoId);
-      const limit = args.limit || 50;
-
-      const analyticsResponse = await youtubeAnalytics.reports.query({
-        ids: 'channel==MINE',
-        startDate: '2000-01-01',
+      // Shared data layer (lib/analytics.ts, #102). MCP keeps its all-time
+      // default (the CLI command defaults to the last 30 days).
+      const result = await fetchSearchTerms({
+        videoId: parseVideoId(args.videoId),
+        startDate: ALL_TIME_START_DATE,
         endDate: toLocalYmd(new Date()),
-        metrics: 'views',
-        dimensions: 'insightTrafficSourceDetail',
-        filters: `video==${parsedId};insightTrafficSourceType==YT_SEARCH`,
-        maxResults: limit,
-        sort: '-views',
+        limit: args.limit || 50,
       });
 
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify(analyticsResponse.data, null, 2),
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };
@@ -946,46 +941,34 @@ async function handleToolCall(name: string, args: any) {
     }
 
     case 'youtube_get_traffic_sources': {
-      const parsedId = parseVideoId(args.videoId);
-
-      const analyticsResponse = await youtubeAnalytics.reports.query({
-        ids: 'channel==MINE',
-        startDate: '2000-01-01',
+      // Shared data layer (lib/analytics.ts, #102). MCP keeps its all-time
+      // default (the CLI command defaults to the last 30 days).
+      const result = await fetchTrafficSources({
+        videoId: parseVideoId(args.videoId),
+        startDate: ALL_TIME_START_DATE,
         endDate: toLocalYmd(new Date()),
-        metrics: 'views',
-        dimensions: 'insightTrafficSourceType',
-        filters: `video==${parsedId}`,
-        sort: '-views',
       });
 
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify(analyticsResponse.data, null, 2),
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };
     }
 
     case 'youtube_get_video_retention': {
-      const parsedId = parseVideoId(args.videoId);
-
-      const analyticsResponse = await youtubeAnalytics.reports.query({
-        ids: 'channel==MINE',
-        startDate: '2000-01-01',
-        endDate: toLocalYmd(new Date()),
-        metrics: 'audienceWatchRatio,relativeRetentionPerformance',
-        dimensions: 'elapsedVideoTimeRatio',
-        filters: `video==${parsedId}`,
-        sort: 'elapsedVideoTimeRatio',
-      });
+      // Shared data layer (lib/analytics.ts, #102): single lifetime query
+      // from the upload date; result now includes title/duration context.
+      const result = await fetchVideoRetention({ videoId: parseVideoId(args.videoId) });
 
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify(analyticsResponse.data, null, 2),
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -183,3 +183,157 @@ export async function fetchVideoAnalytics(params: VideoAnalyticsParams): Promise
     rows: allRows,
   };
 }
+
+// ─── Per-video report queries (traffic sources, search terms, retention) ─────
+
+/** YouTube's founding date — the effective "all-time" start for Analytics queries. */
+export const ALL_TIME_START_DATE = '2005-02-14';
+
+/** Rows + headers as the Analytics API returns them, plus display context. */
+export interface VideoReportResult {
+  videoId: string;
+  title: string;
+  dateRange: { startDate: string; endDate: string };
+  columnHeaders: { name?: string | null }[];
+  rows: unknown[][];
+}
+
+interface VideoSnippetInfo {
+  title: string;
+  publishedAt: string;
+  duration: string;
+}
+
+/** Shared lookup: title/publishedAt/duration for display and date defaulting. */
+async function lookupVideoSnippet(videoId: string): Promise<VideoSnippetInfo> {
+  const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
+  const response = await youtube.videos.list({
+    part: ['snippet', 'contentDetails'],
+    id: [videoId],
+  });
+
+  if (!response.data.items || response.data.items.length === 0) {
+    throw new Error(`No video found with ID: ${videoId}`);
+  }
+
+  const item = response.data.items[0];
+  const publishedAt = item.snippet?.publishedAt;
+  if (!publishedAt) {
+    throw new Error('Video publish date is missing');
+  }
+  return {
+    title: item.snippet?.title || 'Untitled',
+    publishedAt,
+    duration: item.contentDetails?.duration || '',
+  };
+}
+
+/**
+ * Traffic-source breakdown for one video (insightTrafficSourceType).
+ * Date range is caller-supplied on purpose: the CLI defaults to the last 30
+ * days, the MCP tool to all-time — consolidating here must not silently
+ * change either surface's documented behavior.
+ */
+export async function fetchTrafficSources(params: {
+  videoId: string;
+  startDate: string;
+  endDate: string;
+}): Promise<VideoReportResult> {
+  const { title } = await lookupVideoSnippet(params.videoId);
+  const auth = await getAuthenticatedClient();
+  const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+
+  const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
+    ids: 'channel==MINE',
+    startDate: params.startDate,
+    endDate: params.endDate,
+    metrics: 'views',
+    dimensions: 'insightTrafficSourceType',
+    filters: `video==${params.videoId}`,
+    sort: '-views',
+  }), { label: 'reports.query(traffic sources)' });
+
+  return {
+    videoId: params.videoId,
+    title,
+    dateRange: { startDate: params.startDate, endDate: params.endDate },
+    columnHeaders: response.data.columnHeaders || [],
+    rows: response.data.rows || [],
+  };
+}
+
+/**
+ * YouTube-search terms that led viewers to one video
+ * (insightTrafficSourceDetail filtered to YT_SEARCH). Same caller-supplied
+ * date-range contract as fetchTrafficSources.
+ */
+export async function fetchSearchTerms(params: {
+  videoId: string;
+  startDate: string;
+  endDate: string;
+  limit: number;
+}): Promise<VideoReportResult> {
+  const { title } = await lookupVideoSnippet(params.videoId);
+  const auth = await getAuthenticatedClient();
+  const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+
+  const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
+    ids: 'channel==MINE',
+    startDate: params.startDate,
+    endDate: params.endDate,
+    metrics: 'views',
+    dimensions: 'insightTrafficSourceDetail',
+    filters: `video==${params.videoId};insightTrafficSourceType==YT_SEARCH`,
+    sort: '-views',
+    maxResults: params.limit,
+  }), { label: 'reports.query(search terms)' });
+
+  return {
+    videoId: params.videoId,
+    title,
+    dateRange: { startDate: params.startDate, endDate: params.endDate },
+    columnHeaders: response.data.columnHeaders || [],
+    rows: response.data.rows || [],
+  };
+}
+
+export interface VideoRetentionResult extends VideoReportResult {
+  duration: string;
+}
+
+/**
+ * Lifetime audience-retention curve (elapsedVideoTimeRatio) in a single
+ * query from the upload date. Deliberately NOT chunked into 90-day windows:
+ * ratio-dimension reports return one complete 100-point curve per query, so
+ * chunking + concatenation would interleave duplicate ratio points whenever
+ * more than one chunk has data (live-verified 2026-07-13: a lifetime query
+ * returns exactly 100 unique ratio points, 0.01 → 1).
+ */
+export async function fetchVideoRetention(params: { videoId: string }): Promise<VideoRetentionResult> {
+  const { title, publishedAt, duration } = await lookupVideoSnippet(params.videoId);
+  const auth = await getAuthenticatedClient();
+  const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+
+  const startDate = publishedAt.split('T')[0];
+  const endDate = toLocalYmd(new Date());
+
+  const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
+    ids: 'channel==MINE',
+    startDate,
+    endDate,
+    metrics: 'audienceWatchRatio,relativeRetentionPerformance',
+    dimensions: 'elapsedVideoTimeRatio',
+    filters: `video==${params.videoId}`,
+    sort: 'elapsedVideoTimeRatio',
+  }), { label: 'reports.query(retention)' });
+
+  return {
+    videoId: params.videoId,
+    title,
+    duration,
+    dateRange: { startDate, endDate },
+    columnHeaders: response.data.columnHeaders || [],
+    rows: response.data.rows || [],
+  };
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -111,6 +111,7 @@ export const DEFAULT_VIDEO_METRICS =
  * dimensions, or an inverted date range.
  */
 export async function fetchVideoAnalytics(params: VideoAnalyticsParams): Promise<VideoAnalyticsResult> {
+  assertVideoId(params.videoId);
   const auth = await getAuthenticatedClient();
   const youtube = google.youtube({ version: 'v3', auth });
   const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
@@ -198,6 +199,17 @@ export interface VideoReportResult {
   rows: unknown[][];
 }
 
+/**
+ * Strict video-ID check before interpolating into an Analytics `filters`
+ * string. parseVideoId passes unmatched input through unchanged, so without
+ * this a malformed value could inject extra filter clauses.
+ */
+function assertVideoId(videoId: string): void {
+  if (!/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+    throw new Error(`Invalid video ID: ${videoId}`);
+  }
+}
+
 interface VideoSnippetInfo {
   title: string;
   publishedAt: string;
@@ -240,6 +252,7 @@ export async function fetchTrafficSources(params: {
   startDate: string;
   endDate: string;
 }): Promise<VideoReportResult> {
+  assertVideoId(params.videoId);
   const { title } = await lookupVideoSnippet(params.videoId);
   const auth = await getAuthenticatedClient();
   const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
@@ -274,6 +287,7 @@ export async function fetchSearchTerms(params: {
   endDate: string;
   limit: number;
 }): Promise<VideoReportResult> {
+  assertVideoId(params.videoId);
   const { title } = await lookupVideoSnippet(params.videoId);
   const auth = await getAuthenticatedClient();
   const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
@@ -311,6 +325,7 @@ export interface VideoRetentionResult extends VideoReportResult {
  * returns exactly 100 unique ratio points, 0.01 → 1).
  */
 export async function fetchVideoRetention(params: { videoId: string }): Promise<VideoRetentionResult> {
+  assertVideoId(params.videoId);
   const { title, publishedAt, duration } = await lookupVideoSnippet(params.videoId);
   const auth = await getAuthenticatedClient();
   const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -9,7 +9,7 @@
  * --dimensions support when #120 shipped it in the CLI).
  */
 
-import { google } from 'googleapis';
+import { google, youtube_v3 } from 'googleapis';
 import { getAuthenticatedClient } from './auth';
 import { chunkDateRange, debug, toLocalYmd, validateDateRange, withRateLimitRetry } from './utils';
 
@@ -217,9 +217,7 @@ interface VideoSnippetInfo {
 }
 
 /** Shared lookup: title/publishedAt/duration for display and date defaulting. */
-async function lookupVideoSnippet(videoId: string): Promise<VideoSnippetInfo> {
-  const auth = await getAuthenticatedClient();
-  const youtube = google.youtube({ version: 'v3', auth });
+async function lookupVideoSnippet(youtube: youtube_v3.Youtube, videoId: string): Promise<VideoSnippetInfo> {
   const response = await youtube.videos.list({
     part: ['snippet', 'contentDetails'],
     id: [videoId],
@@ -253,9 +251,11 @@ export async function fetchTrafficSources(params: {
   endDate: string;
 }): Promise<VideoReportResult> {
   assertVideoId(params.videoId);
-  const { title } = await lookupVideoSnippet(params.videoId);
+  validateDateRange(params.startDate, params.endDate);
   const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
   const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+  const { title } = await lookupVideoSnippet(youtube, params.videoId);
 
   const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
     ids: 'channel==MINE',
@@ -288,9 +288,11 @@ export async function fetchSearchTerms(params: {
   limit: number;
 }): Promise<VideoReportResult> {
   assertVideoId(params.videoId);
-  const { title } = await lookupVideoSnippet(params.videoId);
+  validateDateRange(params.startDate, params.endDate);
   const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
   const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+  const { title } = await lookupVideoSnippet(youtube, params.videoId);
 
   const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
     ids: 'channel==MINE',
@@ -326,9 +328,10 @@ export interface VideoRetentionResult extends VideoReportResult {
  */
 export async function fetchVideoRetention(params: { videoId: string }): Promise<VideoRetentionResult> {
   assertVideoId(params.videoId);
-  const { title, publishedAt, duration } = await lookupVideoSnippet(params.videoId);
   const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
   const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+  const { title, publishedAt, duration } = await lookupVideoSnippet(youtube, params.videoId);
 
   const startDate = publishedAt.split('T')[0];
   const endDate = toLocalYmd(new Date());

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -333,6 +333,13 @@ function toLocalYmd(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+/** Local-timezone YYYY-MM-DD for `n` days before today (CLI date-range defaults). */
+function daysAgoYmd(n: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - n);
+  return toLocalYmd(date);
+}
+
 function validateDateOption(flag: string, value: string): void {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
     throw new Error(`${flag} must be in YYYY-MM-DD format (got: ${value})`);
@@ -722,6 +729,7 @@ export {
   withRateLimitRetry,
   parsePositiveInt,
   toLocalYmd,
+  daysAgoYmd,
   validateDateOption,
   validateDateRange,
   validatePrivacyFilter,


### PR DESCRIPTION
Part of #102, following the #146 pattern. Resolves the three behavioral divergences documented in the issue comment:

1. **Date defaults preserved per surface** — shared functions take explicit ranges; CLI keeps last-30-days, MCP keeps all-time (now via one `ALL_TIME_START_DATE` constant instead of `2000-01-01` scattered literals).
2. **Retention chunking removed — it was a latent bug.** Live experiment (2026-07-13): a lifetime `elapsedVideoTimeRatio` query returns exactly **100 unique ratio points, zero duplicates**, so the CLI's 90-day chunk-and-concatenate would interleave duplicate curves for any older video with views across chunks. Single query from upload date now, documented in the lib.
3. `lookupVideoSnippet` shared across all four analytics fetchers (title/publishedAt/duration in one place); the three report queries gained `withRateLimitRetry` (the CLI copies previously had none).

MCP bonus: retention/traffic/search results now carry `videoId`/`title`/`dateRange` context instead of raw API payloads.

## Verification (live on @staqan)

- `get-video-retention` → 100-point curve (101 CSV lines), identical to pre-refactor output
- `get-traffic-sources --output json` → title + rows intact; `get-search-terms --output json` → same shape as before
- `bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓ · `bun test` 61 pass

Remaining #102 phases: channel-analytics + channel-search-terms (the two big mcp.ts blocks), then the reporting tools' monkey-patching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared analytics layer for video search terms, traffic sources, and retention across command line and MCP tools.
  - MCP search-terms now span from an all-time start through today; traffic sources cover the last 30 days; retention covers the video’s lifetime.
- **Improvements**
  - Standardized JSON output (titles, headers, rows) across commands and MCP tools.
  - Improved handling when analytics data is empty: CSV is now emitted only when report data is present.
  - More consistent local-time date windows for reporting ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->