### PR TITLE
refactor(#102): phase 4 — shared Reporting API data layer, drop console monkey-patching

### DIFF
--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -1,20 +1,7 @@
-import { google } from 'googleapis';
-import { getAuthenticatedClient } from '../lib/auth';
-import { warning, debug, initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, runOrExit, withRateLimitRetry } from '../lib/utils';
-import { getOutputFormat, getConfigValue } from '../lib/config';
+import { initCommand, withSpinner, formatTimestampWithTimezone, validateDateOption, validateDateRange, runOrExit } from '../lib/utils';
+import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
-import {
-  analyzeCacheCoverage,
-  findCachedReports,
-  loadReportMetadata,
-  readCachedReport,
-  saveReportToCache,
-  ensureCacheDir,
-} from '../lib/cache';
-import { getChannelId } from '../lib/youtube';
-import { acquireLock, getLockPath } from '../lib/lock';
-import { downloadReport, safeReportPath } from '../lib/reports';
-import { CacheIndexEntry } from '../types';
+import { fetchReportData } from '../lib/reports';
 import chalk from 'chalk';
 
 interface ReportDataOptions {
@@ -39,61 +26,20 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
   runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
   await withSpinner('Checking for existing reporting job...', 'Failed to fetch report data', async (spinner) => {
-    // Resolve channel handle → canonical channel ID for cache namespacing
-    const channelHandle = options.channel || await getConfigValue('default.channel');
-    if (!channelHandle) {
-      throw new Error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
-    }
+    // Shared data layer (lib/reports.ts, #102) — same cache-merging pipeline
+    // as the MCP tool.
+    const result = await fetchReportData({
+      type: options.type,
+      channel: options.channel,
+      videoId: options.videoId,
+      startDate: options.startDate,
+      endDate: options.endDate,
+      onProgress: (message) => { spinner.text = message; },
+    });
 
-    spinner.text = `Resolving channel ID for ${channelHandle}...`;
-    const channelId = await getChannelId(channelHandle);
-    debug(`Using channel ID: ${channelId}`);
-
-    // Ensure cache directory exists before attempting lock
-    try {
-      await ensureCacheDir(channelId);
-    } catch (err) {
-      throw new Error(`Failed to create cache directory: ${(err as Error).message}`);
-    }
-
-    const auth = await getAuthenticatedClient();
-    const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
-
-    // Step 1: Find or create reporting job
-
-    const jobsResponse = await withRateLimitRetry(
-      () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined }),
-      { label: 'jobs.list' }
-    );
-
-    const jobs = jobsResponse.data.jobs || [];
-    const matchingJob = jobs.find((job: typeof jobs[0]) => job.reportTypeId === options.type);
-
-    let jobId: string;
-
-    if (matchingJob) {
-      jobId = matchingJob.id!;
-      debug(`Found existing job: ${jobId}`);
-    } else {
-      // Create new job
-      spinner.text = `Creating new reporting job for type: ${options.type}...`;
-
-      const createResponse = await withRateLimitRetry(
-        () => youtubeReporting.jobs.create({
-          requestBody: {
-            reportTypeId: options.type,
-            name: `${options.type} Report Job`,
-          },
-        }),
-        { label: `jobs.create(${options.type})` }
-      );
-
-      jobId = createResponse.data.id!;
-      const jobCreated = new Date(createResponse.data.createTime || '');
-      const readyAt = new Date(jobCreated.getTime() + 48 * 60 * 60 * 1000);
-      const formatted = formatTimestampWithTimezone(readyAt);
-
-      spinner.succeed(`Created new job: ${jobId}`);
+    if (result.status === 'job-created') {
+      const formatted = formatTimestampWithTimezone(new Date(result.readyAt));
+      spinner.succeed(`Created new job: ${result.jobId}`);
       console.log('');
       console.log(chalk.gray('First report available:') + ' ' + chalk.cyan(`${formatted.local} (${formatted.timezone})`));
       console.log('');
@@ -105,39 +51,15 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       return;
     }
 
-    // Step 2: Check if reports are available
-    spinner.text = 'Fetching available reports...';
-
-    spinner.text = 'Fetching available reports...';
-
-    const allFetchedReports: any[] = [];
-    let reportsPageToken: string | undefined;
-    do {
-      const reportsResponse = await withRateLimitRetry(
-        () => youtubeReporting.jobs.reports.list({
-          jobId,
-          onBehalfOfContentOwner: undefined,
-          pageToken: reportsPageToken,
-        }),
-        { label: `jobs.reports.list(${options.type})` }
-      );
-      const pageReports = reportsResponse.data.reports || [];
-      allFetchedReports.push(...pageReports);
-      reportsPageToken = reportsResponse.data.nextPageToken || undefined;
-    } while (reportsPageToken);
-    let reports = allFetchedReports;
-
-    if (reports.length === 0) {
-      // Job exists but no reports yet (within 48h window)
-      const jobCreated = new Date(matchingJob.createTime || '');
-      const readyAt = new Date(jobCreated.getTime() + 48 * 60 * 60 * 1000);
+    if (result.status === 'no-reports-yet') {
+      const readyAt = new Date(result.readyAt);
       const now = new Date();
       const hoursUntilReady = Math.max(0, Math.ceil((readyAt.getTime() - now.getTime()) / (1000 * 60 * 60)));
       const formatted = formatTimestampWithTimezone(readyAt);
 
       spinner.succeed('Job exists but no reports yet');
       console.log('');
-      console.log(chalk.gray('Created:') + ' ' + matchingJob.createTime);
+      console.log(chalk.gray('Created:') + ' ' + result.jobCreateTime);
       console.log(chalk.gray('Ready:') + ' ' + chalk.cyan(`${formatted.local} (${formatted.timezone})`));
       console.log(chalk.yellow('Wait:') + ' ' + chalk.cyan(`${hoursUntilReady} hours remaining`));
       console.log('');
@@ -146,65 +68,10 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       return;
     }
 
-    // Step 3: Validate date range (API returns timestamps, compare date portions only)
-    const minDate = reports[reports.length - 1].startTime!.split('T')[0]; // Oldest
-    const maxDate = reports[0].endTime!.split('T')[0]; // Newest
-
-    const requestedStart = options.startDate || minDate;
-    const requestedEnd = options.endDate || maxDate;
-
-    // Check if requested range is available
-    if (!minDate || !maxDate || !requestedStart || !requestedEnd) {
-      throw new Error('Unable to determine date range');
-    }
-
-    try {
-      validateDateRange(requestedStart, requestedEnd);
-    } catch (e) {
-      throw new Error(`${(e as Error).message}\nProvided: start-date=${requestedStart}, end-date=${requestedEnd}`);
-    }
-
-    // Adjust date range to available data if needed.
-    // Consider both API range and local cache — cache may contain data that
-    // has expired from the API, or may be the only source if API returns nothing.
-    // Use actual CSV data dates (from metadata) rather than API report windows
-    // which span 2 calendar days and would overstate coverage.
-    const cacheEntries = await findCachedReports(channelId, options.type, requestedStart, requestedEnd);
-    let effectiveMinDate = minDate;
-    let effectiveMaxDate = maxDate;
-    if (cacheEntries.length > 0) {
-      const cacheDates = await Promise.all(
-        cacheEntries.map(async (e) => {
-          const meta = await loadReportMetadata(channelId, e.reportId, options.type);
-          if (meta?.startTimeActual) {
-            const s = meta.startTimeActual;
-            return {
-              min: `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
-              max: meta.endTimeActual
-                ? `${meta.endTimeActual.slice(0, 4)}-${meta.endTimeActual.slice(4, 6)}-${meta.endTimeActual.slice(6, 8)}`
-                : `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
-            };
-          }
-          return { min: e.startTime.split('T')[0], max: e.endTime.split('T')[0] };
-        })
-      );
-      const cacheEarliest = cacheDates.reduce((min, d) => d.min < min ? d.min : min, '9999-99-99');
-      const cacheLatest = cacheDates.reduce((max, d) => d.max > max ? d.max : max, '');
-      if (cacheEarliest < effectiveMinDate) effectiveMinDate = cacheEarliest;
-      if (cacheLatest > effectiveMaxDate) effectiveMaxDate = cacheLatest;
-    }
-
-    const adjustedStart = requestedStart < effectiveMinDate ? effectiveMinDate : requestedStart;
-    const adjustedEnd = requestedEnd > effectiveMaxDate ? effectiveMaxDate : requestedEnd;
-
-    // Validate that adjusted range has overlap (i.e., requested range is not entirely before/after available data)
-    if (adjustedStart > adjustedEnd) {
-      throw new Error(
-        'Requested date range has no overlap with available data\n' +
-        `Requested: ${requestedStart} to ${requestedEnd}\n` +
-        `Available: ${effectiveMinDate} to ${effectiveMaxDate}`
-      );
-    }
+    const { rows: filteredData, cachedReports, fetchedReports } = result;
+    const { startDate: requestedStart, endDate: requestedEnd } = result.requestedRange;
+    const { startDate: adjustedStart, endDate: adjustedEnd } = result.adjustedRange;
+    const { startDate: effectiveMinDate, endDate: effectiveMaxDate } = result.availableRange;
 
     // Warn if range was adjusted
     if (adjustedStart !== requestedStart || adjustedEnd !== requestedEnd) {
@@ -231,183 +98,10 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       }
     }
 
-    // Step 4: Filter reports by date range (compare date portions only)
-    // These are API reports — used for fetching data not yet in cache.
-    const filteredReports = reports.filter((report: typeof reports[0]) => {
-      const reportStart = report.startTime!.split('T')[0];
-      const reportEnd = report.endTime!.split('T')[0];
-      return reportStart <= adjustedEnd && reportEnd >= adjustedStart;
-    });
-    reports = filteredReports;
-
-    // It's okay if no API reports match — data may still be available from cache
-    // (e.g. expired from API but present in local archive).
-    if (reports.length === 0 && cacheEntries.length === 0) {
-      throw new Error('No reports match the specified date range.');
-    }
-
-    // Step 5: Analyze cache coverage
-    spinner.text = 'Analyzing cache coverage...';
-    const coverage = await analyzeCacheCoverage(channelId, options.type, adjustedStart, adjustedEnd);
-    debug('Cache coverage:', coverage);
-
-    // Step 6: Load cached data
-    let allData: Record<string, string>[] = [];
-    const cachedReports: CacheIndexEntry[] = [];
-
-    for (const range of coverage.fullyCovered) {
-      const [start, end] = range.split('/');
-      const cached = await findCachedReports(channelId, options.type, start, end);
-
-      for (const cachedReport of cached) {
-        const reportData = await readCachedReport(channelId, cachedReport.reportId, options.type);
-        if (reportData) {
-          allData.push(...reportData.data);
-          cachedReports.push(cachedReport);
-          debug(`Loaded from cache: ${cachedReport.reportId}`);
-        }
-      }
-    }
-
-    if (cachedReports.length > 0) {
-      spinner.text = `Loaded ${cachedReports.length} report(s) from cache`;
-    }
-
-    // Step 7: Fetch missing data
-    const reportsToFetch: { id?: string | null; startTime?: string | null; endTime?: string | null; createTime?: string | null; downloadUrl?: string | null }[] = [];
-
-    // Build list of missing date ranges
-    const missingRanges = [
-      ...coverage.partiallyCovered.map(p => p.missing),
-      ...coverage.notCovered.map(r => {
-        const [start, end] = r.split('/');
-        return { start, end };
-      }),
-    ];
-
-    // Filter reports to only fetch those covering missing ranges
-    for (const report of reports) {
-      const reportStart = report.startTime!;
-      const reportEnd = report.endTime!;
-
-      const coversMissing = missingRanges.some(range => {
-        return reportStart <= range.end && reportEnd >= range.start;
-      });
-
-      if (coversMissing) {
-        reportsToFetch.push(report);
-      }
-    }
-
-    if (reportsToFetch.length > 0) {
-      spinner.text = `Fetching ${reportsToFetch.length} report(s) from API...`;
-    }
-
-    const tmpDir = '/tmp';
-
-    // NOTE: the write lock is acquired and released per-iteration around the
-    // cache write, NOT held across the whole download loop. `downloadReport`
-    // from lib/reports.ts can now retry/backoff for minutes on HTTP 429 or
-    // transient network errors, and holding the lock that long would block
-    // concurrent `fetch-reports` / `get-report-data` runs from the same
-    // channel. The lock guards the cache index write only.
-
-    for (let i = 0; i < reportsToFetch.length; i++) {
-      const report = reportsToFetch[i];
-      // Use the shared sanitizer so a malicious report.id can't escape
-      // `tmpDir` (path-traversal hardening — see lib/reports.ts).
-      // Append pid + timestamp to keep the path unique per process — the
-      // reports lock is now scoped to just the cache write, so two
-      // concurrent runs on the same channel would otherwise clobber each
-      // other's temp CSV (CodeRabbit round 2).
-      const tmpPath = safeReportPath(tmpDir, `${report.id ?? 'report'}-${process.pid}-${Date.now()}`);
-
-      spinner.text = `Downloading report ${i + 1}/${reportsToFetch.length}...`;
-
-      // Download report (shared retry-wrapped helper from lib/reports.ts).
-      // Returns minDate/maxDate directly — no separate parseCsvAndExtractRange call needed.
-      const { csvData, headers, data, minDate, maxDate } = await downloadReport(report, auth, { tmpPath });
-
-      // Calculate expiration date
-      const jobCreated = new Date(matchingJob.createTime || '');
-      const reportCreated = new Date(report.createTime || '');
-      const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
-      const expirationDays = isHistorical ? 30 : 60;
-      const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
-
-      // Acquire the write lock just long enough to update the cache index.
-      // If the lock is busy, skip the cache write (the run still returns data)
-      // rather than queueing behind a possibly-slow download backoff.
-      let writeRelease: (() => Promise<void>) | null = null;
-      try {
-        writeRelease = await acquireLock(getLockPath('reports', channelId), { timeout: 1000 });
-      } catch {
-        // Route to stderr: stdout carries the machine-readable data output
-        // (json/csv) and a console.log here would interleave with the
-        // payload and break downstream parsing (CodeRabbit round 2).
-        process.stderr.write(chalk.gray(`Info: cache lock busy, skipping cache write for ${report.id}\n`));
-      }
-
-      if (writeRelease) {
-        // Save to cache (non-fatal: warn on failure so API data is still returned)
-        try {
-          await saveReportToCache(channelId, report.id || '', options.type, csvData, {
-            reportId: report.id || '',
-            reportTypeId: options.type,
-            channelId,
-            jobId,
-            startTime: report.startTime || '',
-            endTime: report.endTime || '',
-            startTimeActual: minDate,
-            endTimeActual: maxDate,
-            downloadedAt: new Date().toISOString(),
-            expiresAt: expiresAt.toISOString(),
-            downloadUrl: report.downloadUrl || '',
-            columns: headers,
-            isComplete: true,
-            fileSize: csvData.length,
-            row_count: data.length,
-          });
-        } catch (cacheErr) {
-          warning(`Cache save failed for ${report.id}: ${(cacheErr as Error).message} — data will be re-fetched on next run`);
-        } finally {
-          await writeRelease();
-        }
-      }
-
-      allData.push(...data);
-
-      debug(`Downloaded: ${report.startTime} to ${report.endTime}`);
-    }
-
-    spinner.succeed(`Retrieved ${cachedReports.length} cached + ${reportsToFetch.length} new report(s)`);
+    spinner.succeed(`Retrieved ${cachedReports.length} cached + ${fetchedReports.length} new report(s)`);
     process.stderr.write('\n');
 
-    // Deduplicate by (date, video_id) — YouTube may serve duplicate
-    // reports for the same day; last-write-wins.
-    const dedupMap = new Map<string, Record<string, string>>();
-    for (const row of allData) {
-      dedupMap.set(`${row.date}|${row.video_id}`, row);
-    }
-    allData = [...dedupMap.values()];
-
-    // Step 8: Filter by video ID if specified
-    let filteredData = allData;
-    if (options.videoId) {
-      filteredData = allData.filter(row => row.video_id === options.videoId);
-
-      if (filteredData.length === 0) {
-        const uniqueVideoIds = [...new Set(allData.map(row => row.video_id))];
-        const shown = uniqueVideoIds.slice(0, 10).map(vid => `  ${vid}`).join('\n');
-        const more = uniqueVideoIds.length > 10 ? `\n  ... and ${uniqueVideoIds.length - 10} more` : '';
-        throw new Error(
-          `No data found for video ID: ${options.videoId}\n` +
-          `Available video IDs in this date range:\n${shown}${more}`
-        );
-      }
-    }
-
-    // Step 9: Output based on format
+    // Output based on format
     const outputFormat = await getOutputFormat(options.output);
 
     switch (outputFormat) {
@@ -445,7 +139,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
         break;
     }
 
-    // Step 10: Warn about missing dates in the returned data
+    // Warn about missing dates in the returned data
     if (filteredData.length > 0 && !options.videoId) {
       const returnedDates = new Set(filteredData.map(row => row.date));
       // Generate expected date range
@@ -497,9 +191,9 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       }
     }
 
-    // Step 11: Show expiration warning for the reports used
+    // Show expiration warning for the reports used
     const now = new Date();
-    const jobCreated = new Date(matchingJob.createTime || '');
+    const jobCreated = new Date(result.jobCreateTime);
 
     for (const report of cachedReports) {
       const expiresAt = new Date(report.expiresAt);
@@ -514,8 +208,8 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       }
     }
 
-    for (const report of reportsToFetch) {
-      const reportCreated = new Date(report.createTime || '');
+    for (const report of fetchedReports) {
+      const reportCreated = new Date(report.createTime);
       const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
       const expirationDays = isHistorical ? 30 : 60;
       const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);

--- a/commands/list-report-jobs.ts
+++ b/commands/list-report-jobs.ts
@@ -1,9 +1,8 @@
-import { google } from 'googleapis';
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
-import { info, debug, initCommand, formatTimestampWithTimezone, withSpinner } from '../lib/utils';
+import { info, initCommand, formatTimestampWithTimezone, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv, formatText } from '../lib/formatters';
+import { fetchReportJobs } from '../lib/reports';
 
 interface ListReportJobsOptions {
   type?: string;
@@ -19,122 +18,51 @@ async function listReportJobsCommand(options: ListReportJobsOptions): Promise<vo
   initCommand(options);
 
   await withSpinner('Fetching reporting jobs...', 'Failed to fetch reporting jobs', async (spinner) => {
-    const auth = await getAuthenticatedClient();
-    const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
-
-    const jobsResponse = await youtubeReporting.jobs.list({
-      onBehalfOfContentOwner: undefined,
+    // Shared data layer (lib/reports.ts, #102) — same code path as the MCP tool.
+    const { totalJobs, jobs } = await fetchReportJobs({
+      type: options.type,
+      onProgress: (message) => {
+        spinner.text = message;
+        spinner.render();
+      },
     });
 
-    let jobs = jobsResponse.data.jobs || [];
-
-    if (jobs.length === 0) {
+    if (totalJobs === 0) {
       spinner.info('No reporting jobs found for this channel.');
       info('Jobs are created automatically when you run get-report-data for the first time.');
       return;
     }
 
-    // Filter by report type if specified
-    if (options.type) {
-      jobs = jobs.filter(job => job.reportTypeId === options.type);
-      if (jobs.length === 0) {
-        spinner.warn(`No jobs found for report type: ${options.type}`);
-        info(`Run 'list-report-types' to see available report types.`);
-        return;
-      }
+    if (jobs.length === 0) {
+      spinner.warn(`No jobs found for report type: ${options.type}`);
+      info(`Run 'list-report-types' to see available report types.`);
+      return;
     }
 
-    // Don't succeed yet - we need to fetch report details for each job
-    // Collect job data for all formats
     const now = new Date();
-    const jobsData: Array<{
-      jobId: string;
-      reportTypeId: string;
-      name: string;
-      created: string;
-      daysSinceCreation: number;
-      status: string;
-      reportsCount: number;
-      latestReport: string;
-      oldestReport: string;
-      expiringReportsCount: number;
-      expirationWarnings: string[];
-      expirationCriticals: string[];
-    }> = [];
 
-    // For each job, fetch report details
-    for (let i = 0; i < jobs.length; i++) {
-      const job = jobs[i];
-      spinner.text = `Fetching job ${i + 1}/${jobs.length}`;
-      spinner.render();
+    // Flatten the structured lib result into the display strings the
+    // json/csv/text/table formats have always emitted.
+    const formatWindow = (w: { startTime: string; endTime: string } | null) => w
+      ? `${formatTimestampWithTimezone(w.startTime).local} to ${formatTimestampWithTimezone(w.endTime).local}`
+      : 'N/A';
 
-      const jobCreated = new Date(job.createTime || '');
-      const daysSinceCreation = Math.floor((now.getTime() - jobCreated.getTime()) / (1000 * 60 * 60 * 24));
-
-      let reportsCount = 0;
-      let latestReport = 'N/A';
-      let oldestReport = 'N/A';
-      let expiringReportsCount = 0;
-      const warnings: string[] = [];
-      const criticals: string[] = [];
-
-      // Fetch reports for this job
-      try {
-        const reportsResponse = await youtubeReporting.jobs.reports.list({
-          jobId: job.id!,
-          onBehalfOfContentOwner: undefined,
-        });
-
-        const reports = reportsResponse.data.reports || [];
-        reportsCount = reports.length;
-
-        if (reports.length > 0) {
-          const latestStart = formatTimestampWithTimezone(reports[0].startTime || '').local;
-          const latestEnd = formatTimestampWithTimezone(reports[0].endTime || '').local;
-          const oldestStart = formatTimestampWithTimezone(reports[reports.length - 1].startTime || '').local;
-          const oldestEnd = formatTimestampWithTimezone(reports[reports.length - 1].endTime || '').local;
-
-          latestReport = `${latestStart} to ${latestEnd}`;
-          oldestReport = `${oldestStart} to ${oldestEnd}`;
-
-          // Calculate expiration warnings
-          for (const report of reports) {
-            const reportCreated = new Date(report.createTime || '');
-            const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
-            const expirationDays = isHistorical ? 30 : 60;
-            const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
-            const daysUntilExpiration = Math.ceil((expiresAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
-
-            if (daysUntilExpiration <= 3) {
-              criticals.push(`🚨 CRITICAL: ${report.startTime} to ${report.endTime} (expires ${expiresAt.toISOString().split('T')[0]}, ${daysUntilExpiration} days)`);
-            } else if (daysUntilExpiration <= 7) {
-              warnings.push(`⚠️  Expiring soon: ${report.startTime} to ${report.endTime} (expires ${expiresAt.toISOString().split('T')[0]}, ${daysUntilExpiration} days)`);
-            }
-
-            if (daysUntilExpiration <= 7) {
-              expiringReportsCount++;
-            }
-          }
-        }
-      } catch (err) {
-        debug(`Failed to fetch reports for job ${job.id}: ${err}`);
-      }
-
-      jobsData.push({
-        jobId: job.id || '',
-        reportTypeId: job.reportTypeId || '',
-        name: job.name || '',
-        created: job.createTime || '',
-        daysSinceCreation,
-        status: 'Active',
-        reportsCount,
-        latestReport,
-        oldestReport,
-        expiringReportsCount,
-        expirationWarnings: warnings,
-        expirationCriticals: criticals,
-      });
-    }
+    const jobsData = jobs.map(job => ({
+      jobId: job.jobId,
+      reportTypeId: job.reportTypeId,
+      name: job.name,
+      created: job.created,
+      daysSinceCreation: job.daysSinceCreation,
+      status: job.status,
+      reportsCount: job.reportsCount,
+      latestReport: formatWindow(job.latestReport),
+      oldestReport: formatWindow(job.oldestReport),
+      expiringReportsCount: job.expiringReportsCount,
+      expirationWarnings: job.expirationWarnings.map(w =>
+        `⚠️  Expiring soon: ${w.startTime} to ${w.endTime} (expires ${w.expiresAt}, ${w.daysUntilExpiration} days)`),
+      expirationCriticals: job.expirationCriticals.map(c =>
+        `🚨 CRITICAL: ${c.startTime} to ${c.endTime} (expires ${c.expiresAt}, ${c.daysUntilExpiration} days)`),
+    }));
 
     spinner.succeed(`Found ${jobs.length} job(s)`);
     console.log('');

--- a/commands/list-report-jobs.ts
+++ b/commands/list-report-jobs.ts
@@ -42,10 +42,14 @@ async function listReportJobsCommand(options: ListReportJobsOptions): Promise<vo
     const now = new Date();
 
     // Flatten the structured lib result into the display strings the
-    // json/csv/text/table formats have always emitted.
-    const formatWindow = (w: { startTime: string; endTime: string } | null) => w
-      ? `${formatTimestampWithTimezone(w.startTime).local} to ${formatTimestampWithTimezone(w.endTime).local}`
-      : 'N/A';
+    // json/csv/text/table formats have always emitted. The timezone label
+    // comes from the formatter — the values are local, not UTC.
+    const formatWindow = (w: { startTime: string; endTime: string } | null) => {
+      if (!w) return 'N/A';
+      const start = formatTimestampWithTimezone(w.startTime);
+      const end = formatTimestampWithTimezone(w.endTime);
+      return `${start.local} to ${end.local} (${start.timezone})`;
+    };
 
     const jobsData = jobs.map(job => ({
       jobId: job.jobId,
@@ -95,13 +99,16 @@ async function listReportJobsCommand(options: ListReportJobsOptions): Promise<vo
           console.log(chalk.cyan(`Job ID:`) + ' ' + chalk.yellow(job.jobId));
           console.log(chalk.gray('Report Type:') + ' ' + job.reportTypeId);
           console.log(chalk.gray('Name:') + ' ' + job.name);
-          console.log(chalk.gray('Created:') + ' ' + formatTimestampWithTimezone(job.created).local + chalk.gray(' (UTC)'));
+          {
+            const created = formatTimestampWithTimezone(job.created);
+            console.log(chalk.gray('Created:') + ' ' + created.local + chalk.gray(` (${created.timezone})`));
+          }
           console.log(chalk.gray('Status:') + ' ' + chalk.green(`${job.status} (${job.daysSinceCreation} days ago)`));
           console.log(chalk.gray('Reports:') + ' ' + chalk.yellow(job.reportsCount.toString()));
 
           if (job.reportsCount > 0) {
-            console.log(chalk.gray('  Latest:') + ' ' + job.latestReport + chalk.gray(' (UTC)'));
-            console.log(chalk.gray('  Oldest:') + ' ' + job.oldestReport + chalk.gray(' (UTC)'));
+            console.log(chalk.gray('  Latest:') + ' ' + job.latestReport);
+            console.log(chalk.gray('  Oldest:') + ' ' + job.oldestReport);
 
             // Show detailed expiration warnings
             if (job.expirationCriticals.length > 0) {

--- a/commands/list-report-types.ts
+++ b/commands/list-report-types.ts
@@ -1,9 +1,8 @@
-import { google } from 'googleapis';
 import chalk from 'chalk';
-import { getAuthenticatedClient } from '../lib/auth';
 import { initCommand, withSpinner } from '../lib/utils';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
+import { fetchReportTypes, ReportTypeInfo } from '../lib/reports';
 
 interface ReportTypesOptions {
   output?: 'json' | 'table' | 'text' | 'csv' | 'pretty';
@@ -17,14 +16,8 @@ async function listReportTypesCommand(options: ReportTypesOptions): Promise<void
   initCommand(options);
 
   await withSpinner('Fetching available report types...', 'Failed to fetch report types', async (spinner) => {
-    const auth = await getAuthenticatedClient();
-    const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
-
-    const response = await youtubeReporting.reportTypes.list({
-      onBehalfOfContentOwner: undefined,
-    });
-
-    const reportTypes = response.data.reportTypes || [];
+    // Shared data layer (lib/reports.ts, #102) — same code path as the MCP tool.
+    const reportTypes = await fetchReportTypes();
 
     if (reportTypes.length === 0) {
       spinner.info('No report types found for this channel.');
@@ -35,8 +28,8 @@ async function listReportTypesCommand(options: ReportTypesOptions): Promise<void
     console.log('');
 
     // Group report types by category
-    const grouped = reportTypes.reduce((acc: Record<string, typeof reportTypes>, rt: typeof reportTypes[0]) => {
-      const category = rt.id?.split('_')[0] || 'other';
+    const grouped = reportTypes.reduce((acc: Record<string, ReportTypeInfo[]>, rt) => {
+      const category = rt.id.split('_')[0] || 'other';
       if (!acc[category]) {
         acc[category] = [];
       }
@@ -54,14 +47,11 @@ async function listReportTypesCommand(options: ReportTypesOptions): Promise<void
         break;
 
       case 'csv':
-        console.log(formatCsv(reportTypes.map(rt => ({
-          id: rt.id || '',
-          name: rt.name || '',
-        }))));
+        console.log(formatCsv(reportTypes));
         break;
 
       case 'text':
-        Object.entries(grouped).forEach(([category, types]: [string, typeof reportTypes]) => {
+        Object.entries(grouped).forEach(([category, types]) => {
           console.log(`\n${category.toUpperCase()}:`);
           types.forEach(rt => {
             console.log(`  ${rt.id}`);
@@ -72,18 +62,15 @@ async function listReportTypesCommand(options: ReportTypesOptions): Promise<void
         break;
 
       case 'table':
-        console.log(formatTable(reportTypes.map(rt => ({
-          id: rt.id || '',
-          name: rt.name || '',
-        }))));
+        console.log(formatTable(reportTypes));
         break;
 
       case 'pretty':
       default:
         // Pretty format with colors
         reportTypes.forEach(rt => {
-          console.log(chalk.cyan(rt.id || ''));
-          console.log(chalk.gray('  Name:') + ' ' + (rt.name || ''));
+          console.log(chalk.cyan(rt.id));
+          console.log(chalk.gray('  Name:') + ' ' + rt.name);
           console.log('');
         });
         break;

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -24,6 +24,7 @@ import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
 import { parseVideoId, initCommand, toLocalYmd, validateDateOption } from '../lib/utils';
 import { fetchVideoAnalytics, fetchTrafficSources, fetchSearchTerms, fetchVideoRetention, fetchChannelAnalytics, fetchChannelSearchTerms, ALL_TIME_START_DATE } from '../lib/analytics';
+import { fetchReportTypes, fetchReportJobs, fetchReportData } from '../lib/reports';
 import { requireChannel } from '../lib/config';
 import { getVersion } from '../lib/version';
 
@@ -440,13 +441,7 @@ const TOOLS: Tool[] = [
     description: 'List all available YouTube Reporting API report types (e.g., thumbnail CTR, demographics, traffic sources)',
     inputSchema: {
       type: 'object',
-      properties: {
-        output: {
-          type: 'string',
-          description: 'Output format: json, table, or text',
-          enum: ['json', 'table', 'text'],
-        },
-      },
+      properties: {},
       required: [],
     },
   },
@@ -459,11 +454,6 @@ const TOOLS: Tool[] = [
         type: {
           type: 'string',
           description: 'Filter by report type ID (e.g., channel_reach_basic_a1)',
-        },
-        output: {
-          type: 'string',
-          description: 'Output format: json, table, or text',
-          enum: ['json', 'table', 'text'],
         },
       },
       required: [],
@@ -490,11 +480,6 @@ const TOOLS: Tool[] = [
         endDate: {
           type: 'string',
           description: 'End date in YYYY-MM-DD format',
-        },
-        output: {
-          type: 'string',
-          description: 'Output format: json, csv, text, table, or pretty',
-          enum: ['json', 'csv', 'text', 'table', 'pretty'],
         },
       },
       required: ['type'],
@@ -1048,103 +1033,63 @@ async function handleToolCall(name: string, args: any) {
     }
 
     case 'youtube_list_report_types': {
-      const listReportTypesCommand = require('./list-report-types');
-      const originalConsoleLog = console.log;
-      const originalConsoleError = console.error;
-
-      try {
-        const logs: string[] = [];
-        console.log = (...args: any[]) => logs.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
-        console.error = (...args: any[]) => logs.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
-
-        await listReportTypesCommand({ output: args.output || 'table', verbose: false });
-
-        console.log = originalConsoleLog;
-        console.error = originalConsoleError;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: logs.join('\n'),
-            },
-          ],
-        };
-      } catch (err) {
-        console.log = originalConsoleLog;
-        console.error = originalConsoleError;
-        throw err;
-      }
+      // Shared data layer (lib/reports.ts, #102 phase 4) — no more console
+      // monkey-patching to scrape the command's formatted output.
+      const reportTypes = await fetchReportTypes();
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ reportTypes }, null, 2),
+          },
+        ],
+      };
     }
 
     case 'youtube_list_report_jobs': {
-      const listReportJobsCommand = require('./list-report-jobs');
-      const originalConsoleLog = console.log;
-      const originalConsoleError = console.error;
-
-      try {
-        const logs: string[] = [];
-        console.log = (...args: any[]) => logs.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
-        console.error = (...args: any[]) => logs.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
-
-        await listReportJobsCommand({ type: args.type, output: args.output || 'table', verbose: false });
-
-        console.log = originalConsoleLog;
-        console.error = originalConsoleError;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: logs.join('\n'),
-            },
-          ],
-        };
-      } catch (err) {
-        console.log = originalConsoleLog;
-        console.error = originalConsoleError;
-        throw err;
-      }
+      // Shared data layer (lib/reports.ts, #102 phase 4).
+      const result = await fetchReportJobs({ type: args.type });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
     }
 
     case 'youtube_get_report_data': {
-      const getReportDataCommand = require('./get-report-data');
-      const originalConsoleLog = console.log;
-      const originalConsoleError = console.error;
+      // Shared data layer (lib/reports.ts, #102 phase 4) — same cache-merging
+      // pipeline as the get-report-data CLI command. The result carries the
+      // status ('job-created' | 'no-reports-yet' | 'ok'), rows, and range
+      // metadata instead of scraped CLI output.
+      if (args.startDate) validateDateOption('startDate', args.startDate);
+      if (args.endDate) validateDateOption('endDate', args.endDate);
 
-      try {
-        const logs: string[] = [];
-        console.log = (...args: any[]) => logs.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
-        console.error = (...args: any[]) => logs.push(args.map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' '));
+      const result = await fetchReportData({
+        type: args.type,
+        videoId: args.videoId,
+        startDate: args.startDate,
+        endDate: args.endDate,
+      });
 
-        await getReportDataCommand({
-          type: args.type,
-          videoId: args.videoId,
-          startDate: args.startDate,
-          endDate: args.endDate,
-          output: args.output || 'json',
-          verbose: false,
-        });
-
-        console.log = originalConsoleLog;
-        console.error = originalConsoleError;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: logs.join('\n'),
-            },
-          ],
-        };
-      } catch (err) {
-        console.log = originalConsoleLog;
-        console.error = originalConsoleError;
-        throw err;
-      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
     }
 
     case 'youtube_fetch_reports': {
+      // Deliberately still invokes the command with captured console output:
+      // fetch-reports is interactive-heavy (per-report progress, verify mode)
+      // and #132/#139 made command reuse survivable in-process. Decided in
+      // the 2026-07-13 phase plan on #102 — extract only if it grows an
+      // MCP-specific consumer that needs structured data.
       const fetchReportsCommand = require('./fetch-reports');
       const originalConsoleLog = console.log;
       const originalConsoleError = console.error;

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -22,7 +22,7 @@ import { unlink } from 'fs/promises';
 import { pipeline } from 'stream/promises';
 import https from 'https';
 import path from 'path';
-import { google } from 'googleapis';
+import { google, youtubereporting_v1 } from 'googleapis';
 import { getAuthenticatedClient } from './auth';
 import { debug, progress, validateDateRange, withRateLimitRetry } from './utils';
 import {
@@ -300,15 +300,40 @@ export async function fetchReportTypes(): Promise<ReportTypeInfo[]> {
   const auth = await getAuthenticatedClient();
   const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
 
-  const response = await withRateLimitRetry(
-    () => youtubeReporting.reportTypes.list({ onBehalfOfContentOwner: undefined }),
-    { label: 'reportTypes.list' }
-  );
+  // All list endpoints here are paginated — reading only the first page can
+  // silently miss entries (CodeRabbit on #152).
+  const reportTypes: ReportTypeInfo[] = [];
+  let pageToken: string | undefined;
+  do {
+    const response = await withRateLimitRetry(
+      () => youtubeReporting.reportTypes.list({ onBehalfOfContentOwner: undefined, pageToken }),
+      { label: 'reportTypes.list' }
+    );
+    for (const rt of response.data.reportTypes || []) {
+      reportTypes.push({ id: rt.id || '', name: rt.name || '' });
+    }
+    pageToken = response.data.nextPageToken || undefined;
+  } while (pageToken);
 
-  return (response.data.reportTypes || []).map(rt => ({
-    id: rt.id || '',
-    name: rt.name || '',
-  }));
+  return reportTypes;
+}
+
+/**
+ * All pages of `jobs.list`. First-page-only reads could miss a job and make
+ * fetchReportData create a duplicate for a type that already has one.
+ */
+async function listAllJobs(youtubeReporting: youtubereporting_v1.Youtubereporting): Promise<youtubereporting_v1.Schema$Job[]> {
+  const jobs: youtubereporting_v1.Schema$Job[] = [];
+  let pageToken: string | undefined;
+  do {
+    const response = await withRateLimitRetry(
+      () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined, pageToken }),
+      { label: 'jobs.list' }
+    );
+    jobs.push(...(response.data.jobs || []));
+    pageToken = response.data.nextPageToken || undefined;
+  } while (pageToken);
+  return jobs;
 }
 
 export interface ReportJobInfo {
@@ -317,7 +342,10 @@ export interface ReportJobInfo {
   name: string;
   created: string;
   daysSinceCreation: number;
+  /** 'Active', or 'Unknown (report listing failed)' when reports couldn't be listed. */
   status: string;
+  /** Set when jobs.reports.list failed for this job — reportsCount 0 is then unreliable. */
+  reportsListError?: string;
   reportsCount: number;
   /** ISO start/end of the newest report, or null when the job has none yet. */
   latestReport: { startTime: string; endTime: string } | null;
@@ -347,12 +375,7 @@ export async function fetchReportJobs(params: {
   const auth = await getAuthenticatedClient();
   const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
 
-  const jobsResponse = await withRateLimitRetry(
-    () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined }),
-    { label: 'jobs.list' }
-  );
-
-  const allJobs = jobsResponse.data.jobs || [];
+  const allJobs = await listAllJobs(youtubeReporting);
   const jobs = params.type ? allJobs.filter(job => job.reportTypeId === params.type) : allJobs;
 
   const now = new Date();
@@ -369,19 +392,25 @@ export async function fetchReportJobs(params: {
     let latestReport: ReportJobInfo['latestReport'] = null;
     let oldestReport: ReportJobInfo['oldestReport'] = null;
     let expiringReportsCount = 0;
+    let reportsListError: string | undefined;
     const warnings: ReportJobInfo['expirationWarnings'] = [];
     const criticals: ReportJobInfo['expirationCriticals'] = [];
 
     try {
-      const reportsResponse = await withRateLimitRetry(
-        () => youtubeReporting.jobs.reports.list({
-          jobId: job.id!,
-          onBehalfOfContentOwner: undefined,
-        }),
-        { label: `jobs.reports.list(${job.reportTypeId})` }
-      );
-
-      const reports = reportsResponse.data.reports || [];
+      const reports: youtubereporting_v1.Schema$Report[] = [];
+      let reportsPageToken: string | undefined;
+      do {
+        const reportsResponse = await withRateLimitRetry(
+          () => youtubeReporting.jobs.reports.list({
+            jobId: job.id!,
+            onBehalfOfContentOwner: undefined,
+            pageToken: reportsPageToken,
+          }),
+          { label: `jobs.reports.list(${job.reportTypeId})` }
+        );
+        reports.push(...(reportsResponse.data.reports || []));
+        reportsPageToken = reportsResponse.data.nextPageToken || undefined;
+      } while (reportsPageToken);
       reportsCount = reports.length;
 
       if (reports.length > 0) {
@@ -419,6 +448,9 @@ export async function fetchReportJobs(params: {
         }
       }
     } catch (err) {
+      // Keep listing the remaining jobs, but don't present this one as a
+      // healthy zero-report job — record the failure (CodeRabbit on #152).
+      reportsListError = (err as Error).message;
       debug(`Failed to fetch reports for job ${job.id}: ${err}`);
     }
 
@@ -428,7 +460,8 @@ export async function fetchReportJobs(params: {
       name: job.name || '',
       created: job.createTime || '',
       daysSinceCreation,
-      status: 'Active',
+      status: reportsListError ? 'Unknown (report listing failed)' : 'Active',
+      reportsListError,
       reportsCount,
       latestReport,
       oldestReport,
@@ -522,13 +555,8 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
 
   // Step 1: Find or create reporting job
-  const jobsResponse = await withRateLimitRetry(
-    () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined }),
-    { label: 'jobs.list' }
-  );
-
-  const jobs = jobsResponse.data.jobs || [];
-  const matchingJob = jobs.find((job: typeof jobs[0]) => job.reportTypeId === params.type);
+  const jobs = await listAllJobs(youtubeReporting);
+  const matchingJob = jobs.find((job) => job.reportTypeId === params.type);
 
   if (!matchingJob) {
     params.onProgress?.(`Creating new reporting job for type: ${params.type}...`);
@@ -583,7 +611,19 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     }
     reportsPageToken = reportsResponse.data.nextPageToken || undefined;
   } while (reportsPageToken);
-  let reports = allFetchedReports;
+
+  // YouTube can reissue a report for the same window with a newer createTime
+  // (e.g. corrected data). Keep only the newest per window so two versions of
+  // the same window never both contribute rows (CodeRabbit on #152).
+  const newestByWindow = new Map<string, FetchedReportInfo>();
+  for (const report of allFetchedReports) {
+    const key = `${report.startTime}|${report.endTime}`;
+    const prev = newestByWindow.get(key);
+    if (!prev || report.createTime > prev.createTime) {
+      newestByWindow.set(key, report);
+    }
+  }
+  let reports = [...newestByWindow.values()];
 
   if (reports.length === 0) {
     // Job exists but no reports yet (within 48h window)
@@ -596,9 +636,16 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     };
   }
 
-  // Step 3: Validate date range (API returns timestamps, compare date portions only)
-  const minDate = reports[reports.length - 1].startTime.split('T')[0]; // Oldest
-  const maxDate = reports[0].endTime.split('T')[0]; // Newest
+  // Step 3: Validate date range (API returns timestamps, compare date portions
+  // only). Computed over all reports rather than relying on response order.
+  const minDate = reports.reduce((min, r) => {
+    const d = r.startTime.split('T')[0];
+    return d < min ? d : min;
+  }, '9999-99-99');
+  const maxDate = reports.reduce((max, r) => {
+    const d = r.endTime.split('T')[0];
+    return d > max ? d : max;
+  }, '');
 
   const requestedStart = params.startDate || minDate;
   const requestedEnd = params.endDate || maxDate;
@@ -675,7 +722,7 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   debug('Cache coverage:', coverage);
 
   // Step 6: Load cached data
-  let allData: Record<string, string>[] = [];
+  const cachedData: Record<string, string>[] = [];
   const cachedReports: CacheIndexEntry[] = [];
 
   for (const range of coverage.fullyCovered) {
@@ -685,7 +732,7 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     for (const cachedReport of cached) {
       const reportData = await readCachedReport(channelId, cachedReport.reportId, params.type);
       if (reportData) {
-        allData.push(...reportData.data);
+        cachedData.push(...reportData.data);
         cachedReports.push(cachedReport);
         debug(`Loaded from cache: ${cachedReport.reportId}`);
       }
@@ -708,10 +755,15 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     }),
   ];
 
-  // Filter reports to only fetch those covering missing ranges
+  // Filter reports to only fetch those covering missing ranges. Compare date
+  // portions: the report bounds are full timestamps while the range bounds
+  // are YYYY-MM-DD, and lexical comparison on an equal-day boundary would
+  // skip a report covering a single-day gap (CodeRabbit on #152).
   for (const report of reports) {
+    const reportStart = report.startTime.split('T')[0];
+    const reportEnd = report.endTime.split('T')[0];
     const coversMissing = missingRanges.some(range => {
-      return report.startTime <= range.end && report.endTime >= range.start;
+      return reportStart <= range.end && reportEnd >= range.start;
     });
 
     if (coversMissing) {
@@ -729,6 +781,10 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   // index write only.
 
   const jobCreated = new Date(jobCreateTime);
+  const fetchedData: Record<string, string>[] = [];
+  // Actual data windows (YYYYMMDD row dates) of the fresh downloads — used to
+  // drop overlapping cached rows below.
+  const fetchedWindows: { min: string; max: string }[] = [];
 
   for (let i = 0; i < reportsToFetch.length; i++) {
     const report = reportsToFetch[i];
@@ -790,18 +846,38 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
       }
     }
 
-    allData.push(...data);
+    fetchedData.push(...data);
+    if (dataMinDate && dataMaxDate) {
+      fetchedWindows.push({ min: dataMinDate, max: dataMaxDate });
+    }
 
     debug(`Downloaded: ${report.startTime} to ${report.endTime}`);
   }
 
-  // Deduplicate by (date, video_id) — YouTube may serve duplicate
-  // reports for the same day; last-write-wins.
-  const dedupMap = new Map<string, Record<string, string>>();
-  for (const row of allData) {
-    dedupMap.set(`${row.date}|${row.video_id}`, row);
-  }
-  allData = [...dedupMap.values()];
+  // Merge cached + fresh rows. Fresh downloads win where their actual data
+  // window overlaps cached rows (a reissued report can carry corrected
+  // values), then byte-identical duplicate rows are dropped. The previous
+  // dedup keyed on (date, video_id) alone, which collapsed distinct rows in
+  // report types with more dimensions — demographics, traffic sources, etc.
+  // (CodeRabbit on #152, critical).
+  const cachedSurviving = cachedData.filter(row =>
+    !row.date || !fetchedWindows.some(w => row.date >= w.min && row.date <= w.max)
+  );
+  let allData = [...cachedSurviving, ...fetchedData];
+  const seenRows = new Set<string>();
+  allData = allData.filter(row => {
+    const key = JSON.stringify(row);
+    if (seenRows.has(key)) return false;
+    seenRows.add(key);
+    return true;
+  });
+
+  // Clamp to the adjusted range: report files span whole windows, so rows
+  // just outside the requested range would otherwise leak into a result that
+  // claims a narrower dateRange (CodeRabbit on #152). Row dates are YYYYMMDD.
+  const startKey = adjustedStart.replace(/-/g, '');
+  const endKey = adjustedEnd.replace(/-/g, '');
+  allData = allData.filter(row => !row.date || (row.date >= startKey && row.date <= endKey));
 
   // Step 8: Filter by video ID if specified
   let rows = allData;

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -1,13 +1,19 @@
 /**
- * Shared report-download primitives used by both `fetch-reports` and
- * `get-report-data`. Centralizing these here eliminates the duplicated
- * HTTPS-download + CSV-parse code that previously lived in both commands
- * (issue #101).
+ * YouTube Reporting API data layer.
+ *
+ * Download primitives shared by `fetch-reports` and `get-report-data`
+ * (issue #101), plus the report-types/jobs/report-data query functions
+ * consumed by both the CLI commands and the MCP tools (issue #102 phase 4 —
+ * before this, commands/mcp.ts invoked the commands and monkey-patched
+ * console.log/error to capture their formatted output).
  *
  * Public surface:
  *   - safeTmpReportPath(reportId)            — sanitize a report ID for /tmp
  *   - downloadOnce(url, token, dest)         — single HTTPS GET, no retry
  *   - downloadReport(report, auth, opts?)    — retry-wrapped download + CSV parse
+ *   - fetchReportTypes()                     — list available report types
+ *   - fetchReportJobs(params)                — list jobs + per-job report status
+ *   - fetchReportData(params)                — cached+fresh report rows for a type
  */
 
 import { promises as fs } from 'fs';
@@ -16,8 +22,22 @@ import { unlink } from 'fs/promises';
 import { pipeline } from 'stream/promises';
 import https from 'https';
 import path from 'path';
-import { debug, progress } from './utils';
-import { parseCsvAndExtractRange } from './cache';
+import { google } from 'googleapis';
+import { getAuthenticatedClient } from './auth';
+import { debug, progress, validateDateRange, withRateLimitRetry } from './utils';
+import {
+  analyzeCacheCoverage,
+  ensureCacheDir,
+  findCachedReports,
+  loadReportMetadata,
+  parseCsvAndExtractRange,
+  readCachedReport,
+  saveReportToCache,
+} from './cache';
+import { getConfigValue } from './config';
+import { getChannelId } from './youtube';
+import { acquireLock, getLockPath } from './lock';
+import { CacheIndexEntry } from '../types';
 
 /**
  * A minimal slice of `youtube.reports.jobs.list` report shape — both call
@@ -265,5 +285,549 @@ export async function downloadReport(
     data: parsed.data,
     minDate: parsed.minDate,
     maxDate: parsed.maxDate,
+  };
+}
+
+// ─── Reporting API queries (report types, jobs, report data) — #102 phase 4 ──
+
+export interface ReportTypeInfo {
+  id: string;
+  name: string;
+}
+
+/** List available YouTube Reporting API report types. */
+export async function fetchReportTypes(): Promise<ReportTypeInfo[]> {
+  const auth = await getAuthenticatedClient();
+  const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
+
+  const response = await withRateLimitRetry(
+    () => youtubeReporting.reportTypes.list({ onBehalfOfContentOwner: undefined }),
+    { label: 'reportTypes.list' }
+  );
+
+  return (response.data.reportTypes || []).map(rt => ({
+    id: rt.id || '',
+    name: rt.name || '',
+  }));
+}
+
+export interface ReportJobInfo {
+  jobId: string;
+  reportTypeId: string;
+  name: string;
+  created: string;
+  daysSinceCreation: number;
+  status: string;
+  reportsCount: number;
+  /** ISO start/end of the newest report, or null when the job has none yet. */
+  latestReport: { startTime: string; endTime: string } | null;
+  /** ISO start/end of the oldest report, or null when the job has none yet. */
+  oldestReport: { startTime: string; endTime: string } | null;
+  expiringReportsCount: number;
+  expirationWarnings: { startTime: string; endTime: string; expiresAt: string; daysUntilExpiration: number }[];
+  expirationCriticals: { startTime: string; endTime: string; expiresAt: string; daysUntilExpiration: number }[];
+}
+
+export interface ReportJobsResult {
+  /** Job count before the type filter — lets callers tell "no jobs at all" from "filter matched none". */
+  totalJobs: number;
+  jobs: ReportJobInfo[];
+}
+
+/**
+ * List Reporting API jobs with per-job report counts and expiration analysis.
+ * Reports created within ~4 days of the job are historical backfills and
+ * expire after 30 days; regular reports expire after 60.
+ */
+export async function fetchReportJobs(params: {
+  /** Filter by report type ID. */
+  type?: string;
+  onProgress?: (message: string) => void;
+} = {}): Promise<ReportJobsResult> {
+  const auth = await getAuthenticatedClient();
+  const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
+
+  const jobsResponse = await withRateLimitRetry(
+    () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined }),
+    { label: 'jobs.list' }
+  );
+
+  const allJobs = jobsResponse.data.jobs || [];
+  const jobs = params.type ? allJobs.filter(job => job.reportTypeId === params.type) : allJobs;
+
+  const now = new Date();
+  const jobsData: ReportJobInfo[] = [];
+
+  for (let i = 0; i < jobs.length; i++) {
+    const job = jobs[i];
+    params.onProgress?.(`Fetching job ${i + 1}/${jobs.length}`);
+
+    const jobCreated = new Date(job.createTime || '');
+    const daysSinceCreation = Math.floor((now.getTime() - jobCreated.getTime()) / (1000 * 60 * 60 * 24));
+
+    let reportsCount = 0;
+    let latestReport: ReportJobInfo['latestReport'] = null;
+    let oldestReport: ReportJobInfo['oldestReport'] = null;
+    let expiringReportsCount = 0;
+    const warnings: ReportJobInfo['expirationWarnings'] = [];
+    const criticals: ReportJobInfo['expirationCriticals'] = [];
+
+    try {
+      const reportsResponse = await withRateLimitRetry(
+        () => youtubeReporting.jobs.reports.list({
+          jobId: job.id!,
+          onBehalfOfContentOwner: undefined,
+        }),
+        { label: `jobs.reports.list(${job.reportTypeId})` }
+      );
+
+      const reports = reportsResponse.data.reports || [];
+      reportsCount = reports.length;
+
+      if (reports.length > 0) {
+        latestReport = {
+          startTime: reports[0].startTime || '',
+          endTime: reports[0].endTime || '',
+        };
+        oldestReport = {
+          startTime: reports[reports.length - 1].startTime || '',
+          endTime: reports[reports.length - 1].endTime || '',
+        };
+
+        for (const report of reports) {
+          const reportCreated = new Date(report.createTime || '');
+          const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
+          const expirationDays = isHistorical ? 30 : 60;
+          const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
+          const daysUntilExpiration = Math.ceil((expiresAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
+
+          const entry = {
+            startTime: report.startTime || '',
+            endTime: report.endTime || '',
+            expiresAt: expiresAt.toISOString().split('T')[0],
+            daysUntilExpiration,
+          };
+          if (daysUntilExpiration <= 3) {
+            criticals.push(entry);
+          } else if (daysUntilExpiration <= 7) {
+            warnings.push(entry);
+          }
+
+          if (daysUntilExpiration <= 7) {
+            expiringReportsCount++;
+          }
+        }
+      }
+    } catch (err) {
+      debug(`Failed to fetch reports for job ${job.id}: ${err}`);
+    }
+
+    jobsData.push({
+      jobId: job.id || '',
+      reportTypeId: job.reportTypeId || '',
+      name: job.name || '',
+      created: job.createTime || '',
+      daysSinceCreation,
+      status: 'Active',
+      reportsCount,
+      latestReport,
+      oldestReport,
+      expiringReportsCount,
+      expirationWarnings: warnings,
+      expirationCriticals: criticals,
+    });
+  }
+
+  return { totalJobs: allJobs.length, jobs: jobsData };
+}
+
+export interface ReportDataParams {
+  /** Report type ID (e.g. channel_reach_basic_a1). */
+  type: string;
+  /** Channel handle/ID; falls back to `default.channel` config. */
+  channel?: string;
+  /** Filter rows by video ID; throws (listing available IDs) when nothing matches. */
+  videoId?: string;
+  /** YYYY-MM-DD; defaults to the oldest available data. */
+  startDate?: string;
+  /** YYYY-MM-DD; defaults to the newest available data. */
+  endDate?: string;
+  /** Progress hook — commands wire this to the spinner; MCP omits it. */
+  onProgress?: (message: string) => void;
+}
+
+/** A report fetched fresh from the API in this run (for expiration display). */
+export interface FetchedReportInfo {
+  id: string;
+  startTime: string;
+  endTime: string;
+  createTime: string;
+}
+
+export type ReportDataResult =
+  /** No job existed — one was created; data arrives after the 48h window. */
+  | {
+      status: 'job-created';
+      jobId: string;
+      jobCreateTime: string;
+      readyAt: string;
+    }
+  /** Job exists but has produced no reports yet (within the 48h window). */
+  | {
+      status: 'no-reports-yet';
+      jobId: string;
+      jobCreateTime: string;
+      readyAt: string;
+    }
+  | {
+      status: 'ok';
+      jobId: string;
+      jobCreateTime: string;
+      rows: Record<string, string>[];
+      requestedRange: { startDate: string; endDate: string };
+      /** Requested range clamped to what the API + local cache can cover. */
+      adjustedRange: { startDate: string; endDate: string };
+      availableRange: { startDate: string; endDate: string };
+      cachedReports: CacheIndexEntry[];
+      fetchedReports: FetchedReportInfo[];
+    };
+
+/**
+ * Fetch Reporting API rows for a report type, merging the local cache with
+ * fresh downloads (issue #101 pipeline). Finds or creates the reporting job,
+ * clamps the requested date range to available data (API + cache), loads
+ * covered ranges from cache, downloads only the missing reports, caches them
+ * (skipping the write when the lock is busy), and deduplicates rows by
+ * (date, video_id).
+ */
+export async function fetchReportData(params: ReportDataParams): Promise<ReportDataResult> {
+  // Resolve channel handle → canonical channel ID for cache namespacing
+  const channelHandle = params.channel || await getConfigValue('default.channel');
+  if (!channelHandle) {
+    throw new Error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
+  }
+
+  params.onProgress?.(`Resolving channel ID for ${channelHandle}...`);
+  const channelId = await getChannelId(channelHandle);
+  debug(`Using channel ID: ${channelId}`);
+
+  // Ensure cache directory exists before attempting lock
+  try {
+    await ensureCacheDir(channelId);
+  } catch (err) {
+    throw new Error(`Failed to create cache directory: ${(err as Error).message}`);
+  }
+
+  const auth = await getAuthenticatedClient();
+  const youtubeReporting = google.youtubereporting({ version: 'v1', auth });
+
+  // Step 1: Find or create reporting job
+  const jobsResponse = await withRateLimitRetry(
+    () => youtubeReporting.jobs.list({ onBehalfOfContentOwner: undefined }),
+    { label: 'jobs.list' }
+  );
+
+  const jobs = jobsResponse.data.jobs || [];
+  const matchingJob = jobs.find((job: typeof jobs[0]) => job.reportTypeId === params.type);
+
+  if (!matchingJob) {
+    params.onProgress?.(`Creating new reporting job for type: ${params.type}...`);
+
+    const createResponse = await withRateLimitRetry(
+      () => youtubeReporting.jobs.create({
+        requestBody: {
+          reportTypeId: params.type,
+          name: `${params.type} Report Job`,
+        },
+      }),
+      { label: `jobs.create(${params.type})` }
+    );
+
+    const jobCreateTime = createResponse.data.createTime || '';
+    const readyAt = new Date(new Date(jobCreateTime).getTime() + 48 * 60 * 60 * 1000);
+    return {
+      status: 'job-created',
+      jobId: createResponse.data.id!,
+      jobCreateTime,
+      readyAt: readyAt.toISOString(),
+    };
+  }
+
+  const jobId = matchingJob.id!;
+  const jobCreateTime = matchingJob.createTime || '';
+  debug(`Found existing job: ${jobId}`);
+
+  // Step 2: Check if reports are available
+  params.onProgress?.('Fetching available reports...');
+
+  const allFetchedReports: FetchedReportInfo[] = [];
+  const reportsById = new Map<string, { downloadUrl?: string | null }>();
+  let reportsPageToken: string | undefined;
+  do {
+    const reportsResponse = await withRateLimitRetry(
+      () => youtubeReporting.jobs.reports.list({
+        jobId,
+        onBehalfOfContentOwner: undefined,
+        pageToken: reportsPageToken,
+      }),
+      { label: `jobs.reports.list(${params.type})` }
+    );
+    for (const report of reportsResponse.data.reports || []) {
+      allFetchedReports.push({
+        id: report.id || '',
+        startTime: report.startTime || '',
+        endTime: report.endTime || '',
+        createTime: report.createTime || '',
+      });
+      reportsById.set(report.id || '', { downloadUrl: report.downloadUrl });
+    }
+    reportsPageToken = reportsResponse.data.nextPageToken || undefined;
+  } while (reportsPageToken);
+  let reports = allFetchedReports;
+
+  if (reports.length === 0) {
+    // Job exists but no reports yet (within 48h window)
+    const readyAt = new Date(new Date(jobCreateTime).getTime() + 48 * 60 * 60 * 1000);
+    return {
+      status: 'no-reports-yet',
+      jobId,
+      jobCreateTime,
+      readyAt: readyAt.toISOString(),
+    };
+  }
+
+  // Step 3: Validate date range (API returns timestamps, compare date portions only)
+  const minDate = reports[reports.length - 1].startTime.split('T')[0]; // Oldest
+  const maxDate = reports[0].endTime.split('T')[0]; // Newest
+
+  const requestedStart = params.startDate || minDate;
+  const requestedEnd = params.endDate || maxDate;
+
+  if (!minDate || !maxDate || !requestedStart || !requestedEnd) {
+    throw new Error('Unable to determine date range');
+  }
+
+  try {
+    validateDateRange(requestedStart, requestedEnd);
+  } catch (e) {
+    throw new Error(`${(e as Error).message}\nProvided: start-date=${requestedStart}, end-date=${requestedEnd}`);
+  }
+
+  // Adjust date range to available data if needed.
+  // Consider both API range and local cache — cache may contain data that
+  // has expired from the API, or may be the only source if API returns nothing.
+  // Use actual CSV data dates (from metadata) rather than API report windows
+  // which span 2 calendar days and would overstate coverage.
+  const cacheEntries = await findCachedReports(channelId, params.type, requestedStart, requestedEnd);
+  let effectiveMinDate = minDate;
+  let effectiveMaxDate = maxDate;
+  if (cacheEntries.length > 0) {
+    const cacheDates = await Promise.all(
+      cacheEntries.map(async (e) => {
+        const meta = await loadReportMetadata(channelId, e.reportId, params.type);
+        if (meta?.startTimeActual) {
+          const s = meta.startTimeActual;
+          return {
+            min: `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
+            max: meta.endTimeActual
+              ? `${meta.endTimeActual.slice(0, 4)}-${meta.endTimeActual.slice(4, 6)}-${meta.endTimeActual.slice(6, 8)}`
+              : `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
+          };
+        }
+        return { min: e.startTime.split('T')[0], max: e.endTime.split('T')[0] };
+      })
+    );
+    const cacheEarliest = cacheDates.reduce((min, d) => d.min < min ? d.min : min, '9999-99-99');
+    const cacheLatest = cacheDates.reduce((max, d) => d.max > max ? d.max : max, '');
+    if (cacheEarliest < effectiveMinDate) effectiveMinDate = cacheEarliest;
+    if (cacheLatest > effectiveMaxDate) effectiveMaxDate = cacheLatest;
+  }
+
+  const adjustedStart = requestedStart < effectiveMinDate ? effectiveMinDate : requestedStart;
+  const adjustedEnd = requestedEnd > effectiveMaxDate ? effectiveMaxDate : requestedEnd;
+
+  // Validate that adjusted range has overlap (i.e., requested range is not entirely before/after available data)
+  if (adjustedStart > adjustedEnd) {
+    throw new Error(
+      'Requested date range has no overlap with available data\n' +
+      `Requested: ${requestedStart} to ${requestedEnd}\n` +
+      `Available: ${effectiveMinDate} to ${effectiveMaxDate}`
+    );
+  }
+
+  // Step 4: Filter reports by date range (compare date portions only)
+  // These are API reports — used for fetching data not yet in cache.
+  reports = reports.filter((report) => {
+    const reportStart = report.startTime.split('T')[0];
+    const reportEnd = report.endTime.split('T')[0];
+    return reportStart <= adjustedEnd && reportEnd >= adjustedStart;
+  });
+
+  // It's okay if no API reports match — data may still be available from cache
+  // (e.g. expired from API but present in local archive).
+  if (reports.length === 0 && cacheEntries.length === 0) {
+    throw new Error('No reports match the specified date range.');
+  }
+
+  // Step 5: Analyze cache coverage
+  params.onProgress?.('Analyzing cache coverage...');
+  const coverage = await analyzeCacheCoverage(channelId, params.type, adjustedStart, adjustedEnd);
+  debug('Cache coverage:', coverage);
+
+  // Step 6: Load cached data
+  let allData: Record<string, string>[] = [];
+  const cachedReports: CacheIndexEntry[] = [];
+
+  for (const range of coverage.fullyCovered) {
+    const [start, end] = range.split('/');
+    const cached = await findCachedReports(channelId, params.type, start, end);
+
+    for (const cachedReport of cached) {
+      const reportData = await readCachedReport(channelId, cachedReport.reportId, params.type);
+      if (reportData) {
+        allData.push(...reportData.data);
+        cachedReports.push(cachedReport);
+        debug(`Loaded from cache: ${cachedReport.reportId}`);
+      }
+    }
+  }
+
+  if (cachedReports.length > 0) {
+    params.onProgress?.(`Loaded ${cachedReports.length} report(s) from cache`);
+  }
+
+  // Step 7: Fetch missing data
+  const reportsToFetch: FetchedReportInfo[] = [];
+
+  // Build list of missing date ranges
+  const missingRanges = [
+    ...coverage.partiallyCovered.map(p => p.missing),
+    ...coverage.notCovered.map(r => {
+      const [start, end] = r.split('/');
+      return { start, end };
+    }),
+  ];
+
+  // Filter reports to only fetch those covering missing ranges
+  for (const report of reports) {
+    const coversMissing = missingRanges.some(range => {
+      return report.startTime <= range.end && report.endTime >= range.start;
+    });
+
+    if (coversMissing) {
+      reportsToFetch.push(report);
+    }
+  }
+
+  const tmpDir = '/tmp';
+
+  // NOTE: the write lock is acquired and released per-iteration around the
+  // cache write, NOT held across the whole download loop. `downloadReport`
+  // can retry/backoff for minutes on HTTP 429 or transient network errors,
+  // and holding the lock that long would block concurrent `fetch-reports` /
+  // `get-report-data` runs from the same channel. The lock guards the cache
+  // index write only.
+
+  const jobCreated = new Date(jobCreateTime);
+
+  for (let i = 0; i < reportsToFetch.length; i++) {
+    const report = reportsToFetch[i];
+    // Use the shared sanitizer so a malicious report.id can't escape
+    // `tmpDir` (path-traversal hardening). Append pid + timestamp to keep
+    // the path unique per process — the reports lock is scoped to just the
+    // cache write, so two concurrent runs on the same channel would
+    // otherwise clobber each other's temp CSV (CodeRabbit round 2).
+    const tmpPath = safeReportPath(tmpDir, `${report.id || 'report'}-${process.pid}-${Date.now()}`);
+
+    params.onProgress?.(`Downloading report ${i + 1}/${reportsToFetch.length}...`);
+
+    const downloadUrl = reportsById.get(report.id)?.downloadUrl;
+    const { csvData, headers, data, minDate: dataMinDate, maxDate: dataMaxDate } =
+      await downloadReport({ ...report, downloadUrl }, auth, { tmpPath });
+
+    // Calculate expiration date
+    const reportCreated = new Date(report.createTime);
+    const isHistorical = reportCreated.getTime() - jobCreated.getTime() < 4 * 24 * 60 * 60 * 1000;
+    const expirationDays = isHistorical ? 30 : 60;
+    const expiresAt = new Date(reportCreated.getTime() + expirationDays * 24 * 60 * 60 * 1000);
+
+    // Acquire the write lock just long enough to update the cache index.
+    // If the lock is busy, skip the cache write (the run still returns data)
+    // rather than queueing behind a possibly-slow download backoff.
+    let writeRelease: (() => Promise<void>) | null = null;
+    try {
+      writeRelease = await acquireLock(getLockPath('reports', channelId), { timeout: 1000 });
+    } catch {
+      // progress() routes to stderr: stdout carries the machine-readable
+      // data output and interleaving would break downstream parsing.
+      progress(`Info: cache lock busy, skipping cache write for ${report.id}`);
+    }
+
+    if (writeRelease) {
+      // Save to cache (non-fatal: warn on failure so API data is still returned)
+      try {
+        await saveReportToCache(channelId, report.id, params.type, csvData, {
+          reportId: report.id,
+          reportTypeId: params.type,
+          channelId,
+          jobId,
+          startTime: report.startTime,
+          endTime: report.endTime,
+          startTimeActual: dataMinDate,
+          endTimeActual: dataMaxDate,
+          downloadedAt: new Date().toISOString(),
+          expiresAt: expiresAt.toISOString(),
+          downloadUrl: downloadUrl || '',
+          columns: headers,
+          isComplete: true,
+          fileSize: csvData.length,
+          row_count: data.length,
+        });
+      } catch (cacheErr) {
+        progress(`Warning: cache save failed for ${report.id}: ${(cacheErr as Error).message} — data will be re-fetched on next run`);
+      } finally {
+        await writeRelease();
+      }
+    }
+
+    allData.push(...data);
+
+    debug(`Downloaded: ${report.startTime} to ${report.endTime}`);
+  }
+
+  // Deduplicate by (date, video_id) — YouTube may serve duplicate
+  // reports for the same day; last-write-wins.
+  const dedupMap = new Map<string, Record<string, string>>();
+  for (const row of allData) {
+    dedupMap.set(`${row.date}|${row.video_id}`, row);
+  }
+  allData = [...dedupMap.values()];
+
+  // Step 8: Filter by video ID if specified
+  let rows = allData;
+  if (params.videoId) {
+    rows = allData.filter(row => row.video_id === params.videoId);
+
+    if (rows.length === 0) {
+      const uniqueVideoIds = [...new Set(allData.map(row => row.video_id))];
+      const shown = uniqueVideoIds.slice(0, 10).map(vid => `  ${vid}`).join('\n');
+      const more = uniqueVideoIds.length > 10 ? `\n  ... and ${uniqueVideoIds.length - 10} more` : '';
+      throw new Error(
+        `No data found for video ID: ${params.videoId}\n` +
+        `Available video IDs in this date range:\n${shown}${more}`
+      );
+    }
+  }
+
+  return {
+    status: 'ok',
+    jobId,
+    jobCreateTime,
+    rows,
+    requestedRange: { startDate: requestedStart, endDate: requestedEnd },
+    adjustedRange: { startDate: adjustedStart, endDate: adjustedEnd },
+    availableRange: { startDate: effectiveMinDate, endDate: effectiveMaxDate },
+    cachedReports,
+    fetchedReports: reportsToFetch,
   };
 }


### PR DESCRIPTION
## Value proposition

Phase 4 (final extraction phase) of #102: the MCP reporting tools stop invoking CLI commands with monkey-patched `console.log`/`console.error` to scrape their formatted output — the pattern the issue was filed about. `lib/reports.ts` (already home to the #101 download primitives) gains three data functions consumed by both surfaces:

- `fetchReportTypes()` — report-type list
- `fetchReportJobs({type?})` — jobs + per-job report counts and structured expiration analysis; returns `totalJobs` alongside the filtered list so callers can distinguish "no jobs at all" from "filter matched none"
- `fetchReportData({type, channel?, videoId?, startDate?, endDate?})` — the full get-report-data cache-merging pipeline (job find-or-create, range clamping to API+cache coverage, cache loads, missing-report downloads with per-write locking, dedup). Returns a discriminated union: `job-created` / `no-reports-yet` / `ok`.

Commands remain presentation shells (spinner via `onProgress`, all existing output formats and stderr warnings preserved). MCP serializes the structured results.

## Deliberate decisions (per the 2026-07-13 phase plan on #102)

- **`youtube_fetch_reports` still calls the command** with captured console output — it's interactive-heavy, and #132/#139 made in-process command reuse survivable. Extract only if an MCP consumer needs structured data. A comment in mcp.ts records this.
- **The `output` arg is removed from the three converted tool schemas** — it only existed because the tools returned scraped CLI output; they now return JSON like every other consolidated tool.
- **`reportTypes.list` / `jobs.list` / `jobs.reports.list` now go through `withRateLimitRetry`** — previously only get-report-data wrapped them (#84 convention).

## MCP response-shape notes

- `youtube_list_report_types`: structured `{reportTypes: [{id, name}]}` instead of a scraped table.
- `youtube_list_report_jobs`: structured job objects with machine-readable expiration entries instead of pre-rendered warning strings.
- `youtube_get_report_data`: `{status, rows, requestedRange, adjustedRange, availableRange, cachedReports, fetchedReports}` — MCP consumers now see range-clamping metadata they previously had to parse from stderr-styled text.

## Verification (local — Actions quota dead until end of July)

- `bun run type-check && bun run lint && bun run build && bun test` — 61/61 pass, 0 errors; lint warnings dropped 11 → 4 (the monkey-patch `any`s are gone)
- Live CLI: `list-report-types` (20 types), `list-report-jobs` (20 jobs, expiration criticals intact), `get-report-data --type channel_reach_basic_a1 --start-date 2026-07-10 --end-date 2026-07-12` (91 rows, 7 cached + 0 downloaded — cache pipeline intact)
- Live MCP (stdio JSON-RPC): all three converted tools return structured data matching the CLI results exactly

Built on main (82b318a lineage); trivially rebasable if #151 (phase 3) lands first — the only overlap is the mcp.ts import block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2vaCGp3E3xtU84Q7RZiEz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved report type, job, and data retrieval with consistent results across CLI and MCP tools.
  * Report data now combines cached and newly downloaded reports, removes duplicate rows, and supports video and date-range filtering.
  * Added clearer progress updates and warnings for incomplete coverage, expiring reports, and newly created jobs.
  * Added structured report information for MCP integrations.

* **Improvements**
  * Report listings now include report windows, latest and oldest reports, and expiration warnings.
  * Output remains available in JSON, CSV, text, table, and pretty formats where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->