### PR TITLE
fix: caption format guard — reject unsupported files, fail loudly on processing failure

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -457,7 +457,7 @@ program
   .description('Upload a new caption track to a video (fails if same language+name track exists)')
   .requiredOption('--video-id <id>', 'Video ID (must be on your channel)')
   .requiredOption('--language <lang>', 'Caption language (BCP-47 code, e.g. "ja", "en")')
-  .requiredOption('--file <path>', 'Caption file: srt, vtt, sbv, scc, or ttml')
+  .requiredOption('--file <path>', 'Caption file: srt, sbv, vtt, ttml, dfxp, or scc')
   .option('--name <name>', 'Track name shown in the player (default: empty)')
   .option('--draft', 'Upload as draft (not visible to viewers)')
   .option('-f, --force', 'Replace the existing track content if one matches the language+name')

--- a/commands/put-caption.ts
+++ b/commands/put-caption.ts
@@ -6,7 +6,7 @@ import { parseVideoId, debug, initCommand, withSpinner } from '../lib/utils';
 import { normalizeLanguage, getLanguageName } from '../lib/language';
 import { getOutputFormat } from '../lib/config';
 import { formatData } from '../lib/formatters';
-import { PutCaptionOptions } from '../types';
+import { PutCaptionOptions, CAPTION_UPLOAD_EXTENSIONS } from '../types';
 
 async function putCaptionCommand(options: PutCaptionOptions): Promise<void> {
   initCommand(options);
@@ -37,7 +37,19 @@ async function putCaptionCommand(options: PutCaptionOptions): Promise<void> {
   } catch (err) {
     throw new Error(
       `Cannot read caption file: ${filePath}\n${(err as Error).message}\n` +
-      'Supported formats: srt, vtt, sbv, scc, ttml'
+      `Supported formats: ${CAPTION_UPLOAD_EXTENSIONS.join(', ')}`
+    );
+  }
+
+  // Reject unsupported file types client-side. The API accepts ANY upload
+  // and only fails during later processing (status=failed /
+  // failureReason=unknownFormat — live-verified with a .txt), which would
+  // waste quota and leave a zombie track.
+  const ext = path.extname(filePath).toLowerCase();
+  if (!(CAPTION_UPLOAD_EXTENSIONS as readonly string[]).includes(ext)) {
+    throw new Error(
+      `Unsupported caption file type: ${ext || '(no extension)'}\n` +
+      `Supported formats: ${CAPTION_UPLOAD_EXTENSIONS.join(', ')}`
     );
   }
 

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -235,7 +235,7 @@ staqan-yt put-caption --video-id <videoId> --language <lang> --file <path>
 
 - `--video-id <id>` - Video ID (must be on your authenticated channel) (required)
 - `--language <lang>` - Caption language as a BCP-47 code, e.g. `ja`, `en`, `ko` (required)
-- `--file <path>` - Caption file: srt, vtt, sbv, scc, or ttml (required)
+- `--file <path>` - Caption file: `.srt`, `.sbv`, `.vtt`, `.ttml`, `.dfxp`, or `.scc` (required). Other file types (e.g. `.txt`) are rejected client-side — the API would accept them and then fail processing with `unknownFormat`, leaving a broken track
 - `--name <name>` - Track name shown in the player (default: empty)
 - `--draft` - Upload as a draft (not visible to viewers until published in YouTube Studio)
 - `-f, --force` - If a track with the same language and name already exists, replace its content (via `captions.update`) instead of failing

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -965,12 +965,17 @@ async function assertCaptionProcessed(
   }
   const reason = snippet?.failureReason || 'unknown reason';
   if (cleanup) {
+    let removed = true;
     await youtube.captions.delete({ id: captionId }).catch(err => {
+      removed = false;
       debug(`Cleanup of failed caption track ${captionId} failed:`, (err as Error).message);
     });
     throw new Error(
       `Caption upload was accepted but processing failed (${reason}). ` +
-      'The file content is not a supported subtitle format. The failed track was removed.'
+      'The file content is not a supported subtitle format. ' +
+      (removed
+        ? 'The failed track was removed.'
+        : `The failed track ${captionId} could not be removed automatically — delete it in YouTube Studio.`)
     );
   }
   throw new Error(

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -964,6 +964,12 @@ async function assertCaptionProcessed(
     return status;
   }
   const reason = snippet?.failureReason || 'unknown reason';
+  // The API documents two failure reasons: unknownFormat (bad file content)
+  // and processingFailed (YouTube-side error) — only blame the file for the former.
+  const explanation =
+    snippet?.failureReason === 'unknownFormat'
+      ? 'The file content is not a supported subtitle format.'
+      : 'YouTube could not process the file — the content may still be valid; retrying may succeed.';
   if (cleanup) {
     let removed = true;
     await youtube.captions.delete({ id: captionId }).catch(err => {
@@ -971,16 +977,15 @@ async function assertCaptionProcessed(
       debug(`Cleanup of failed caption track ${captionId} failed:`, (err as Error).message);
     });
     throw new Error(
-      `Caption upload was accepted but processing failed (${reason}). ` +
-      'The file content is not a supported subtitle format. ' +
+      `Caption upload was accepted but processing failed (${reason}). ${explanation} ` +
       (removed
         ? 'The failed track was removed.'
         : `The failed track ${captionId} could not be removed automatically — delete it in YouTube Studio.`)
     );
   }
   throw new Error(
-    `Caption content replacement failed processing (${reason}). ` +
-    `The existing track ${captionId} is now in a failed state — re-run with a valid subtitle file to fix it.`
+    `Caption content replacement failed processing (${reason}). ${explanation} ` +
+    `The existing track ${captionId} is now in a failed state — re-run the upload to fix it.`
   );
 }
 

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -939,6 +939,44 @@ export interface UploadedCaption {
   isDraft: boolean;
   /** True when --force replaced an existing track's content instead of creating one. */
   replaced: boolean;
+  /** Processing status from the API: 'serving' | 'syncing' | 'failed'. */
+  status: string;
+}
+
+/**
+ * Verify the API accepted the caption content. captions.insert/update accept
+ * ANY file and only report unparseable content afterwards via
+ * snippet.status === 'failed' (live-verified 2026-07-13: a .txt upload
+ * succeeds, then the track sits at status=failed / failureReason=unknownFormat).
+ * Throws so callers fail loudly instead of leaving a zombie track the user
+ * only discovers in YouTube Studio. `cleanup` deletes the just-created track
+ * first (insert path only — never delete a pre-existing track on the update
+ * path, its content is already replaced either way).
+ */
+async function assertCaptionProcessed(
+  youtube: youtube_v3.Youtube,
+  captionId: string,
+  snippet: youtube_v3.Schema$CaptionSnippet | undefined,
+  cleanup: boolean
+): Promise<string> {
+  const status = snippet?.status ?? 'serving';
+  if (status !== 'failed') {
+    return status;
+  }
+  const reason = snippet?.failureReason || 'unknown reason';
+  if (cleanup) {
+    await youtube.captions.delete({ id: captionId }).catch(err => {
+      debug(`Cleanup of failed caption track ${captionId} failed:`, (err as Error).message);
+    });
+    throw new Error(
+      `Caption upload was accepted but processing failed (${reason}). ` +
+      'The file content is not a supported subtitle format. The failed track was removed.'
+    );
+  }
+  throw new Error(
+    `Caption content replacement failed processing (${reason}). ` +
+    `The existing track ${captionId} is now in a failed state — re-run with a valid subtitle file to fix it.`
+  );
 }
 
 /**
@@ -983,6 +1021,9 @@ async function uploadCaption(
         });
 
         const snippet = response.data.snippet;
+        const status = await assertCaptionProcessed(
+          youtube, response.data.id || existing.id, snippet ?? undefined, false
+        );
         return {
           id: response.data.id || existing.id,
           videoId,
@@ -990,6 +1031,7 @@ async function uploadCaption(
           name: snippet?.name ?? trackName,
           isDraft: snippet?.isDraft ?? false,
           replaced: true,
+          status,
         };
       } catch (err) {
         media.destroy();
@@ -1015,6 +1057,7 @@ async function uploadCaption(
     });
 
     const snippet = response.data.snippet;
+    const status = await assertCaptionProcessed(youtube, response.data.id!, snippet ?? undefined, true);
     return {
       id: response.data.id!,
       videoId: snippet?.videoId || videoId,
@@ -1022,6 +1065,7 @@ async function uploadCaption(
       name: snippet?.name ?? '',
       isDraft: snippet?.isDraft ?? false,
       replaced: false,
+      status,
     };
   } catch (err) {
     media.destroy();

--- a/types/index.ts
+++ b/types/index.ts
@@ -290,6 +290,11 @@ export type CaptionTrackKind = 'standard' | 'ASR' | 'forced';
 export const CAPTION_FORMATS = ['srt', 'vtt', 'sbv', 'scc', 'ttml', 'json'] as const;
 export type CaptionFormat = typeof CAPTION_FORMATS[number];
 
+// File extensions accepted for caption uploads (put-caption). The API
+// accepts any bytes and only fails during processing, so uploads are
+// gated client-side to these subtitle formats YouTube documents.
+export const CAPTION_UPLOAD_EXTENSIONS = ['.srt', '.sbv', '.vtt', '.ttml', '.dfxp', '.scc'] as const;
+
 export interface CaptionInfo {
   id: string;
   videoId: string;


### PR DESCRIPTION
Follow-up to #148, *what happens if we submit an unsupported file?*

## The live answer (test video, reverted after)

The API **accepts anything**: a `.txt` upload returns success, creates a track, and only later does the track sit at `status: failed / failureReason: unknownFormat` — a zombie the user discovers in YouTube Studio. Classic silent failure.

## Two-layer fix

1. **Client-side extension allowlist** (`CAPTION_UPLOAD_EXTENSIONS` in types: `.srt .sbv .vtt .ttml .dfxp .scc`): `.txt` and friends are rejected before any quota is spent, with the supported list in the error.
2. **Post-upload status guard** (`assertCaptionProcessed` in lib/youtube.ts) — catches the case the extension check can't: a valid `.srt` extension wrapping garbage content. On `status: failed`:
   - **insert path**: the just-created zombie track is auto-deleted, then a loud error with the API's `failureReason`
   - **`--force` replace path**: throws with an explicit warning that the *existing* track is now in a failed state and needs a valid re-run (never deletes a pre-existing track)
   - Result objects now include `status` (`serving`/`syncing`/`failed`).

## Live verification matrix (unlisted test video, baseline restored)

| Case | Result |
|---|---|
| `.txt` | client-side rejection, exit 1, **zero API calls** |
| garbage bytes in `.srt` | upload accepted → `failed/unknownFormat` detected → **track auto-deleted** → loud error, exit 1 |
| valid `.srt` | uploaded, `status: "serving"` in the result; reverted |
| post-cases baseline | only the original `ar` track remains — no zombies |

Also answers the format-coverage half of the question: download (`get-caption`) already covers the API's `tfmt` set (srt/vtt/sbv/scc/ttml + raw json); upload now documents and enforces the subtitle formats YouTube accepts (`.dfxp` added as the TTML synonym).

`bun run type-check` ✓ · `bun run lint` ✓ (0 errors, 11 pre-existing warnings) · `bun run build` ✓ · `bun test` 61 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Caption uploads now include YouTube caption processing status in results.
  - Command help and supported format messaging were expanded for caption uploads.

- **Bug Fixes**
  - Unsupported caption file types are now rejected client-side before any upload, with errors listing supported extensions.
  - Failed caption processing is detected to prevent “zombie” captions; failed tracks can be cleaned up when enabled.

- **Documentation**
  - Updated `put-caption --file` docs to list the accepted extensions and note client-side validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->