### PR TITLE
refactor(#102): phase 3 — shared channel-analytics/channel-search-terms data layer

### DIFF
--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -1,34 +1,9 @@
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
-import { google } from 'googleapis';
-import { parseChannelHandle, debug, formatNumber, initCommand, withSpinner, createSpinner, toLocalYmd, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { debug, formatNumber, initCommand, withSpinner, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { requireChannel, getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { fetchChannelAnalytics, ChannelAnalyticsResult } from '../lib/analytics';
 import { ChannelAnalyticsOptions } from '../types';
-
-// Predefined report type mappings
-const REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
-  demographics: {
-    dimensions: 'ageGroup,gender',
-    metrics: 'views,estimatedMinutesWatched',
-  },
-  devices: {
-    dimensions: 'deviceType,operatingSystem',
-    metrics: 'views,estimatedMinutesWatched',
-  },
-  geography: {
-    dimensions: 'country',
-    metrics: 'views,estimatedMinutesWatched',
-  },
-  'traffic-sources': {
-    dimensions: 'insightTrafficSourceType',
-    metrics: 'views,estimatedMinutesWatched',
-  },
-  'subscription-status': {
-    dimensions: 'subscribedStatus',
-    metrics: 'views,estimatedMinutesWatched',
-  },
-};
 
 async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Promise<void> {
   initCommand(options);
@@ -42,229 +17,23 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
   const outputFormat = await getOutputFormat(options.output);
 
   await withSpinner('Fetching channel analytics...', 'Failed to fetch channel analytics', async (spinner) => {
-    // Determine channel ID
-    const channelId = await requireChannel(options.channel);
-    debug(`Using channel: ${channelId}`);
+    const channel = await requireChannel(options.channel);
+    debug(`Using channel: ${channel}`);
 
-    const parsedChannel = parseChannelHandle(channelId);
-    debug('Parsed channel', parsedChannel);
-
-    // Get authenticated client
-    const auth = await getAuthenticatedClient();
-    const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
-
-    // Get channel info for title
-    const youtube = google.youtube({ version: 'v3', auth });
-    let channelTitle = '';
-    let actualChannelId = parsedChannel.value;
-
-    // Resolve channel handle to ID if needed. A not-found channel fails the
-    // command here — previously the ID branch swallowed the empty response
-    // (and any lookup error) into a debug-only catch and proceeded, so the
-    // Analytics query failed later with an opaque message (#123).
-    if (parsedChannel.type === 'handle') {
-      debug('Looking up channel by handle:', parsedChannel.value);
-      const channelResponse = await youtube.channels.list({
-        part: ['id', 'snippet'],
-        forHandle: parsedChannel.value.replace('@', ''),
-      });
-
-      if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
-        throw new Error(`Channel not found: ${channelId}`);
-      }
-      actualChannelId = channelResponse.data.items[0].id!;
-      channelTitle = channelResponse.data.items[0].snippet?.title || '';
-    } else {
-      // Get channel by ID
-      const channelResponse = await youtube.channels.list({
-        part: ['snippet'],
-        id: [parsedChannel.value],
-      });
-
-      if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
-        throw new Error(`Channel not found: ${channelId}`);
-      }
-      channelTitle = channelResponse.data.items[0].snippet?.title || '';
-    }
-
-    debug('Resolved channel ID:', actualChannelId);
-    debug('Channel title:', channelTitle);
-
-    spinner.succeed('Channel information retrieved');
-
-    // Determine date range (default: last 30 days)
-    const endDate = options.endDate || toLocalYmd(new Date());
-    const startDate = options.startDate ||
-      toLocalYmd(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
-
-    validateDateRange(startDate, endDate);
-    debug(`Date range: ${startDate} to ${endDate}`);
-
-    // Determine dimensions and metrics based on report type or custom
-    let dimensions: string;
-    let metrics: string;
-    let reportName = '';
-
-    if (
-      options.report !== undefined &&
-      (options.dimensions !== undefined || options.metrics !== undefined)
-    ) {
-      throw new Error('Cannot combine --report with --dimensions or --metrics. Use one or the other.');
-    }
-
-    if (options.report) {
-      // Use predefined report type
-      const reportConfig = REPORT_TYPES[options.report];
-      if (!reportConfig) {
-        throw new Error(`Unknown report type: ${options.report}`);
-      }
-      dimensions = reportConfig.dimensions;
-      metrics = reportConfig.metrics;
-      reportName = options.report;
-      debug(`Using predefined report: ${options.report}`);
-      debug(`Dimensions: ${dimensions}, Metrics: ${metrics}`);
-    } else if (options.dimensions && options.metrics) {
-      // Custom query
-      dimensions = options.dimensions;
-      metrics = options.metrics;
-      reportName = 'custom';
-      debug('Using custom dimensions and metrics');
-    } else {
-      throw new Error(
-        'Must specify either --report type or both --dimensions and --metrics\n' +
-        'Predefined report types:\n' +
-        '  demographics    - Audience age and gender\n' +
-        '  devices         - Device and OS breakdown\n' +
-        '  geography       - Top countries\n' +
-        '  traffic-sources - Traffic source types\n' +
-        '  subscription-status - Subscribed vs non-subscribed\n' +
-        'Or use custom query:\n' +
-        '  --dimensions "deviceType,operatingSystem" --metrics "views,estimatedMinutesWatched"'
-      );
-    }
-
-    // Fetch analytics
-    const analyticsSpinner = createSpinner('Fetching analytics data...').start();
-
+    // Shared data layer (lib/analytics.ts, #102) — same code path as the
+    // MCP tool, so report/dimension behavior can't drift between surfaces.
+    let result: ChannelAnalyticsResult;
     try {
-      const response = await youtubeAnalytics.reports.query({
-        ids: `channel==${actualChannelId}`,
-        startDate,
-        endDate,
-        dimensions,
-        metrics,
-        sort: '-views', // Sort by views descending
+      result = await fetchChannelAnalytics({
+        channel,
+        startDate: options.startDate,
+        endDate: options.endDate,
+        report: options.report,
+        dimensions: options.dimensions,
+        metrics: options.metrics,
+        onProgress: (message) => { spinner.text = message; },
       });
-
-      analyticsSpinner.succeed('Analytics data retrieved');
-
-      if (!response.data.rows || response.data.rows.length === 0) {
-        console.log('');
-        console.log(chalk.yellow('No analytics data available for this channel and time period.'));
-        console.log('');
-        console.log(chalk.dim('Note: Channel must have sufficient views and activity.'));
-        console.log('');
-        return;
-      }
-
-      const columnHeaders = response.data.columnHeaders || [];
-      const rows = response.data.rows || [];
-
-      debug(`Retrieved ${rows.length} row(s)`);
-      debug('Column headers:', columnHeaders);
-
-      // Format output
-      if (outputFormat === 'json') {
-        const jsonData = {
-          channelId: actualChannelId,
-          channelTitle,
-          reportType: reportName,
-          dateRange: { startDate, endDate },
-          columnHeaders: columnHeaders.map(h => h.name),
-          rows,
-        };
-        console.log(formatJson(jsonData));
-      } else if (outputFormat === 'csv') {
-        // Build CSV data
-        const csvData: Record<string, unknown>[] = [];
-        for (const row of rows) {
-          const rowData: Record<string, unknown> = {};
-          for (let i = 0; i < row.length; i++) {
-            const headerName = columnHeaders[i]?.name || `column_${i}`;
-            rowData[headerName] = row[i];
-          }
-          csvData.push(rowData);
-        }
-        console.log(formatCsv(csvData));
-      } else if (outputFormat === 'table') {
-        // Build table data
-        const tableData: Record<string, string>[] = [];
-        for (const row of rows) {
-          const rowData: Record<string, string> = {};
-          for (let i = 0; i < row.length; i++) {
-            const headerName = columnHeaders[i]?.name || `column_${i}`;
-            const val = row[i];
-            rowData[headerName] = typeof val === 'number' ? formatNumber(val) : String(val);
-          }
-          tableData.push(rowData);
-        }
-        console.log(formatTable(tableData));
-      } else if (outputFormat === 'text') {
-        // Tab-delimited output
-        const headerNames = columnHeaders.map(h => h.name || '').join('\t');
-        console.log(headerNames);
-        for (const row of rows) {
-          console.log(row.join('\t'));
-        }
-      } else {
-        // Pretty output (default)
-        console.log('');
-        if (channelTitle) {
-          console.log(chalk.bold.cyan(channelTitle));
-          console.log(chalk.gray(`Channel ID: ${actualChannelId}`));
-        } else {
-          console.log(chalk.bold.cyan(`Channel: ${actualChannelId}`));
-        }
-        console.log(chalk.gray(`Report Type: ${reportName}`));
-        console.log(chalk.gray(`Date Range: ${startDate} to ${endDate}`));
-        console.log('');
-
-        // Display each row
-        for (let i = 0; i < rows.length; i++) {
-          const row = rows[i];
-          if (i > 0) {
-            console.log(chalk.gray('─'.repeat(80)));
-            console.log('');
-          }
-
-          for (let j = 0; j < row.length; j++) {
-            const value = row[j];
-            const header = columnHeaders[j];
-            const headerName = header?.name || `Column ${j}`;
-            const formattedHeader = headerName
-              .replace(/([A-Z])/g, ' $1')
-              .replace(/^./, str => str.toUpperCase())
-              .trim();
-
-            // Format value
-            let formattedValue: string;
-            if (typeof value === 'number') {
-              formattedValue = formatNumber(value);
-            } else {
-              formattedValue = String(value);
-            }
-
-            console.log(chalk.gray(`${formattedHeader}:`) + ' ' + chalk.white(formattedValue));
-          }
-
-          console.log('');
-        }
-
-        console.log(chalk.dim(`Total: ${rows.length} result(s)`));
-        console.log('');
-      }
     } catch (analyticsErr) {
-      analyticsSpinner.fail('Failed to fetch analytics');
       const errorMessage = (analyticsErr as Error).message || '';
 
       // Translate common API errors into actionable messages; the throw
@@ -294,6 +63,114 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
         );
       }
       throw analyticsErr;
+    }
+
+    spinner.succeed('Analytics data retrieved');
+
+    const { channelId, channelTitle, reportType, dateRange, columnHeaders, rows } = result;
+    const { startDate, endDate } = dateRange;
+
+    if (rows.length === 0) {
+      console.log('');
+      console.log(chalk.yellow('No analytics data available for this channel and time period.'));
+      console.log('');
+      console.log(chalk.dim('Note: Channel must have sufficient views and activity.'));
+      console.log('');
+      return;
+    }
+
+    debug(`Retrieved ${rows.length} row(s)`);
+    debug('Column headers:', columnHeaders);
+
+    // Format output
+    if (outputFormat === 'json') {
+      const jsonData = {
+        channelId,
+        channelTitle,
+        reportType,
+        dateRange: { startDate, endDate },
+        columnHeaders: columnHeaders.map(h => h.name),
+        rows,
+      };
+      console.log(formatJson(jsonData));
+    } else if (outputFormat === 'csv') {
+      // Build CSV data
+      const csvData: Record<string, unknown>[] = [];
+      for (const row of rows) {
+        const rowData: Record<string, unknown> = {};
+        for (let i = 0; i < row.length; i++) {
+          const headerName = columnHeaders[i]?.name || `column_${i}`;
+          rowData[headerName] = row[i];
+        }
+        csvData.push(rowData);
+      }
+      console.log(formatCsv(csvData));
+    } else if (outputFormat === 'table') {
+      // Build table data
+      const tableData: Record<string, string>[] = [];
+      for (const row of rows) {
+        const rowData: Record<string, string> = {};
+        for (let i = 0; i < row.length; i++) {
+          const headerName = columnHeaders[i]?.name || `column_${i}`;
+          const val = row[i];
+          rowData[headerName] = typeof val === 'number' ? formatNumber(val) : String(val);
+        }
+        tableData.push(rowData);
+      }
+      console.log(formatTable(tableData));
+    } else if (outputFormat === 'text') {
+      // Tab-delimited output
+      const headerNames = columnHeaders.map(h => h.name || '').join('\t');
+      console.log(headerNames);
+      for (const row of rows) {
+        console.log(row.join('\t'));
+      }
+    } else {
+      // Pretty output (default)
+      console.log('');
+      if (channelTitle) {
+        console.log(chalk.bold.cyan(channelTitle));
+        console.log(chalk.gray(`Channel ID: ${channelId}`));
+      } else {
+        console.log(chalk.bold.cyan(`Channel: ${channelId}`));
+      }
+      console.log(chalk.gray(`Report Type: ${reportType}`));
+      console.log(chalk.gray(`Date Range: ${startDate} to ${endDate}`));
+      console.log('');
+
+      // Display each row
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        if (i > 0) {
+          console.log(chalk.gray('─'.repeat(80)));
+          console.log('');
+        }
+
+        for (let j = 0; j < row.length; j++) {
+          const value = row[j];
+          const header = columnHeaders[j];
+          const headerName = header?.name || `Column ${j}`;
+          const formattedHeader = headerName
+            .replace(/([A-Z])/g, ' $1')
+            .replace(/^./, str => str.toUpperCase())
+            .trim();
+
+          // Format value
+          let formattedValue: string;
+          if (typeof value === 'number') {
+            formattedValue = formatNumber(value);
+          } else {
+            formattedValue = String(value);
+          }
+
+          console.log(chalk.gray(`${formattedHeader}:`) + ' ' + chalk.white(formattedValue));
+        }
+
+        console.log('');
+      }
+
+      console.log(chalk.dim(`Total: ${rows.length} result(s)`));
+      console.log('');
     }
   });
 }

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -1,35 +1,14 @@
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
-import { google } from 'googleapis';
-import { parseChannelHandle, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, validateDateOption, validateDateRange, parseDuration, runOrExit } from '../lib/utils';
+import { parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
 import { getOutputFormat, requireChannel } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import {
+  fetchChannelSearchTerms,
+  validateContentType,
+  ALL_TIME_START_DATE,
+  CHANNEL_SEARCH_TERMS_MAX_VIDEOS,
+} from '../lib/analytics';
 import { ChannelSearchTermsOptions } from '../types';
-
-// Metrics for insightTrafficSourceDetail with insightTrafficSourceType==YT_SEARCH.
-// videoThumbnailImpressions/CTR are only valid for discovery-type sources and
-// cause a 400 when combined with YT_SEARCH. Keep only the two safe ones.
-const ANALYTICS_METRICS = [
-  'views',
-  'estimatedMinutesWatched',
-].join(',');
-
-// This report type enforces a hard limit of 25 results
-const MAX_RESULTS_LIMIT = 25;
-
-// Maximum video IDs per Analytics API call (documented limit)
-const MAX_VIDEO_IDS = 500;
-
-// YouTube founding date — used as the effective "lifetime" start
-const YOUTUBE_START_DATE = '2005-02-14';
-
-// YouTube's documented Shorts threshold. Note: Shorts can be up to 60s of
-// vertical video; videos at exactly 60s are accepted as Shorts, but we use
-// `>= 60s` for the long-form bucket to match YouTube Studio's own bucketing.
-const SHORTS_DURATION_LIMIT_SECONDS = 60;
-
-// videos.list accepts at most 50 IDs per call
-const VIDEOS_LIST_CHUNK_SIZE = 50;
 
 async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions): Promise<void> {
   initCommand(options);
@@ -39,184 +18,35 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
   runOrExit(() => { if (options.endDate) validateDateOption('--end-date', options.endDate); });
   runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
-  // Validate --content-type against the allowlist. The type is already
-  // narrowed to 'all' | 'video' | 'shorts' in types/index.ts, but commander.js
+  // Validate --content-type against the allowlist before spending any API
+  // quota. The type is already narrowed in types/index.ts, but commander.js
   // passes arbitrary strings through at runtime, so an unknown value would
-  // silently fall through to the 'all' branch below.
-  const validContentTypes = ['all', 'video', 'shorts'];
-  if (options.contentType !== undefined && !validContentTypes.includes(options.contentType)) {
-    throw new Error(`Invalid --content-type "${options.contentType}". Valid values: ${validContentTypes.join(', ')}`);
-  }
+  // otherwise silently fall through to the 'all' branch.
+  runOrExit(() => validateContentType(options.contentType));
 
   await withSpinner('Resolving channel...', 'Failed to fetch channel search terms', async (spinner) => {
     // Resolve channel from arg or config default
-    const channelArg = await requireChannel(options.channel);
-    debug(`Using channel: ${channelArg}`);
+    const channel = await requireChannel(options.channel);
+    debug(`Using channel: ${channel}`);
 
-    const parsedChannel = parseChannelHandle(channelArg);
-    debug('Parsed channel', parsedChannel);
-
-    const auth = await getAuthenticatedClient();
-    const youtube = google.youtube({ version: 'v3', auth });
-    const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
-
-    // Resolve handle → channel ID, uploads playlist ID, and title
-    let channelId = parsedChannel.value;
-    let channelTitle = '';
-    let uploadsPlaylistId = '';
-
-    const channelParts = ['id', 'snippet', 'contentDetails'];
-
-    if (parsedChannel.type === 'handle') {
-      debug('Looking up channel by handle:', parsedChannel.value);
-      const channelResponse = await youtube.channels.list({
-        part: channelParts,
-        forHandle: parsedChannel.value.replace('@', ''),
-      });
-
-      if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
-        throw new Error(`Channel not found: ${channelArg}`);
-      }
-
-      channelId = channelResponse.data.items[0].id!;
-      channelTitle = channelResponse.data.items[0].snippet?.title || '';
-      uploadsPlaylistId = channelResponse.data.items[0].contentDetails?.relatedPlaylists?.uploads || '';
-    } else {
-      const channelResponse = await youtube.channels.list({
-        part: channelParts,
-        id: [parsedChannel.value],
-      });
-      if (!channelResponse.data.items || channelResponse.data.items.length === 0) {
-        // Previously this silently proceeded with the unresolved input as the
-        // channel ID, producing an opaque Analytics failure downstream (#123).
-        throw new Error(`Channel not found: ${channelArg}`);
-      }
-      channelTitle = channelResponse.data.items[0].snippet?.title || '';
-      uploadsPlaylistId = channelResponse.data.items[0].contentDetails?.relatedPlaylists?.uploads || '';
-    }
-
-    debug('Resolved channel ID:', channelId);
-    debug('Channel title:', channelTitle);
-    debug('Uploads playlist ID:', uploadsPlaylistId);
-
-    if (!uploadsPlaylistId) {
-      throw new Error('Unable to find the uploads playlist for this channel.');
-    }
-
-    // Fetch video IDs from the uploads playlist.
-    // The Analytics API requires video==id1,id2,... in the filter —
-    // there is no channel-wide aggregate endpoint in the public API.
-    // We collect up to MAX_VIDEO_IDS (500) IDs, which is the per-call limit.
-    spinner.text = `Fetching video list from ${channelTitle || channelId}...`;
-
-    const videoIds: string[] = [];
-    let nextPageToken: string | undefined;
-
-    do {
-      const playlistResponse = await youtube.playlistItems.list({
-        part: ['contentDetails'],
-        playlistId: uploadsPlaylistId,
-        maxResults: 50,
-        pageToken: nextPageToken,
-      });
-
-      for (const item of playlistResponse.data.items || []) {
-        const vid = item.contentDetails?.videoId;
-        if (vid) videoIds.push(vid);
-      }
-
-      nextPageToken = playlistResponse.data.nextPageToken || undefined;
-    } while (nextPageToken && videoIds.length < MAX_VIDEO_IDS);
-
-    debug(`Collected ${videoIds.length} video IDs`);
-
-    if (videoIds.length === 0) {
-      throw new Error('No videos found for this channel.');
-    }
-
-    // --content-type filtering is done CLIENT-SIDE by duration, because the
-    // YouTube Analytics API does not accept `creatorContentType` as a filter
-    // for the `insightTrafficSourceDetail` + `YT_SEARCH` report. We verified
-    // live that it returns `Invalid value (...) given in field parameters.filters`
-    // even with the correct enum values (VIDEO_ON_DEMAND / SHORTS). The only
-    // way to scope search traffic by content type for this report is to
-    // pre-filter the `video==` list to just Shorts (duration < 60s) or just
-    // long-form videos (duration >= 60s). See #88.
-    const contentType = options.contentType ?? 'all';
-    if (contentType !== 'all') {
-      const wantShorts = contentType === 'shorts';
-      spinner.text = `Fetching video durations (${wantShorts ? 'Shorts' : 'long-form'} filter)...`;
-
-      const durationById = new Map<string, number>();
-      for (let i = 0; i < videoIds.length; i += VIDEOS_LIST_CHUNK_SIZE) {
-        const chunk = videoIds.slice(i, i + VIDEOS_LIST_CHUNK_SIZE);
-        const videosResponse = await youtube.videos.list({
-          part: ['contentDetails'],
-          id: chunk,
-        });
-        for (const item of videosResponse.data.items || []) {
-          if (item.id && item.contentDetails?.duration) {
-            durationById.set(item.id, parseDuration(item.contentDetails.duration));
-          }
-        }
-      }
-
-      const filtered = videoIds.filter((id) => {
-        const secs = durationById.get(id);
-        if (secs === undefined) return false; // unknown duration → exclude
-        return wantShorts ? secs < SHORTS_DURATION_LIMIT_SECONDS : secs >= SHORTS_DURATION_LIMIT_SECONDS;
-      });
-
-      debug(`Content-type filter (${contentType}): ${videoIds.length} → ${filtered.length} videos`);
-
-      if (filtered.length === 0) {
-        throw new Error(
-          `No ${wantShorts ? 'Shorts' : 'long-form videos'} found for this channel. ` +
-          `Try a different --content-type value or omit the flag for all videos.`
-        );
-      }
-
-      // Mutate in place: subsequent filter assembly uses the trimmed list.
-      videoIds.length = 0;
-      videoIds.push(...filtered);
-    }
-
-    const videoFilter = `video==${videoIds.join(',')}`;
-    const sourceFilter = 'insightTrafficSourceType==YT_SEARCH';
-    const filters = `${videoFilter};${sourceFilter}`;
-
-    const endDate = options.endDate || toLocalYmd(new Date());
-    const startDate = options.startDate || YOUTUBE_START_DATE;
-    const isLifetime = startDate === YOUTUBE_START_DATE;
-    // validateDateRange throws on bad ranges; withSpinner's catch handles it
-    // (fail + error + exit) — no manual try/catch needed here.
-    validateDateRange(startDate, endDate);
-    // API enforces maxResults ≤ 25 for this report type
-    const limit = Math.min(rawLimit, MAX_RESULTS_LIMIT);
-
-    debug('Video count in filter:', videoIds.length);
-    debug('Filters (truncated):', filters.substring(0, 120) + '...');
-    debug(`Date range: ${startDate} to ${endDate}`);
-
-    spinner.text = `Fetching channel search terms (${isLifetime ? 'lifetime' : `${startDate} → ${endDate}`})...`;
-
-    const analyticsResponse = await youtubeAnalytics.reports.query({
-      ids: 'channel==MINE',
-      startDate,
-      endDate,
-      metrics: ANALYTICS_METRICS,
-      dimensions: 'insightTrafficSourceDetail',
-      filters,
-      sort: '-views',
-      maxResults: limit,
+    // Shared data layer (lib/analytics.ts, #102) — same code path as the
+    // MCP tool; the #88/#90 client-side Shorts duration filter lives there.
+    const result = await fetchChannelSearchTerms({
+      channel,
+      startDate: options.startDate,
+      endDate: options.endDate,
+      limit: rawLimit,
+      contentType: options.contentType,
+      onProgress: (message) => { spinner.text = message; },
     });
 
     spinner.succeed('Search terms data retrieved');
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
-    const columnHeaders = analyticsResponse.data.columnHeaders || [];
-    const rows = analyticsResponse.data.rows || [];
+    const { channelId, channelTitle, videosAnalyzed, columnHeaders, rows } = result;
+    const { startDate, endDate } = result.dateRange;
+    const isLifetime = startDate === ALL_TIME_START_DATE;
 
     debug(`Retrieved ${rows.length} row(s)`);
 
@@ -243,9 +73,9 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
       options.contentType === 'shorts' ? 'Shorts only' :
       'All content';
 
-    const videoCountNote = videoIds.length >= MAX_VIDEO_IDS
-      ? ` (first ${MAX_VIDEO_IDS} videos)`
-      : ` (${videoIds.length} videos)`;
+    const videoCountNote = videosAnalyzed >= CHANNEL_SEARCH_TERMS_MAX_VIDEOS
+      ? ` (first ${CHANNEL_SEARCH_TERMS_MAX_VIDEOS} videos)`
+      : ` (${videosAnalyzed} videos)`;
 
     switch (outputFormat) {
       case 'json':
@@ -254,7 +84,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
           channelTitle,
           contentType: contentTypeLabel,
           period: isLifetime ? 'lifetime' : 'custom',
-          videosAnalyzed: videoIds.length,
+          videosAnalyzed,
           dateRange: { startDate, endDate },
           columnHeaders: columnHeaders.map(h => h.name),
           rows,
@@ -291,7 +121,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
         console.log(chalk.gray('Period:         ') + chalk.white(isLifetime ? 'Lifetime' : `${startDate} → ${endDate}`));
         console.log(chalk.gray('Content type:   ') + chalk.white(contentTypeLabel));
         console.log(chalk.gray('Traffic source: ') + chalk.white('YouTube Search'));
-        console.log(chalk.gray('Videos covered: ') + chalk.white(`${videoIds.length}${videoIds.length >= MAX_VIDEO_IDS ? ' (capped at 500)' : ''}`));
+        console.log(chalk.gray('Videos covered: ') + chalk.white(`${videosAnalyzed}${videosAnalyzed >= CHANNEL_SEARCH_TERMS_MAX_VIDEOS ? ' (capped at 500)' : ''}`));
         console.log('');
 
         if (rows.length === 0) {

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -22,8 +22,8 @@ import {
 } from '../lib/youtube';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, initCommand, toLocalYmd, validateDateOption, validateDateRange, parseDuration } from '../lib/utils';
-import { fetchVideoAnalytics, fetchTrafficSources, fetchSearchTerms, fetchVideoRetention, ALL_TIME_START_DATE } from '../lib/analytics';
+import { parseVideoId, initCommand, toLocalYmd, validateDateOption } from '../lib/utils';
+import { fetchVideoAnalytics, fetchTrafficSources, fetchSearchTerms, fetchVideoRetention, fetchChannelAnalytics, fetchChannelSearchTerms, ALL_TIME_START_DATE } from '../lib/analytics';
 import { requireChannel } from '../lib/config';
 import { getVersion } from '../lib/version';
 
@@ -540,7 +540,6 @@ const TOOLS: Tool[] = [
 async function handleToolCall(name: string, args: any) {
   const auth = await getAuthenticatedClient();
   const youtube = google.youtube({ version: 'v3', auth });
-  const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
 
   switch (name) {
     case 'youtube_get_video': {
@@ -673,76 +672,22 @@ async function handleToolCall(name: string, args: any) {
       };
     }
     case 'youtube_get_channel_analytics': {
-      const auth = await getAuthenticatedClient();
-      const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
-      const youtube = google.youtube({ version: 'v3', auth });
-
-      // Resolve channel ID
-      const channelId = await requireChannel(args.channelHandle);
-
-      const parsedChannel = channelId.startsWith('@')
-        ? { type: 'handle', value: channelId }
-        : { type: 'id', value: channelId };
-
-      let actualChannelId = parsedChannel.value;
-
-      // Resolve handle to ID if needed
-      if (parsedChannel.type === 'handle') {
-        const channelResponse = await youtube.channels.list({
-          part: ['id'],
-          forHandle: parsedChannel.value.replace('@', ''),
-        });
-
-        if (channelResponse.data.items && channelResponse.data.items.length > 0) {
-          actualChannelId = channelResponse.data.items[0].id!;
-        }
-      }
-
+      // Shared data layer (lib/analytics.ts, #102). Consolidation also fixed
+      // two drifts: unresolved channels now fail loudly (#123) and the
+      // report + dimensions/metrics conflict is rejected (#70).
       if (args.startDate) validateDateOption('startDate', args.startDate);
       if (args.endDate) validateDateOption('endDate', args.endDate);
 
-      // Determine date range (default: last 30 days)
-      const endDate = args.endDate || toLocalYmd(new Date());
-      const startDate = args.startDate ||
-        toLocalYmd(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
-      validateDateRange(startDate, endDate);
-
-      // Determine dimensions and metrics
-      let dimensions: string;
-      let metrics: string;
-
-      if (args.report) {
-        const REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
-          demographics: { dimensions: 'ageGroup,gender', metrics: 'views,estimatedMinutesWatched' },
-          devices: { dimensions: 'deviceType,operatingSystem', metrics: 'views,estimatedMinutesWatched' },
-          geography: { dimensions: 'country', metrics: 'views,estimatedMinutesWatched' },
-          'traffic-sources': { dimensions: 'insightTrafficSourceType', metrics: 'views,estimatedMinutesWatched' },
-          'subscription-status': { dimensions: 'subscribedStatus', metrics: 'views,estimatedMinutesWatched' },
-        };
-        const reportConfig = REPORT_TYPES[args.report];
-        if (!reportConfig) {
-          throw new Error(`Unknown report type: ${args.report}`);
-        }
-        dimensions = reportConfig.dimensions;
-        metrics = reportConfig.metrics;
-      } else if (args.dimensions && args.metrics) {
-        dimensions = args.dimensions;
-        metrics = args.metrics;
-      } else {
-        throw new Error('Must specify either --report type or both --dimensions and --metrics');
-      }
-
-      // Fetch analytics
-      const response = await youtubeAnalytics.reports.query({
-        ids: `channel==${actualChannelId}`,
-        startDate,
-        endDate,
-        dimensions,
-        metrics,
-        sort: '-views',
+      const result = await fetchChannelAnalytics({
+        channel: await requireChannel(args.channelHandle),
+        startDate: args.startDate,
+        endDate: args.endDate,
+        report: args.report,
+        dimensions: args.dimensions,
+        metrics: args.metrics,
       });
 
-      if (!response.data.rows || response.data.rows.length === 0) {
+      if (result.rows.length === 0) {
         return {
           content: [
             {
@@ -753,20 +698,11 @@ async function handleToolCall(name: string, args: any) {
         };
       }
 
-      const columnHeaders = response.data.columnHeaders || [];
-      const rows = response.data.rows || [];
-
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify({
-              channelId: actualChannelId,
-              reportType: args.report || 'custom',
-              dateRange: { startDate, endDate },
-              columnHeaders: columnHeaders.map(h => h.name),
-              rows,
-            }, null, 2),
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };
@@ -818,123 +754,24 @@ async function handleToolCall(name: string, args: any) {
     }
 
     case 'youtube_get_channel_search_terms': {
-      // Resolve channel
-      const channelArg = await requireChannel(args.channelHandle);
-
-      // Resolve handle → uploads playlist ID
-      let uploadsPlaylistId = '';
-      if (channelArg.startsWith('@')) {
-        const channelResponse = await youtube.channels.list({
-          part: ['contentDetails'],
-          forHandle: channelArg.replace('@', ''),
-        });
-        uploadsPlaylistId = channelResponse.data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads || '';
-      } else {
-        const channelResponse = await youtube.channels.list({
-          part: ['contentDetails'],
-          id: [channelArg],
-        });
-        uploadsPlaylistId = channelResponse.data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads || '';
-      }
-
-      if (!uploadsPlaylistId) {
-        throw new Error(`Could not find uploads playlist for channel: ${channelArg}`);
-      }
-
-      // Collect up to 500 video IDs from the uploads playlist
-      const videoIds: string[] = [];
-      let nextPageToken: string | undefined;
-      do {
-        const playlistResponse = await youtube.playlistItems.list({
-          part: ['contentDetails'],
-          playlistId: uploadsPlaylistId,
-          maxResults: 50,
-          pageToken: nextPageToken,
-        });
-        for (const item of playlistResponse.data.items || []) {
-          const vid = item.contentDetails?.videoId;
-          if (vid) videoIds.push(vid);
-        }
-        nextPageToken = playlistResponse.data.nextPageToken || undefined;
-      } while (nextPageToken && videoIds.length < 500);
-
-      if (videoIds.length === 0) {
-        throw new Error('No videos found for this channel.');
-      }
-
+      // Shared data layer (lib/analytics.ts, #102) — carries the #88/#90
+      // client-side Shorts duration filter exactly once.
       if (args.startDate) validateDateOption('startDate', args.startDate);
       if (args.endDate) validateDateOption('endDate', args.endDate);
 
-      const endDate = args.endDate || toLocalYmd(new Date());
-      const startDate = args.startDate || '2005-02-14';
-      validateDateRange(startDate, endDate);
-      const limit = Math.min(args.limit || 25, 25);
-
-      // --content-type is filtered CLIENT-SIDE by duration. The YouTube
-      // Analytics API rejects `creatorContentType` as a filter for the
-      // `insightTrafficSourceDetail` + `YT_SEARCH` report with
-      // `Invalid value (...) given in field parameters.filters`, even for the
-      // correct enum values. So we pre-trim the `video==` list to Shorts
-      // (<60s) or long-form (>=60s). See #88.
-      const validContentTypes = ['all', 'video', 'shorts'];
-      const contentType = args.contentType ?? 'all';
-      if (!validContentTypes.includes(contentType)) {
-        throw new Error(`Invalid contentType "${contentType}". Valid values: ${validContentTypes.join(', ')}`);
-      }
-      if (contentType !== 'all') {
-        const wantShorts = contentType === 'shorts';
-        const durationById = new Map<string, number>();
-        for (let i = 0; i < videoIds.length; i += 50) {
-          const chunk = videoIds.slice(i, i + 50);
-          const videosResponse = await youtube.videos.list({
-            part: ['contentDetails'],
-            id: chunk,
-          });
-          for (const item of videosResponse.data.items || []) {
-            if (item.id && item.contentDetails?.duration) {
-              durationById.set(item.id, parseDuration(item.contentDetails.duration));
-            }
-          }
-        }
-        const filtered = videoIds.filter((id) => {
-          const secs = durationById.get(id);
-          if (secs === undefined) return false;
-          return wantShorts ? secs < 60 : secs >= 60;
-        });
-        if (filtered.length === 0) {
-          throw new Error(
-            `No ${wantShorts ? 'Shorts' : 'long-form videos'} found for this channel.`
-          );
-        }
-        videoIds.length = 0;
-        videoIds.push(...filtered);
-      }
-
-      const videoFilter = `video==${videoIds.join(',')}`;
-      const sourceFilter = 'insightTrafficSourceType==YT_SEARCH';
-      const filters = `${videoFilter};${sourceFilter}`;
-
-      const analyticsResponse = await youtubeAnalytics.reports.query({
-        ids: 'channel==MINE',
-        startDate,
-        endDate,
-        metrics: 'views,estimatedMinutesWatched',
-        dimensions: 'insightTrafficSourceDetail',
-        filters,
-        sort: '-views',
-        maxResults: limit,
+      const result = await fetchChannelSearchTerms({
+        channel: await requireChannel(args.channelHandle),
+        startDate: args.startDate,
+        endDate: args.endDate,
+        limit: args.limit,
+        contentType: args.contentType,
       });
 
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify({
-              channelHandle: channelArg,
-              videosAnalyzed: videoIds.length,
-              dateRange: { startDate, endDate },
-              ...analyticsResponse.data,
-            }, null, 2),
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -11,7 +11,7 @@
 
 import { google, youtube_v3 } from 'googleapis';
 import { getAuthenticatedClient } from './auth';
-import { chunkDateRange, debug, toLocalYmd, validateDateRange, withRateLimitRetry } from './utils';
+import { chunkDateRange, debug, parseChannelHandle, parseDuration, toLocalYmd, validateDateRange, withRateLimitRetry } from './utils';
 
 /**
  * Allowlist of Analytics API dimensions valid for video-level queries.
@@ -350,6 +350,364 @@ export async function fetchVideoRetention(params: { videoId: string }): Promise<
     videoId: params.videoId,
     title,
     duration,
+    dateRange: { startDate, endDate },
+    columnHeaders: response.data.columnHeaders || [],
+    rows: response.data.rows || [],
+  };
+}
+
+// ─── Channel-level reports (channel analytics, channel search terms) ─────────
+
+/**
+ * Predefined report types for channel analytics, shared by the CLI command
+ * and the MCP tool (the two copies were identical before consolidation).
+ */
+export const CHANNEL_REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
+  demographics: {
+    dimensions: 'ageGroup,gender',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  devices: {
+    dimensions: 'deviceType,operatingSystem',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  geography: {
+    dimensions: 'country',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  'traffic-sources': {
+    dimensions: 'insightTrafficSourceType',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+  'subscription-status': {
+    dimensions: 'subscribedStatus',
+    metrics: 'views,estimatedMinutesWatched',
+  },
+};
+
+interface ChannelInfo {
+  channelId: string;
+  channelTitle: string;
+  uploadsPlaylistId: string;
+}
+
+/**
+ * Resolve a channel handle or ID to its canonical ID, title, and uploads
+ * playlist. Throws "Channel not found" for both input forms — the MCP copies
+ * used to silently proceed with an unresolved handle/ID and fail later with
+ * an opaque Analytics error (the same drift #123 fixed in the CLI commands).
+ */
+async function lookupChannel(youtube: youtube_v3.Youtube, channel: string): Promise<ChannelInfo> {
+  const parsed = parseChannelHandle(channel);
+  debug('Parsed channel', parsed);
+
+  const part = ['id', 'snippet', 'contentDetails'];
+  const response = parsed.type === 'handle'
+    ? await youtube.channels.list({ part, forHandle: parsed.value.replace('@', '') })
+    : await youtube.channels.list({ part, id: [parsed.value] });
+
+  if (!response.data.items || response.data.items.length === 0) {
+    throw new Error(`Channel not found: ${channel}`);
+  }
+
+  const item = response.data.items[0];
+  return {
+    channelId: item.id || parsed.value,
+    channelTitle: item.snippet?.title || '',
+    uploadsPlaylistId: item.contentDetails?.relatedPlaylists?.uploads || '',
+  };
+}
+
+export interface ChannelAnalyticsParams {
+  /** Channel handle (@name) or ID (callers run requireChannel first). */
+  channel: string;
+  /** YYYY-MM-DD; defaults to 30 days ago (local). */
+  startDate?: string;
+  /** YYYY-MM-DD; defaults to today (local). */
+  endDate?: string;
+  /** Predefined report type; mutually exclusive with dimensions/metrics. */
+  report?: string;
+  /** Custom dimensions; requires metrics. */
+  dimensions?: string;
+  /** Custom metrics; requires dimensions. */
+  metrics?: string;
+  /** Progress hook — commands wire this to the spinner; MCP omits it. */
+  onProgress?: (message: string) => void;
+}
+
+export interface ChannelAnalyticsResult {
+  channelId: string;
+  channelTitle: string;
+  reportType: string;
+  dateRange: { startDate: string; endDate: string };
+  columnHeaders: { name?: string | null }[];
+  rows: unknown[][];
+}
+
+/**
+ * Channel-level Analytics query, either via a predefined report type or a
+ * custom dimensions+metrics pair. Rejects the --report + --dimensions/--metrics
+ * combination (#70) — a check the MCP copy never gained before consolidation.
+ */
+export async function fetchChannelAnalytics(params: ChannelAnalyticsParams): Promise<ChannelAnalyticsResult> {
+  if (
+    params.report !== undefined &&
+    (params.dimensions !== undefined || params.metrics !== undefined)
+  ) {
+    throw new Error('Cannot combine --report with --dimensions or --metrics. Use one or the other.');
+  }
+
+  let dimensions: string;
+  let metrics: string;
+  let reportName: string;
+
+  if (params.report) {
+    const reportConfig = CHANNEL_REPORT_TYPES[params.report];
+    if (!reportConfig) {
+      throw new Error(`Unknown report type: ${params.report}`);
+    }
+    dimensions = reportConfig.dimensions;
+    metrics = reportConfig.metrics;
+    reportName = params.report;
+  } else if (params.dimensions && params.metrics) {
+    dimensions = params.dimensions;
+    metrics = params.metrics;
+    reportName = 'custom';
+  } else {
+    throw new Error(
+      'Must specify either --report type or both --dimensions and --metrics\n' +
+      'Predefined report types:\n' +
+      '  demographics    - Audience age and gender\n' +
+      '  devices         - Device and OS breakdown\n' +
+      '  geography       - Top countries\n' +
+      '  traffic-sources - Traffic source types\n' +
+      '  subscription-status - Subscribed vs non-subscribed\n' +
+      'Or use custom query:\n' +
+      '  --dimensions "deviceType,operatingSystem" --metrics "views,estimatedMinutesWatched"'
+    );
+  }
+  debug(`Report: ${reportName}, Dimensions: ${dimensions}, Metrics: ${metrics}`);
+
+  const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
+  const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+
+  params.onProgress?.('Resolving channel...');
+  const { channelId, channelTitle } = await lookupChannel(youtube, params.channel);
+  debug('Resolved channel ID:', channelId);
+
+  // Default: last 30 days.
+  const endDate = params.endDate || toLocalYmd(new Date());
+  const startDate = params.startDate ||
+    toLocalYmd(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000));
+  validateDateRange(startDate, endDate);
+  debug(`Date range: ${startDate} to ${endDate}`);
+
+  params.onProgress?.('Fetching analytics data...');
+  const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
+    ids: `channel==${channelId}`,
+    startDate,
+    endDate,
+    dimensions,
+    metrics,
+    sort: '-views',
+  }), { label: 'reports.query(channel analytics)' });
+
+  return {
+    channelId,
+    channelTitle,
+    reportType: reportName,
+    dateRange: { startDate, endDate },
+    columnHeaders: response.data.columnHeaders || [],
+    rows: response.data.rows || [],
+  };
+}
+
+/** This report type enforces a hard limit of 25 results. */
+export const CHANNEL_SEARCH_TERMS_MAX_RESULTS = 25;
+
+/** Maximum video IDs per Analytics API `video==` filter (documented limit). */
+export const CHANNEL_SEARCH_TERMS_MAX_VIDEOS = 500;
+
+// YouTube's documented Shorts threshold. Note: Shorts can be up to 60s of
+// vertical video; videos at exactly 60s are accepted as Shorts, but we use
+// `>= 60s` for the long-form bucket to match YouTube Studio's own bucketing.
+const SHORTS_DURATION_LIMIT_SECONDS = 60;
+
+// videos.list accepts at most 50 IDs per call
+const VIDEOS_LIST_CHUNK_SIZE = 50;
+
+export type ChannelContentType = 'all' | 'video' | 'shorts';
+
+const CHANNEL_CONTENT_TYPES: ReadonlyArray<string> = ['all', 'video', 'shorts'];
+
+/**
+ * Validate a content-type value (defaulting to 'all'). Exported so the CLI
+ * command can fail fast before spending any API quota.
+ */
+export function validateContentType(raw: string | undefined): ChannelContentType {
+  const contentType = raw ?? 'all';
+  if (!CHANNEL_CONTENT_TYPES.includes(contentType)) {
+    throw new Error(`Invalid content type "${contentType}". Valid values: ${CHANNEL_CONTENT_TYPES.join(', ')}`);
+  }
+  return contentType as ChannelContentType;
+}
+
+/**
+ * #88/#90: filter video IDs CLIENT-SIDE by duration. The YouTube Analytics
+ * API does not accept `creatorContentType` as a filter for the
+ * `insightTrafficSourceDetail` + `YT_SEARCH` report — verified live that it
+ * returns `Invalid value (...) given in field parameters.filters` even with
+ * the correct enum values (VIDEO_ON_DEMAND / SHORTS). The only way to scope
+ * search traffic by content type for this report is to pre-trim the
+ * `video==` list to Shorts (<60s) or long-form (>=60s).
+ */
+async function filterVideoIdsByDuration(
+  youtube: youtube_v3.Youtube,
+  videoIds: string[],
+  contentType: ChannelContentType,
+): Promise<string[]> {
+  if (contentType === 'all') {
+    return videoIds;
+  }
+  const wantShorts = contentType === 'shorts';
+
+  const durationById = new Map<string, number>();
+  for (let i = 0; i < videoIds.length; i += VIDEOS_LIST_CHUNK_SIZE) {
+    const chunk = videoIds.slice(i, i + VIDEOS_LIST_CHUNK_SIZE);
+    const videosResponse = await youtube.videos.list({
+      part: ['contentDetails'],
+      id: chunk,
+    });
+    for (const item of videosResponse.data.items || []) {
+      if (item.id && item.contentDetails?.duration) {
+        durationById.set(item.id, parseDuration(item.contentDetails.duration));
+      }
+    }
+  }
+
+  const filtered = videoIds.filter((id) => {
+    const secs = durationById.get(id);
+    if (secs === undefined) return false; // unknown duration → exclude
+    return wantShorts ? secs < SHORTS_DURATION_LIMIT_SECONDS : secs >= SHORTS_DURATION_LIMIT_SECONDS;
+  });
+
+  debug(`Content-type filter (${contentType}): ${videoIds.length} → ${filtered.length} videos`);
+
+  if (filtered.length === 0) {
+    throw new Error(
+      `No ${wantShorts ? 'Shorts' : 'long-form videos'} found for this channel. ` +
+      `Try a different --content-type value or omit the flag for all videos.`
+    );
+  }
+  return filtered;
+}
+
+export interface ChannelSearchTermsParams {
+  /** Channel handle (@name) or ID (callers run requireChannel first). */
+  channel: string;
+  /** YYYY-MM-DD; defaults to all-time (ALL_TIME_START_DATE). */
+  startDate?: string;
+  /** YYYY-MM-DD; defaults to today (local). */
+  endDate?: string;
+  /** Max results; the API caps this report type at 25. */
+  limit?: number;
+  /** 'all' | 'video' | 'shorts'; validated here (see #88/#90). */
+  contentType?: string;
+  /** Progress hook — commands wire this to the spinner; MCP omits it. */
+  onProgress?: (message: string) => void;
+}
+
+export interface ChannelSearchTermsResult {
+  channelId: string;
+  channelTitle: string;
+  contentType: ChannelContentType;
+  /** Video count in the final `video==` filter (after content-type trimming). */
+  videosAnalyzed: number;
+  dateRange: { startDate: string; endDate: string };
+  columnHeaders: { name?: string | null }[];
+  rows: unknown[][];
+}
+
+// Metrics for insightTrafficSourceDetail with insightTrafficSourceType==YT_SEARCH.
+// videoThumbnailImpressions/CTR are only valid for discovery-type sources and
+// cause a 400 when combined with YT_SEARCH. Keep only the two safe ones.
+const SEARCH_TERMS_METRICS = 'views,estimatedMinutesWatched';
+
+/**
+ * YouTube-search terms that led viewers to a channel's videos. The Analytics
+ * API has no channel-wide aggregate for this report, so the uploads playlist
+ * is walked (up to CHANNEL_SEARCH_TERMS_MAX_VIDEOS IDs, the per-call filter
+ * limit) and passed as an explicit `video==` filter, optionally trimmed to
+ * Shorts/long-form client-side (#88/#90).
+ */
+export async function fetchChannelSearchTerms(params: ChannelSearchTermsParams): Promise<ChannelSearchTermsResult> {
+  const contentType = validateContentType(params.contentType);
+
+  const auth = await getAuthenticatedClient();
+  const youtube = google.youtube({ version: 'v3', auth });
+  const youtubeAnalytics = google.youtubeAnalytics({ version: 'v2', auth });
+
+  params.onProgress?.('Resolving channel...');
+  const { channelId, channelTitle, uploadsPlaylistId } = await lookupChannel(youtube, params.channel);
+  debug('Resolved channel ID:', channelId);
+  if (!uploadsPlaylistId) {
+    throw new Error('Unable to find the uploads playlist for this channel.');
+  }
+
+  params.onProgress?.(`Fetching video list from ${channelTitle || channelId}...`);
+  let videoIds: string[] = [];
+  let nextPageToken: string | undefined;
+  do {
+    const playlistResponse = await youtube.playlistItems.list({
+      part: ['contentDetails'],
+      playlistId: uploadsPlaylistId,
+      maxResults: 50,
+      pageToken: nextPageToken,
+    });
+    for (const item of playlistResponse.data.items || []) {
+      const vid = item.contentDetails?.videoId;
+      if (vid) videoIds.push(vid);
+    }
+    nextPageToken = playlistResponse.data.nextPageToken || undefined;
+  } while (nextPageToken && videoIds.length < CHANNEL_SEARCH_TERMS_MAX_VIDEOS);
+
+  debug(`Collected ${videoIds.length} video IDs`);
+  if (videoIds.length === 0) {
+    throw new Error('No videos found for this channel.');
+  }
+
+  if (contentType !== 'all') {
+    params.onProgress?.(`Fetching video durations (${contentType === 'shorts' ? 'Shorts' : 'long-form'} filter)...`);
+    videoIds = await filterVideoIdsByDuration(youtube, videoIds, contentType);
+  }
+
+  const endDate = params.endDate || toLocalYmd(new Date());
+  const startDate = params.startDate || ALL_TIME_START_DATE;
+  validateDateRange(startDate, endDate);
+  const limit = Math.min(params.limit || CHANNEL_SEARCH_TERMS_MAX_RESULTS, CHANNEL_SEARCH_TERMS_MAX_RESULTS);
+
+  const filters = `video==${videoIds.join(',')};insightTrafficSourceType==YT_SEARCH`;
+  debug('Video count in filter:', videoIds.length);
+  debug(`Date range: ${startDate} to ${endDate}`);
+
+  params.onProgress?.('Fetching channel search terms...');
+  const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
+    ids: 'channel==MINE',
+    startDate,
+    endDate,
+    metrics: SEARCH_TERMS_METRICS,
+    dimensions: 'insightTrafficSourceDetail',
+    filters,
+    sort: '-views',
+    maxResults: limit,
+  }), { label: 'reports.query(channel search terms)' });
+
+  return {
+    channelId,
+    channelTitle,
+    contentType,
+    videosAnalyzed: videoIds.length,
     dateRange: { startDate, endDate },
     columnHeaders: response.data.columnHeaders || [],
     rows: response.data.rows || [],

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -361,27 +361,37 @@ export async function fetchVideoRetention(params: { videoId: string }): Promise<
 /**
  * Predefined report types for channel analytics, shared by the CLI command
  * and the MCP tool (the two copies were identical before consolidation).
+ *
+ * demographics uses viewerPercentage — the only metric the Analytics API
+ * accepts for ageGroup/gender reports (live-verified 2026-07-17: the old
+ * views,estimatedMinutesWatched pair was rejected with "not supported",
+ * so the report type never worked on either surface).
  */
-export const CHANNEL_REPORT_TYPES: Record<string, { dimensions: string; metrics: string }> = {
+export const CHANNEL_REPORT_TYPES: Record<string, { dimensions: string; metrics: string; sort: string }> = {
   demographics: {
     dimensions: 'ageGroup,gender',
-    metrics: 'views,estimatedMinutesWatched',
+    metrics: 'viewerPercentage',
+    sort: '-viewerPercentage',
   },
   devices: {
     dimensions: 'deviceType,operatingSystem',
     metrics: 'views,estimatedMinutesWatched',
+    sort: '-views',
   },
   geography: {
     dimensions: 'country',
     metrics: 'views,estimatedMinutesWatched',
+    sort: '-views',
   },
   'traffic-sources': {
     dimensions: 'insightTrafficSourceType',
     metrics: 'views,estimatedMinutesWatched',
+    sort: '-views',
   },
   'subscription-status': {
     dimensions: 'subscribedStatus',
     metrics: 'views,estimatedMinutesWatched',
+    sort: '-views',
   },
 };
 
@@ -460,6 +470,7 @@ export async function fetchChannelAnalytics(params: ChannelAnalyticsParams): Pro
   let dimensions: string;
   let metrics: string;
   let reportName: string;
+  let sort: string | undefined;
 
   if (params.report) {
     const reportConfig = CHANNEL_REPORT_TYPES[params.report];
@@ -468,10 +479,14 @@ export async function fetchChannelAnalytics(params: ChannelAnalyticsParams): Pro
     }
     dimensions = reportConfig.dimensions;
     metrics = reportConfig.metrics;
+    sort = reportConfig.sort;
     reportName = params.report;
   } else if (params.dimensions && params.metrics) {
     dimensions = params.dimensions;
     metrics = params.metrics;
+    // The API rejects a sort field that isn't in metrics/dimensions, so only
+    // sort custom queries that actually select views.
+    sort = params.metrics.split(',').map(m => m.trim()).includes('views') ? '-views' : undefined;
     reportName = 'custom';
   } else {
     throw new Error(
@@ -510,7 +525,7 @@ export async function fetchChannelAnalytics(params: ChannelAnalyticsParams): Pro
     endDate,
     dimensions,
     metrics,
-    sort: '-views',
+    sort,
   }), { label: 'reports.query(channel analytics)' });
 
   return {
@@ -640,6 +655,13 @@ const SEARCH_TERMS_METRICS = 'views,estimatedMinutesWatched';
  * is walked (up to CHANNEL_SEARCH_TERMS_MAX_VIDEOS IDs, the per-call filter
  * limit) and passed as an explicit `video==` filter, optionally trimmed to
  * Shorts/long-form client-side (#88/#90).
+ *
+ * Deliberately a single query, not chunked: this is a top-N report
+ * (maxResults ≤ 25) and merging truncated per-chunk top-25 lists would
+ * produce incorrect rankings. All-time queries with the full uploads list
+ * are live-verified to succeed; if a much larger channel ever trips an API
+ * size limit, it fails loudly and the fix is a deliberate date-range cap,
+ * not silent chunking.
  */
 export async function fetchChannelSearchTerms(params: ChannelSearchTermsParams): Promise<ChannelSearchTermsResult> {
   const contentType = validateContentType(params.contentType);
@@ -692,8 +714,11 @@ export async function fetchChannelSearchTerms(params: ChannelSearchTermsParams):
   debug(`Date range: ${startDate} to ${endDate}`);
 
   params.onProgress?.('Fetching channel search terms...');
+  // Query the resolved channel (not MINE) so a mismatch between the requested
+  // channel and the authenticated one fails loudly instead of silently
+  // returning empty rows for the unowned video IDs (CodeRabbit on #151).
   const response = await withRateLimitRetry(() => youtubeAnalytics.reports.query({
-    ids: 'channel==MINE',
+    ids: `channel==${channelId}`,
     startDate,
     endDate,
     metrics: SEARCH_TERMS_METRICS,


### PR DESCRIPTION
## Value proposition

Phase 3 of #102: the channel-analytics and channel-search-terms queries — previously the two largest inline blocks in `commands/mcp.ts` — move into `lib/analytics.ts` as `fetchChannelAnalytics()` and `fetchChannelSearchTerms()`, shared by the CLI commands and the MCP tools. Same pattern as phases 1–2 (#146, #149): the lib returns typed data with an optional `onProgress` hook; commands layer spinner/output formats on top; MCP serializes the result directly.

The **#88/#90 client-side Shorts duration filter** (the Analytics API rejects `creatorContentType` as a filter for `insightTrafficSourceDetail` + `YT_SEARCH` reports, so the `video==` list is pre-trimmed by duration) now exists exactly once, as `filterVideoIdsByDuration()`.

## Deliberate drift resolutions (all in the MCP copies)

Exactly the drift #102 predicted — the MCP copies never received fixes the CLI commands got:

1. **Unresolved channels now fail loudly** — the MCP copies silently proceeded with an unresolved handle/ID and failed later with an opaque Analytics error (the pre-#123 behavior). Lib adopts the strict CLI behavior. Live-verified: `Error: Channel not found: @nonexistent…`.
2. **`report` + `dimensions`/`metrics` conflict rejected** — the MCP channel-analytics tool silently ignored the conflict (the pre-#70 behavior).
3. **MCP channel-analytics gains `channelTitle`** and both queries gain `withRateLimitRetry` (lib convention).

Minor consolidations: the content-type error message is now identical on both surfaces; the all-time start date uses the existing `ALL_TIME_START_DATE` (2005-02-14) constant, which both copies already agreed on.

## MCP response-shape notes

- `youtube_get_channel_analytics`: adds `channelTitle`; `columnHeaders` are now full header objects (matching every other consolidated tool) instead of bare names. Empty-result message preserved.
- `youtube_get_channel_search_terms`: `channelHandle` → resolved `channelId` + `channelTitle`; drops the `kind` envelope; adds `contentType`.

## Verification (local — Actions quota dead until end of July)

- `bun run type-check && bun run lint && bun run build && bun test` — 61/61 pass, 0 errors
- Live CLI: `get-channel-analytics --report geography --output json`, `get-channel-search-terms --limit 3 --output json`, `--content-type shorts` (duration filter: 49 → 30 videos), conflict + invalid-content-type error paths
- Live MCP (stdio JSON-RPC): both tools return correct data; unresolved-channel error path verified

CLI flags and output formats are unchanged; docs describe CLI usage only, so no doc changes needed.

Closes nothing on its own — #102 continues with phase 4 (reporting tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2vaCGp3E3xtU84Q7RZiEz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consolidated channel analytics reporting with predefined reports or custom dimensions/metrics, available across command-line and MCP tooling.
  - Added channel search-term insights for all content, videos, or Shorts, with capped-result behavior.
  - Search-term outputs now include “videos analyzed” and updated capped messaging.
  - Analytics results consistently support JSON, CSV, table, tab-delimited text, and formatted views.
- **Bug Fixes**
  - Improved channel lookup, date-range validation, and content-type validation.
  - Standardized analytics progress messaging and common error handling across interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->