### PR TITLE
fix(#153): key reporting cache by authenticated channel, validate --channel

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -8,7 +8,7 @@ import {
   loadReportMetadata,
   ensureCacheDir,
 } from '../lib/cache';
-import { getChannelId } from '../lib/youtube';
+import { getChannelId, getAuthenticatedChannelId } from '../lib/youtube';
 import { getConfigValue, getLockTimeout } from '../lib/config';
 import { acquireLock, getLockPath } from '../lib/lock';
 import { downloadReport } from '../lib/reports';
@@ -35,15 +35,34 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
   runOrExit(() => { if (options.startDate && options.endDate) validateDateRange(options.startDate, options.endDate); });
 
   await withSpinner('Initializing...', 'Failed to fetch reports', async (spinner) => {
-    // Resolve channel handle → canonical channel ID for cache namespacing
-    const channelHandle = options.channel || await getConfigValue('default.channel');
-    if (!channelHandle) {
-      throw new Error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
-    }
+    // Resolve the cache namespace from the AUTHENTICATED channel. The
+    // Reporting API always returns data for whoever's authenticated — there's
+    // no channel parameter and `onBehalfOfContentOwner` is always undefined in
+    // this CLI — so the cache has to be keyed by the same channel or we
+    // silently write the authed account's data under another channel's path
+    // (issue #153).
+    //
+    // `--channel` / `default.channel` is accepted only for validation: today
+    // it can only name the authed channel (no multi-account auth-swap yet,
+    // see #153), so we resolve it and fail loudly on mismatch. That surfaces
+    // stale `default.channel` config or a wrong `--channel` instead of
+    // letting the bug recur.
+    spinner.text = 'Resolving authenticated channel...';
+    const channelId = await getAuthenticatedChannelId();
 
-    spinner.text = `Resolving channel ID for ${channelHandle}...`;
-    const channelId = await getChannelId(channelHandle);
-    debug(`Using channel ID: ${channelId}`);
+    const requestedChannel = options.channel || await getConfigValue('default.channel');
+    if (requestedChannel) {
+      const requestedChannelId = await getChannelId(requestedChannel);
+      if (requestedChannelId !== channelId) {
+        throw new Error(
+          `Reporting data is always scoped to the authenticated channel.\n` +
+          `You requested channel "${requestedChannel}" (ID ${requestedChannelId}), ` +
+          `but you are authenticated as channel ID ${channelId}.\n` +
+          `Re-authenticate as the requested channel, or remove default.channel / omit --channel.`
+        );
+      }
+    }
+    debug(`Using authenticated channel ID for cache namespace: ${channelId}`);
 
     // Ensure cache directory exists before touching the lock
     try {
@@ -298,7 +317,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     if (options.verify) {
       spinner.text = 'Verifying cached files...';
 
-      const index = await loadCacheIndex(channelId, channelHandle);
+      const index = await loadCacheIndex(channelId);
       let verified = 0;
       let corrupted = 0;
 

--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -8,7 +8,7 @@ import {
   loadReportMetadata,
   ensureCacheDir,
 } from '../lib/cache';
-import { getChannelId, getAuthenticatedChannelId } from '../lib/youtube';
+import { getAuthenticatedChannelId, assertChannelMatchesAuthenticated } from '../lib/youtube';
 import { getConfigValue, getLockTimeout } from '../lib/config';
 import { acquireLock, getLockPath } from '../lib/lock';
 import { downloadReport } from '../lib/reports';
@@ -46,22 +46,12 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
     // it can only name the authed channel (no multi-account auth-swap yet,
     // see #153), so we resolve it and fail loudly on mismatch. That surfaces
     // stale `default.channel` config or a wrong `--channel` instead of
-    // letting the bug recur.
+    // letting the bug recur. The shared helper keeps the message identical
+    // across fetchReportData and fetch-reports.
     spinner.text = 'Resolving authenticated channel...';
     const channelId = await getAuthenticatedChannelId();
-
     const requestedChannel = options.channel || await getConfigValue('default.channel');
-    if (requestedChannel) {
-      const requestedChannelId = await getChannelId(requestedChannel);
-      if (requestedChannelId !== channelId) {
-        throw new Error(
-          `Reporting data is always scoped to the authenticated channel.\n` +
-          `You requested channel "${requestedChannel}" (ID ${requestedChannelId}), ` +
-          `but you are authenticated as channel ID ${channelId}.\n` +
-          `Re-authenticate as the requested channel, or remove default.channel / omit --channel.`
-        );
-      }
-    }
+    await assertChannelMatchesAuthenticated(requestedChannel, channelId);
     debug(`Using authenticated channel ID for cache namespace: ${channelId}`);
 
     // Ensure cache directory exists before touching the lock

--- a/docs/commands/reporting-api.md
+++ b/docs/commands/reporting-api.md
@@ -150,7 +150,7 @@ staqan-yt get-report-data
 ### Options
 
 - `--type <id>` - Report type ID (e.g., `channel_reach_basic_a1`)
-- `-c, --channel <handle>` - Channel handle or ID (overrides config default)
+- `-c, --channel <handle>` - Channel handle or ID of the authenticated channel. Reporting data is always scoped to the authenticated account (no multi-account auth swap yet), so this is reserved for future use; supplying a value that doesn't match the authenticated channel fails loudly. If omitted, `default.channel` is checked the same way.
 - `--video-id <id>` - Filter by video ID
 - `--start-date <date>` - Start date (YYYY-MM-DD)
 - `--end-date <date>` - End date (YYYY-MM-DD)
@@ -232,10 +232,7 @@ staqan-yt get-report-data \
 
 Cache location: `~/.staqan-yt-cli/data/{channelId}/reports/`
 
-**Required:** Set a default channel or pass `--channel`:
-```bash
-staqan-yt config set default.channel @yourchannel
-```
+The cache is keyed by the authenticated channel ID, not by `--channel` / `default.channel` — Reporting API jobs, jobs.reports, and downloads always operate on the authenticated account regardless of any `--channel` flag, so the cache has to follow the same channel or it gets mislabeled. Passing `--channel` is optional and currently only validates against the authenticated channel.
 
 ### Data Freshness
 
@@ -257,7 +254,7 @@ staqan-yt fetch-reports
 
 ### Options
 
-- `-c, --channel <handle>` - Channel handle or ID (overrides config default)
+- `-c, --channel <handle>` - Channel handle or ID of the authenticated channel. Reporting data is always scoped to the authenticated account (no multi-account auth swap yet), so this is reserved for future use; supplying a value that doesn't match the authenticated channel fails loudly. If omitted, `default.channel` is checked the same way.
 - `-t, --type <id>` - Fetch specific report type
 - `-T, --types <ids>` - Fetch multiple report types (comma-separated)
 - `--start-date <date>` - Filter by start date (YYYY-MM-DD). Reports whose window **overlaps** the range are included — see [Date range filtering](#date-range-filtering).

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -34,8 +34,7 @@ import {
   readCachedReport,
   saveReportToCache,
 } from './cache';
-import { getConfigValue } from './config';
-import { getChannelId } from './youtube';
+import { getChannelId, getAuthenticatedChannelId } from './youtube';
 import { acquireLock, getLockPath } from './lock';
 import { CacheIndexEntry } from '../types';
 
@@ -534,15 +533,30 @@ export type ReportDataResult =
  * (date, video_id).
  */
 export async function fetchReportData(params: ReportDataParams): Promise<ReportDataResult> {
-  // Resolve channel handle → canonical channel ID for cache namespacing
-  const channelHandle = params.channel || await getConfigValue('default.channel');
-  if (!channelHandle) {
-    throw new Error('No channel specified. Set a default channel:\n  staqan-yt config set default.channel @yourchannel\nor pass --channel @yourchannel');
+  // Resolve the cache namespace from the AUTHENTICATED channel. The Reporting
+  // API always returns data for whoever's authenticated — there's no channel
+  // parameter and `onBehalfOfContentOwner` is always undefined in this CLI —
+  // so the cache has to be keyed by the same channel or we silently write
+  // the authed account's data under another channel's path (issue #153).
+  //
+  // `params.channel` is accepted only for validation: today it can only name
+  // the authed channel (no multi-account auth-swap yet, see #153), so we
+  // resolve it and fail loudly on mismatch. That surfaces stale
+  // `default.channel` config or a wrong `--channel` instead of letting the
+  // bug recur.
+  const channelId = await getAuthenticatedChannelId();
+  if (params.channel) {
+    const requestedChannelId = await getChannelId(params.channel);
+    if (requestedChannelId !== channelId) {
+      throw new Error(
+        `Reporting data is always scoped to the authenticated channel.\n` +
+        `You requested channel "${params.channel}" (ID ${requestedChannelId}), ` +
+        `but you are authenticated as channel ID ${channelId}.\n` +
+        `Re-authenticate as the requested channel, or remove default.channel / omit --channel.`
+      );
+    }
   }
-
-  params.onProgress?.(`Resolving channel ID for ${channelHandle}...`);
-  const channelId = await getChannelId(channelHandle);
-  debug(`Using channel ID: ${channelId}`);
+  debug(`Using authenticated channel ID for cache namespace: ${channelId}`);
 
   // Ensure cache directory exists before attempting lock
   try {

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -34,7 +34,8 @@ import {
   readCachedReport,
   saveReportToCache,
 } from './cache';
-import { getChannelId, getAuthenticatedChannelId } from './youtube';
+import { getAuthenticatedChannelId, assertChannelMatchesAuthenticated } from './youtube';
+import { getConfigValue } from './config';
 import { acquireLock, getLockPath } from './lock';
 import { CacheIndexEntry } from '../types';
 
@@ -539,23 +540,15 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   // so the cache has to be keyed by the same channel or we silently write
   // the authed account's data under another channel's path (issue #153).
   //
-  // `params.channel` is accepted only for validation: today it can only name
-  // the authed channel (no multi-account auth-swap yet, see #153), so we
-  // resolve it and fail loudly on mismatch. That surfaces stale
-  // `default.channel` config or a wrong `--channel` instead of letting the
-  // bug recur.
+  // `params.channel` (and the `default.channel` config fallback) is accepted
+  // only for validation: today it can only name the authed channel (no
+  // multi-account auth-swap yet, see #153), so we validate any supplied
+  // value against the authed channel and fail loudly on mismatch. That
+  // surfaces stale `default.channel` config or a wrong `--channel` instead
+  // of letting the bug recur.
   const channelId = await getAuthenticatedChannelId();
-  if (params.channel) {
-    const requestedChannelId = await getChannelId(params.channel);
-    if (requestedChannelId !== channelId) {
-      throw new Error(
-        `Reporting data is always scoped to the authenticated channel.\n` +
-        `You requested channel "${params.channel}" (ID ${requestedChannelId}), ` +
-        `but you are authenticated as channel ID ${channelId}.\n` +
-        `Re-authenticate as the requested channel, or remove default.channel / omit --channel.`
-      );
-    }
-  }
+  const requestedChannel = params.channel || await getConfigValue('default.channel');
+  await assertChannelMatchesAuthenticated(requestedChannel, channelId);
   debug(`Using authenticated channel ID for cache namespace: ${channelId}`);
 
   // Ensure cache directory exists before attempting lock

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -85,6 +85,51 @@ async function getYouTubeClient(): Promise<youtube_v3.Youtube> {
 
 // ─── Channels ─────────────────────────────────────────────────────────────────
 
+// Per-process memoization for the authenticated channel ID. The Reporting API
+// always returns data for whoever's authenticated — there is no channel
+// parameter and `onBehalfOfContentOwner` is always undefined in this CLI — so
+// this is the authoritative cache-namespace key for any reporting data the
+// user can access. One OAuth context per process means a single lookup
+// suffices (issue #153).
+let authenticatedChannelIdCache: string | null = null;
+
+/**
+ * Resolve the channel ID of the currently authenticated YouTube account.
+ *
+ * `channels.list({ mine: true })` returns the channel that owns the OAuth
+ * token. Memoized per-process — re-fetching in the same run is a waste of
+ * the 1 quota unit the lookup costs. Used by the Reporting API flows
+ * (lib/reports.ts, commands/fetch-reports.ts) as the cache-namespace root,
+ * because Reporting API jobs/jobs.reports/downloads always operate on the
+ * authenticated channel regardless of any `--channel` flag.
+ *
+ * Throws if the credentials have no associated channel (e.g. brand account
+ * with no YouTube channel, or a misconfigured token). Better to fail loud
+ * than to silently mislabel cache files.
+ */
+export async function getAuthenticatedChannelId(): Promise<string> {
+  if (authenticatedChannelIdCache) {
+    return authenticatedChannelIdCache;
+  }
+  debug('Resolving authenticated channel ID via channels.list({ mine: true })');
+  const youtube = await getYouTubeClient();
+  const response = await youtube.channels.list({
+    part: ['id'],
+    mine: true,
+  });
+  const id = response.data.items?.[0]?.id;
+  if (!id) {
+    throw new Error(
+      'Could not resolve the authenticated YouTube channel. ' +
+      'Your OAuth credentials do not appear to be associated with a YouTube channel. ' +
+      'Run `staqan-yt auth` to re-authenticate.'
+    );
+  }
+  authenticatedChannelIdCache = id;
+  debug(`Authenticated channel ID: ${id}`);
+  return id;
+}
+
 /**
  * Get channel ID from handle or username.
  * Short-circuits if input is already a channel ID (UC + 22 chars).

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -85,13 +85,15 @@ async function getYouTubeClient(): Promise<youtube_v3.Youtube> {
 
 // ─── Channels ─────────────────────────────────────────────────────────────────
 
-// Per-process memoization for the authenticated channel ID. The Reporting API
+// In-flight memoization for the authenticated channel ID. The Reporting API
 // always returns data for whoever's authenticated — there is no channel
 // parameter and `onBehalfOfContentOwner` is always undefined in this CLI — so
 // this is the authoritative cache-namespace key for any reporting data the
-// user can access. One OAuth context per process means a single lookup
-// suffices (issue #153).
-let authenticatedChannelIdCache: string | null = null;
+// user can access. We cache the Promise (not just the resolved value) so
+// concurrent callers before the first resolve share one channels.list
+// request (CodeRabbit round 1 on #157, low-value perf nit). On failure the
+// promise is cleared so a later caller can retry the lookup.
+let authenticatedChannelIdPromise: Promise<string> | null = null;
 
 /**
  * Resolve the channel ID of the currently authenticated YouTube account.
@@ -108,26 +110,59 @@ let authenticatedChannelIdCache: string | null = null;
  * than to silently mislabel cache files.
  */
 export async function getAuthenticatedChannelId(): Promise<string> {
-  if (authenticatedChannelIdCache) {
-    return authenticatedChannelIdCache;
+  if (!authenticatedChannelIdPromise) {
+    authenticatedChannelIdPromise = (async () => {
+      debug('Resolving authenticated channel ID via channels.list({ mine: true })');
+      const youtube = await getYouTubeClient();
+      const response = await youtube.channels.list({
+        part: ['id'],
+        mine: true,
+      });
+      const id = response.data.items?.[0]?.id;
+      if (!id) {
+        throw new Error(
+          'Could not resolve the authenticated YouTube channel. ' +
+          'Your OAuth credentials do not appear to be associated with a YouTube channel. ' +
+          'Run `staqan-yt auth` to re-authenticate.'
+        );
+      }
+      debug(`Authenticated channel ID: ${id}`);
+      return id;
+    })().catch((err) => {
+      // Allow a later caller to retry the lookup instead of being stuck on
+      // a permanently-rejected promise.
+      authenticatedChannelIdPromise = null;
+      throw err;
+    });
   }
-  debug('Resolving authenticated channel ID via channels.list({ mine: true })');
-  const youtube = await getYouTubeClient();
-  const response = await youtube.channels.list({
-    part: ['id'],
-    mine: true,
-  });
-  const id = response.data.items?.[0]?.id;
-  if (!id) {
+  return authenticatedChannelIdPromise;
+}
+
+/**
+ * Validate that a user-supplied channel reference (handle or UC... ID)
+ * resolves to the same channel as the authenticated account. Reporting API
+ * flows use this so a stale `default.channel` config or a wrong `--channel`
+ * fails loudly instead of silently writing the authed account's data under
+ * another channel's cache path (issue #153).
+ *
+ * `requestedChannel` may be a `@handle`, a `UC...` ID, or a legacy username
+ * — `getChannelId` normalizes all of them. Resolves silently when the input
+ * is empty/undefined (no validation requested).
+ */
+export async function assertChannelMatchesAuthenticated(
+  requestedChannel: string | undefined,
+  authenticatedChannelId: string,
+): Promise<void> {
+  if (!requestedChannel) return;
+  const requestedChannelId = await getChannelId(requestedChannel);
+  if (requestedChannelId !== authenticatedChannelId) {
     throw new Error(
-      'Could not resolve the authenticated YouTube channel. ' +
-      'Your OAuth credentials do not appear to be associated with a YouTube channel. ' +
-      'Run `staqan-yt auth` to re-authenticate.'
+      `Reporting data is always scoped to the authenticated channel.\n` +
+      `You requested channel "${requestedChannel}" (ID ${requestedChannelId}), ` +
+      `but you are authenticated as channel ID ${authenticatedChannelId}.\n` +
+      `Re-authenticate as the requested channel, or remove default.channel / omit --channel.`
     );
   }
-  authenticatedChannelIdCache = id;
-  debug(`Authenticated channel ID: ${id}`);
-  return id;
 }
 
 /**


### PR DESCRIPTION
## Value proposition

The Reporting API has no channel parameter — `jobs.list`, `jobs.reports.list`, `jobs.create`, and `downloadReport` all operate on the authenticated account (`onBehalfOfContentOwner` is always undefined in this CLI). The previous `fetchReportData` / `fetch-reports` flow resolved `--channel` / `default.channel` only to namespace the cache directory, so a wrong handle silently wrote the **authenticated** account's data under the **requested** channel's path. Any `--channel` that didn't match the authed account would poison that cache namespace.

This fix aligns the cache namespace with the actual data source: the authenticated channel. `--channel` / `default.channel` is kept as a validation hook (resolves the handle/ID and fails loudly on mismatch), reserved for future multi-account auth-swap where it will become the credential-selector parameter. Today it surfaces stale `default.channel` config or wrong handles as clear errors instead of silent mislabeling.

## What changed

- **`lib/youtube.ts`** — new `getAuthenticatedChannelId()`: one `channels.list({ part: ['id'], mine: true })` per process, memoized. Single auth context per process → one lookup suffices.
- **`lib/reports.ts:fetchReportData`** — cache namespace = authed channel ID. If `params.channel` is supplied, resolve via `getChannelId` and throw a clear error on mismatch. Dropped the unreachable "No channel specified" error since the authed channel is always available.
- **`commands/fetch-reports.ts`** — same pattern: resolve authed channel for cache namespace, validate `--channel` / `default.channel` against it.
- **`commands/fetch-reports.ts`** — drop now-unused `channelHandle` from `loadCacheIndex(...)` call site (the second `channelHandle?` arg of `loadCacheIndex` is still optional).
- **`docs/commands/reporting-api.md`** — update `--channel` description and the "Required: set default.channel" note for both `get-report-data` and `fetch-reports`. Cache is now keyed by the authenticated channel by construction.

## Why validate instead of ignore

A pure "drop the parameter" approach would let `default.channel` config rot silently until users notice mislabeled data. Validation surfaces the mismatch at the moment of misuse, and the validation hook is exactly what future multi-account auth-swap will need anyway — today's `mine:true` check is tomorrow's "did the swap land on the right channel?" check.

## Cost

- `+1 quota unit` per Reporting command run for `channels.list({ mine: true })`. Memoized per process, so subsequent calls in the same run (e.g. a command that calls `fetchReportData` more than once) cost nothing. Acceptable trade-off for closing a silent data-corruption bug.

## Test plan

- [x] `bun run type-check` — clean
- [x] `bun run lint` — clean (4 pre-existing `any` warnings, unrelated)
- [x] `bun run build` — clean
- [ ] Manual verification of mismatch path: set `default.channel` to a different valid handle and confirm `fetch-reports` / `get-report-data` exit with a clear error rather than silently using the wrong cache path.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reporting data and caches are now consistently associated with the currently authenticated channel.
  - Added validation to detect when a requested channel does not match the authenticated channel.

- **Bug Fixes**
  - Prevented authenticated data from being stored or retrieved under an incorrect channel.

- **Documentation**
  - Clarified channel option behavior and explained authenticated-channel cache scoping.
  - Documented that channel mismatches may result in an explicit error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->