### PR TITLE
fix(#154,#155): serve reports from cache when API is empty, expose coverage gaps

### DIFF
--- a/commands/get-report-data.ts
+++ b/commands/get-report-data.ts
@@ -68,7 +68,7 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
       return;
     }
 
-    const { rows: filteredData, cachedReports, fetchedReports } = result;
+    const { rows: filteredData, cachedReports, fetchedReports, uncoveredRanges } = result;
     const { startDate: requestedStart, endDate: requestedEnd } = result.requestedRange;
     const { startDate: adjustedStart, endDate: adjustedEnd } = result.adjustedRange;
     const { startDate: effectiveMinDate, endDate: effectiveMaxDate } = result.availableRange;
@@ -139,56 +139,45 @@ async function getReportDataCommand(options: ReportDataOptions): Promise<void> {
         break;
     }
 
-    // Warn about missing dates in the returned data
-    if (filteredData.length > 0 && !options.videoId) {
-      const returnedDates = new Set(filteredData.map(row => row.date));
-      // Generate expected date range
-      const rangeStart = new Date(adjustedStart);
-      const rangeEnd = new Date(adjustedEnd);
-      const expectedDates: string[] = [];
-      const current = new Date(rangeStart);
-      while (current <= rangeEnd) {
-        expectedDates.push(current.toISOString().split('T')[0].replace(/-/g, ''));
-        current.setDate(current.getDate() + 1);
-      }
-      const missingDates = expectedDates.filter(d => !returnedDates.has(d));
-      if (missingDates.length > 0) {
-        // Format missing dates for display (group consecutive only)
-        const formattedMissing = missingDates.map(d => `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`);
-        const gaps: { start: string; end: string }[] = [];
-        let gapStart = formattedMissing[0];
-        let gapEnd = formattedMissing[0];
-        for (let i = 1; i < formattedMissing.length; i++) {
-          const prev = new Date(formattedMissing[i - 1]);
-          const curr = new Date(formattedMissing[i]);
-          const diffDays = Math.round((curr.getTime() - prev.getTime()) / (24 * 60 * 60 * 1000));
-          if (diffDays === 1) {
-            gapEnd = formattedMissing[i];
-          } else {
-            gaps.push({ start: gapStart, end: gapEnd });
-            gapStart = formattedMissing[i];
-            gapEnd = formattedMissing[i];
-          }
-        }
-        gaps.push({ start: gapStart, end: gapEnd });
+    // Warn about coverage gaps.
+    //
+    // Read from result.uncoveredRanges (computed in lib/reports.ts) rather
+    // than re-deriving gaps from the returned row dates. The old local
+    // computation treated any day without rows as missing data, which
+    // false-flagged quiet days: a report can legitimately cover a date and
+    // carry no rows for it because nothing happened. uncoveredRanges measures
+    // what the message actually claims, which is that no source covered those
+    // dates. Sharing it with the MCP surface also keeps the two consistent
+    // (issue #155).
+    //
+    // Skipped under --video-id: one video's absence on a date says nothing
+    // about whether the channel's data covers it.
+    const spanDays = (from: string, to: string) =>
+      Math.round((new Date(to).getTime() - new Date(from).getTime()) / (24 * 60 * 60 * 1000)) + 1;
 
-        process.stderr.write('\n');
-        process.stderr.write(chalk.yellow('⚠️  Incomplete Data:\n'));
-        process.stderr.write(chalk.gray(`  Requested: ${adjustedStart} to ${adjustedEnd} (${expectedDates.length} days)\n`));
-        process.stderr.write(chalk.gray(`  Returned:  ${returnedDates.size} of ${expectedDates.length} days\n`));
-        process.stderr.write(chalk.gray('  Missing:\n'));
-        for (const gap of gaps) {
-          const days = Math.round((new Date(gap.end).getTime() - new Date(gap.start).getTime()) / (24 * 60 * 60 * 1000)) + 1;
-          if (gap.start === gap.end) {
-            process.stderr.write(chalk.red(`    ${gap.start}\n`));
-          } else {
-            process.stderr.write(chalk.red(`    ${gap.start} → ${gap.end} (${days} days)\n`));
-          }
+    if (uncoveredRanges.length > 0 && !options.videoId) {
+      const totalDays = spanDays(adjustedStart, adjustedEnd);
+      const missingDays = uncoveredRanges.reduce(
+        (sum, gap) => sum + spanDays(gap.startDate, gap.endDate),
+        0
+      );
+
+      process.stderr.write('\n');
+      process.stderr.write(chalk.yellow('⚠️  Incomplete Data:\n'));
+      process.stderr.write(chalk.gray(`  Requested: ${adjustedStart} to ${adjustedEnd} (${totalDays} days)\n`));
+      process.stderr.write(chalk.gray(`  Covered:   ${totalDays - missingDays} of ${totalDays} days\n`));
+      process.stderr.write(chalk.gray('  Missing:\n'));
+      for (const gap of uncoveredRanges) {
+        const days = spanDays(gap.startDate, gap.endDate);
+        if (gap.startDate === gap.endDate) {
+          process.stderr.write(chalk.red(`    ${gap.startDate}\n`));
+        } else {
+          process.stderr.write(chalk.red(`    ${gap.startDate} → ${gap.endDate} (${days} days)\n`));
         }
-        process.stderr.write(chalk.yellow('  Tip:') + ' Data may have expired from YouTube or was never archived.\n');
-        process.stderr.write(chalk.gray('       ') + 'Run ' + chalk.cyan(`staqan-yt fetch-reports --type=${options.type}`) + ' to archive available data.\n');
-        process.stderr.write('\n');
       }
+      process.stderr.write(chalk.yellow('  Tip:') + ' Data may have expired from YouTube or was never archived.\n');
+      process.stderr.write(chalk.gray('       ') + 'Run ' + chalk.cyan(`staqan-yt fetch-reports --type=${options.type}`) + ' to archive available data.\n');
+      process.stderr.write('\n');
     }
 
     // Show expiration warning for the reports used

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -461,7 +461,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_report_data',
-    description: 'Get YouTube Reporting API report data including thumbnail impressions, CTR, and other metrics. IMPORTANT: Thumbnail CTR data is ONLY available through the Reporting API, not regular analytics.',
+    description: 'Get YouTube Reporting API report data including thumbnail impressions, CTR, and other metrics. IMPORTANT: Thumbnail CTR data is ONLY available through the Reporting API, not regular analytics. Check `uncoveredRanges` in the result before treating the rows as complete: `availableRange` is only an outer bound, and any dates listed there had no source data (expired from the API and never archived locally).',
     inputSchema: {
       type: 'object',
       properties: {

--- a/docs/commands/reporting-api.md
+++ b/docs/commands/reporting-api.md
@@ -240,6 +240,15 @@ The cache is keyed by the authenticated channel ID, not by `--channel` / `defaul
 - 1-2 day delay from actual data
 - Use `--start-date` and `--end-date` to control range
 
+### Coverage and gaps
+
+YouTube expires reports from the API after 30-60 days, while `fetch-reports` keeps them locally forever. The two sources are consulted together:
+
+- **The local archive is used even when the API has nothing left.** An old job whose reports have all expired still serves from cache rather than reporting "no reports yet".
+- **Gaps are reported explicitly.** The date range shown as available is an outer bound across both sources, so when they cover disjoint periods (archive holds January, API holds June) the span between them is a hole, not data. Any such holes are listed under an `Incomplete Data` warning on stderr, and exposed to MCP consumers as `uncoveredRanges` in the structured result.
+
+A date that is covered but simply had no activity is not a gap. Only dates that no source could supply are reported.
+
 ---
 
 ## fetch-reports

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -396,7 +396,17 @@ export function computeDateRangeOverlap(
 }
 
 /**
- * Merge overlapping/adjacent date ranges
+ * Merge overlapping/adjacent date ranges.
+ *
+ * Returns fresh objects and never mutates the caller's input. `[...ranges]`
+ * is only a shallow copy, so the previous implementation wrote through to the
+ * caller's own range objects: it seeded `merged` with `sorted[0]` and then
+ * extended `last.end` in place. `analyzeCacheCoverage` hit this
+ * directly: it passes the same `{start,end}` objects to `findDateGaps` that
+ * it afterwards classifies as fully/partially covered, so merging two
+ * adjacent cached reports silently widened the first report's end date and
+ * mis-classified its coverage (loading the same cached report twice and
+ * inflating the reported cached-report count).
  */
 export function mergeDateRanges(
   ranges: { start: string; end: string }[]
@@ -407,7 +417,7 @@ export function mergeDateRanges(
     new Date(a.start).getTime() - new Date(b.start).getTime()
   );
 
-  const merged: { start: string; end: string }[] = [sorted[0]];
+  const merged: { start: string; end: string }[] = [{ ...sorted[0] }];
 
   for (let i = 1; i < sorted.length; i++) {
     const current = sorted[i];
@@ -422,7 +432,7 @@ export function mergeDateRanges(
         last.end = current.end;
       }
     } else {
-      merged.push(current);
+      merged.push({ ...current });
     }
   }
 
@@ -472,7 +482,7 @@ export function findDateGaps(
 /**
  * Convert YYYYMMDD string to YYYY-MM-DD for consistent date handling
  */
-function normalizeDate(d: string): string {
+export function normalizeDate(d: string): string {
   if (/^\d{4}-\d{2}-\d{2}$/.test(d)) return d;
   if (/^\d{4}\d{2}\d{2}$/.test(d)) return `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`;
   // Handle ISO timestamps
@@ -485,7 +495,7 @@ function normalizeDate(d: string): string {
  * We use these instead of the API report time windows for gap analysis,
  * because API windows span 2 calendar days and overlap with adjacent reports.
  */
-async function getActualDates(
+export async function getActualDates(
   entry: CacheIndexEntry,
   channelId: string
 ): Promise<{ start: string; end: string }> {

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -29,7 +29,9 @@ import {
   analyzeCacheCoverage,
   ensureCacheDir,
   findCachedReports,
-  loadReportMetadata,
+  findDateGaps,
+  getActualDates,
+  normalizeDate,
   parseCsvAndExtractRange,
   readCachedReport,
   saveReportToCache,
@@ -38,6 +40,15 @@ import { getAuthenticatedChannelId, assertChannelMatchesAuthenticated } from './
 import { getConfigValue } from './config';
 import { acquireLock, getLockPath } from './lock';
 import { CacheIndexEntry } from '../types';
+
+/**
+ * Bounds for an unbounded local-archive scan. Used when the Reporting API
+ * lists no reports and the archive itself has to define what's available, so
+ * there is no API window to anchor a range to (issue #154). YouTube's
+ * Reporting API predates neither bound, so this is effectively "everything".
+ */
+const ARCHIVE_SCAN_START = '1970-01-01';
+const ARCHIVE_SCAN_END = '9999-12-31';
 
 /**
  * A minimal slice of `youtube.reports.jobs.list` report shape — both call
@@ -505,7 +516,11 @@ export type ReportDataResult =
       jobCreateTime: string;
       readyAt: string;
     }
-  /** Job exists but has produced no reports yet (within the 48h window). */
+  /**
+   * Job exists, the API has produced no reports yet, AND the local archive is
+   * empty. Only returned when neither source can supply data. An old job
+   * whose API reports have expired still serves from cache (issue #154).
+   */
   | {
       status: 'no-reports-yet';
       jobId: string;
@@ -520,7 +535,22 @@ export type ReportDataResult =
       requestedRange: { startDate: string; endDate: string };
       /** Requested range clamped to what the API + local cache can cover. */
       adjustedRange: { startDate: string; endDate: string };
+      /**
+       * Outer bounds of available data across the API and the local cache.
+       *
+       * These are bounds, NOT a guarantee of continuous coverage: when the two
+       * sources are disjoint (cache holds January, API holds June) the range
+       * spans both islands. Read `uncoveredRanges` to find the holes inside it
+       * (issue #155).
+       */
       availableRange: { startDate: string; endDate: string };
+      /**
+       * Sub-ranges of `adjustedRange` that no source could cover, derived from
+       * the actual data windows of the cached and freshly-downloaded reports.
+       * Empty when coverage is continuous. Both the CLI warning and MCP
+       * consumers read this, so gaps are reported from one source of truth.
+       */
+      uncoveredRanges: { startDate: string; endDate: string }[];
       cachedReports: CacheIndexEntry[];
       fetchedReports: FetchedReportInfo[];
     };
@@ -632,8 +662,19 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   }
   let reports = [...newestByWindow.values()];
 
-  if (reports.length === 0) {
-    // Job exists but no reports yet (within 48h window)
+  // The API expires reports after 30-60 days, but `fetch-reports` keeps a
+  // local archive that outlives them. An empty API listing therefore does NOT
+  // mean "no data". Scan the archive before giving up, and only report
+  // no-reports-yet when neither source holds anything (issue #154).
+  //
+  // The scan is unbounded because at this point there is no API window to
+  // anchor a range to: the archive itself defines what is available.
+  const archivedReports = reports.length === 0
+    ? await findCachedReports(channelId, params.type, ARCHIVE_SCAN_START, ARCHIVE_SCAN_END)
+    : [];
+
+  if (reports.length === 0 && archivedReports.length === 0) {
+    // Genuinely nothing anywhere: the job is new and still inside its 48h window.
     const readyAt = new Date(new Date(jobCreateTime).getTime() + 48 * 60 * 60 * 1000);
     return {
       status: 'no-reports-yet',
@@ -643,16 +684,34 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     };
   }
 
+  if (reports.length === 0) {
+    params.onProgress?.(
+      `No reports available from the API; serving ${archivedReports.length} archived report(s) from cache`
+    );
+    debug(`API returned no reports for ${params.type}; falling back to ${archivedReports.length} cached report(s)`);
+  }
+
   // Step 3: Validate date range (API returns timestamps, compare date portions
   // only). Computed over all reports rather than relying on response order.
-  const minDate = reports.reduce((min, r) => {
-    const d = r.startTime.split('T')[0];
-    return d < min ? d : min;
-  }, '9999-99-99');
-  const maxDate = reports.reduce((max, r) => {
-    const d = r.endTime.split('T')[0];
-    return d > max ? d : max;
-  }, '');
+  // With an expired-out API listing the bounds come from the archive instead.
+  let minDate: string;
+  let maxDate: string;
+  if (reports.length > 0) {
+    minDate = reports.reduce((min, r) => {
+      const d = r.startTime.split('T')[0];
+      return d < min ? d : min;
+    }, '9999-99-99');
+    maxDate = reports.reduce((max, r) => {
+      const d = r.endTime.split('T')[0];
+      return d > max ? d : max;
+    }, '');
+  } else {
+    const archivedDates = await Promise.all(
+      archivedReports.map((entry) => getActualDates(entry, channelId))
+    );
+    minDate = archivedDates.reduce((min, d) => (d.start < min ? d.start : min), '9999-99-99');
+    maxDate = archivedDates.reduce((max, d) => (d.end > max ? d.end : max), '');
+  }
 
   const requestedStart = params.startDate || minDate;
   const requestedEnd = params.endDate || maxDate;
@@ -676,23 +735,14 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   let effectiveMinDate = minDate;
   let effectiveMaxDate = maxDate;
   if (cacheEntries.length > 0) {
+    // getActualDates applies the same metadata-first, API-window-fallback rule
+    // the cache layer uses for coverage analysis. Previously reimplemented
+    // inline here, which risked the two drifting apart.
     const cacheDates = await Promise.all(
-      cacheEntries.map(async (e) => {
-        const meta = await loadReportMetadata(channelId, e.reportId, params.type);
-        if (meta?.startTimeActual) {
-          const s = meta.startTimeActual;
-          return {
-            min: `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
-            max: meta.endTimeActual
-              ? `${meta.endTimeActual.slice(0, 4)}-${meta.endTimeActual.slice(4, 6)}-${meta.endTimeActual.slice(6, 8)}`
-              : `${s.slice(0, 4)}-${s.slice(4, 6)}-${s.slice(6, 8)}`,
-          };
-        }
-        return { min: e.startTime.split('T')[0], max: e.endTime.split('T')[0] };
-      })
+      cacheEntries.map((entry) => getActualDates(entry, channelId))
     );
-    const cacheEarliest = cacheDates.reduce((min, d) => d.min < min ? d.min : min, '9999-99-99');
-    const cacheLatest = cacheDates.reduce((max, d) => d.max > max ? d.max : max, '');
+    const cacheEarliest = cacheDates.reduce((min, d) => d.start < min ? d.start : min, '9999-99-99');
+    const cacheLatest = cacheDates.reduce((max, d) => d.end > max ? d.end : max, '');
     if (cacheEarliest < effectiveMinDate) effectiveMinDate = cacheEarliest;
     if (cacheLatest > effectiveMaxDate) effectiveMaxDate = cacheLatest;
   }
@@ -902,6 +952,25 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     }
   }
 
+  // Coverage gaps (issue #155). `availableRange` is only an outer bound: when
+  // the cache and the API cover disjoint islands (cache holds January, API
+  // holds June) it spans both and implies a continuity that doesn't exist.
+  // Derive the real holes from the actual data windows of the reports that
+  // contributed rows (the cached ones that were read, plus the freshly
+  // downloaded ones), so the CLI warning and MCP consumers read one signal
+  // instead of each inferring gaps their own way.
+  const cachedCoveredRanges = await Promise.all(
+    cachedReports.map((entry) => getActualDates(entry, channelId))
+  );
+  const coveredRanges = [
+    ...cachedCoveredRanges,
+    // fetchedWindows carries YYYYMMDD row dates; the gap helpers work in
+    // YYYY-MM-DD.
+    ...fetchedWindows.map((w) => ({ start: normalizeDate(w.min), end: normalizeDate(w.max) })),
+  ];
+  const uncoveredRanges = findDateGaps(coveredRanges, adjustedStart, adjustedEnd)
+    .map((gap) => ({ startDate: gap.start, endDate: gap.end }));
+
   return {
     status: 'ok',
     jobId,
@@ -910,6 +979,7 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     requestedRange: { startDate: requestedStart, endDate: requestedEnd },
     adjustedRange: { startDate: adjustedStart, endDate: adjustedEnd },
     availableRange: { startDate: effectiveMinDate, endDate: effectiveMaxDate },
+    uncoveredRanges,
     cachedReports,
     fetchedReports: reportsToFetch,
   };

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -778,21 +778,34 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   const coverage = await analyzeCacheCoverage(channelId, params.type, adjustedStart, adjustedEnd);
   debug('Cache coverage:', coverage);
 
-  // Step 6: Load cached data
+  // Step 6: Load every cached report whose window overlaps the adjusted range.
+  //
+  // NOT driven by `coverage.fullyCovered`: analyzeCacheCoverage calls a report
+  // "fully covered" only when the report sits entirely inside the requested
+  // range, so the reverse case (one archived report spanning a narrower
+  // request, e.g. a Jan 1-31 report for a Jan 10-20 query) is classified
+  // partial and would never be loaded. That returned zero rows while claiming
+  // the range was uncovered, which the #154 archive-only path made reachable
+  // with no API reports to fall back on. Rows are clamped to the adjusted
+  // range further down, so loading a wider report is safe.
+  //
+  // `coverage` is still used below to decide which API reports to download.
   const cachedData: Record<string, string>[] = [];
   const cachedReports: CacheIndexEntry[] = [];
 
-  for (const range of coverage.fullyCovered) {
-    const [start, end] = range.split('/');
-    const cached = await findCachedReports(channelId, params.type, start, end);
+  const overlappingCached = await findCachedReports(channelId, params.type, adjustedStart, adjustedEnd);
+  const loadedReportIds = new Set<string>();
+  for (const cachedReport of overlappingCached) {
+    // findCachedReports can return the same report once per overlapping
+    // window; loading it twice would duplicate rows and inflate the count.
+    if (loadedReportIds.has(cachedReport.reportId)) continue;
+    loadedReportIds.add(cachedReport.reportId);
 
-    for (const cachedReport of cached) {
-      const reportData = await readCachedReport(channelId, cachedReport.reportId, params.type);
-      if (reportData) {
-        cachedData.push(...reportData.data);
-        cachedReports.push(cachedReport);
-        debug(`Loaded from cache: ${cachedReport.reportId}`);
-      }
+    const reportData = await readCachedReport(channelId, cachedReport.reportId, params.type);
+    if (reportData) {
+      cachedData.push(...reportData.data);
+      cachedReports.push(cachedReport);
+      debug(`Loaded from cache: ${cachedReport.reportId}`);
     }
   }
 
@@ -839,9 +852,19 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
 
   const jobCreated = new Date(jobCreateTime);
   const fetchedData: Record<string, string>[] = [];
-  // Actual data windows (YYYYMMDD row dates) of the fresh downloads — used to
-  // drop overlapping cached rows below.
+  // Actual data windows (YYYYMMDD row dates) of the fresh downloads, used to
+  // drop overlapping cached rows below. Only populated for downloads that
+  // actually carried rows: an empty download must not supersede real cached
+  // data for the same window.
   const fetchedWindows: { min: string; max: string }[] = [];
+  // Windows the downloads are known to COVER (YYYYMMDD), which is a different
+  // question from which rows they carried. A report can legitimately cover a
+  // period and contain zero rows because nothing happened, and treating that
+  // as absent coverage would make uncoveredRanges report a phantom gap, the
+  // exact false positive #155 exists to remove. Falls back to the report's
+  // own window, mirroring getActualDates' fallback for a cached entry whose
+  // metadata has no parsed row dates.
+  const fetchedCoverage: { min: string; max: string }[] = [];
 
   for (let i = 0; i < reportsToFetch.length; i++) {
     const report = reportsToFetch[i];
@@ -906,6 +929,15 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
     fetchedData.push(...data);
     if (dataMinDate && dataMaxDate) {
       fetchedWindows.push({ min: dataMinDate, max: dataMaxDate });
+      fetchedCoverage.push({ min: dataMinDate, max: dataMaxDate });
+    } else {
+      // Downloaded successfully but parsed no row dates (empty report). It
+      // still covers its window, so record that for gap analysis only.
+      fetchedCoverage.push({
+        min: report.startTime.split('T')[0].replace(/-/g, ''),
+        max: report.endTime.split('T')[0].replace(/-/g, ''),
+      });
+      debug(`Report ${report.id} had no row dates; recording its API window as covered`);
     }
 
     debug(`Downloaded: ${report.startTime} to ${report.endTime}`);
@@ -964,9 +996,9 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   );
   const coveredRanges = [
     ...cachedCoveredRanges,
-    // fetchedWindows carries YYYYMMDD row dates; the gap helpers work in
+    // fetchedCoverage carries YYYYMMDD dates; the gap helpers work in
     // YYYY-MM-DD.
-    ...fetchedWindows.map((w) => ({ start: normalizeDate(w.min), end: normalizeDate(w.max) })),
+    ...fetchedCoverage.map((w) => ({ start: normalizeDate(w.min), end: normalizeDate(w.max) })),
   ];
   const uncoveredRanges = findDateGaps(coveredRanges, adjustedStart, adjustedEnd)
     .map((gap) => ({ startDate: gap.start, endDate: gap.end }));

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  computeDateRangeOverlap,
+  findDateGaps,
+  mergeDateRanges,
+  normalizeDate,
+} from '../lib/cache';
+
+describe('normalizeDate', () => {
+  it('passes YYYY-MM-DD through unchanged', () => {
+    expect(normalizeDate('2026-03-04')).toBe('2026-03-04');
+  });
+
+  it('converts the YYYYMMDD row-date format used in report CSVs', () => {
+    expect(normalizeDate('20260304')).toBe('2026-03-04');
+  });
+
+  it('truncates ISO timestamps to their date portion', () => {
+    expect(normalizeDate('2026-03-04T00:00:00Z')).toBe('2026-03-04');
+  });
+});
+
+describe('mergeDateRanges', () => {
+  it('returns an empty array for no input', () => {
+    expect(mergeDateRanges([])).toEqual([]);
+  });
+
+  it('merges adjacent ranges (gapless across the day boundary)', () => {
+    expect(mergeDateRanges([
+      { start: '2026-01-01', end: '2026-01-10' },
+      { start: '2026-01-11', end: '2026-01-20' },
+    ])).toEqual([{ start: '2026-01-01', end: '2026-01-20' }]);
+  });
+
+  it('merges overlapping ranges', () => {
+    expect(mergeDateRanges([
+      { start: '2026-01-01', end: '2026-01-15' },
+      { start: '2026-01-10', end: '2026-01-20' },
+    ])).toEqual([{ start: '2026-01-01', end: '2026-01-20' }]);
+  });
+
+  it('keeps disjoint ranges separate', () => {
+    expect(mergeDateRanges([
+      { start: '2026-01-01', end: '2026-01-10' },
+      { start: '2026-06-01', end: '2026-06-10' },
+    ])).toEqual([
+      { start: '2026-01-01', end: '2026-01-10' },
+      { start: '2026-06-01', end: '2026-06-10' },
+    ]);
+  });
+
+  it('sorts unordered input before merging', () => {
+    expect(mergeDateRanges([
+      { start: '2026-06-01', end: '2026-06-10' },
+      { start: '2026-01-01', end: '2026-01-10' },
+    ])).toEqual([
+      { start: '2026-01-01', end: '2026-01-10' },
+      { start: '2026-06-01', end: '2026-06-10' },
+    ]);
+  });
+
+  it('does not mutate the caller\'s range objects', () => {
+    // Regression: `[...ranges]` is a shallow copy, so seeding the accumulator
+    // with `sorted[0]` and extending `last.end` in place wrote through to the
+    // caller. analyzeCacheCoverage passes the same objects to findDateGaps
+    // that it afterwards classifies, so this silently widened a cached
+    // report's end date and mis-classified its coverage.
+    const ranges = [
+      { start: '2026-01-01', end: '2026-01-10' },
+      { start: '2026-01-11', end: '2026-01-20' },
+    ];
+    const before = structuredClone(ranges);
+    mergeDateRanges(ranges);
+    expect(ranges).toEqual(before);
+  });
+});
+
+describe('findDateGaps', () => {
+  it('reports the whole window when nothing is covered', () => {
+    expect(findDateGaps([], '2026-01-01', '2026-01-31')).toEqual([
+      { start: '2026-01-01', end: '2026-01-31' },
+    ]);
+  });
+
+  it('reports no gaps when coverage spans the window', () => {
+    expect(findDateGaps(
+      [{ start: '2026-01-01', end: '2026-01-31' }],
+      '2026-01-01',
+      '2026-01-31',
+    )).toEqual([]);
+  });
+
+  it('finds an interior gap between disjoint coverage islands', () => {
+    // The #155 case: cache holds January, API holds June. The outer bounds
+    // look continuous, but February through May is missing.
+    expect(findDateGaps(
+      [
+        { start: '2026-01-01', end: '2026-01-31' },
+        { start: '2026-06-01', end: '2026-06-30' },
+      ],
+      '2026-01-01',
+      '2026-06-30',
+    )).toEqual([{ start: '2026-02-01', end: '2026-05-31' }]);
+  });
+
+  it('finds leading and trailing gaps', () => {
+    expect(findDateGaps(
+      [{ start: '2026-01-10', end: '2026-01-20' }],
+      '2026-01-01',
+      '2026-01-31',
+    )).toEqual([
+      { start: '2026-01-01', end: '2026-01-09' },
+      { start: '2026-01-21', end: '2026-01-31' },
+    ]);
+  });
+
+  it('treats adjacent coverage as gapless', () => {
+    expect(findDateGaps(
+      [
+        { start: '2026-01-01', end: '2026-01-10' },
+        { start: '2026-01-11', end: '2026-01-31' },
+      ],
+      '2026-01-01',
+      '2026-01-31',
+    )).toEqual([]);
+  });
+
+  it('finds a single-day gap', () => {
+    expect(findDateGaps(
+      [
+        { start: '2026-01-01', end: '2026-01-10' },
+        { start: '2026-01-12', end: '2026-01-31' },
+      ],
+      '2026-01-01',
+      '2026-01-31',
+    )).toEqual([{ start: '2026-01-11', end: '2026-01-11' }]);
+  });
+
+  it('ignores coverage entirely outside the requested window', () => {
+    expect(findDateGaps(
+      [{ start: '2025-01-01', end: '2025-12-31' }],
+      '2026-01-01',
+      '2026-01-31',
+    )).toEqual([{ start: '2026-01-01', end: '2026-01-31' }]);
+  });
+});
+
+describe('computeDateRangeOverlap', () => {
+  it('returns the intersection when ranges overlap', () => {
+    expect(computeDateRangeOverlap(
+      '2026-01-01', '2026-01-20',
+      '2026-01-10', '2026-01-31',
+    )).toEqual({ start: '2026-01-10', end: '2026-01-20' });
+  });
+
+  it('returns null when ranges are disjoint', () => {
+    expect(computeDateRangeOverlap(
+      '2026-01-01', '2026-01-10',
+      '2026-02-01', '2026-02-10',
+    )).toBeNull();
+  });
+
+  it('returns a single day when ranges touch at one date', () => {
+    expect(computeDateRangeOverlap(
+      '2026-01-01', '2026-01-10',
+      '2026-01-10', '2026-01-20',
+    )).toEqual({ start: '2026-01-10', end: '2026-01-10' });
+  });
+});


### PR DESCRIPTION
Addresses #154 and #155, the two remaining spin-offs from the #102 extraction. Both live in `fetchReportData`, which is why they ship together. No `Closes:` keyword: GitHub only auto-closes one issue per keyword reliably, so both stay open for manual closing.

## Value proposition

The local archive exists so report data survives YouTube expiring it after 30-60 days. Both bugs undermined that: one made the archive unreachable, the other made incomplete data look complete. Together they meant a user could be told "no data" while holding it, or handed a range with silent holes in it.

## #154: the archive was never consulted before giving up

The zero-reports early return fired the moment the API listed nothing, forty lines above the first `findCachedReports` call:

```ts
if (reports.length === 0) {
  return { status: 'no-reports-yet', ... };   // cache never touched
}
```

For an old job whose API reports have all expired, `fetch-reports` has the data on disk and the command still said "wait 48 hours". The `readyAt` it returned was `jobCreateTime + 48h`, which for such a job is **a timestamp in the past**, so the CLI printed "0 hours remaining" and MCP serialized a stale date.

Now an empty API listing triggers an unbounded archive scan, and `no-reports-yet` is returned only when neither source holds anything. When the API is empty but the archive is not, date bounds are derived from the archive and the run serves entirely from cache.

## #155: disjoint coverage was reported as continuous

`availableRange` is a plain min/max across API and cache. Cache holding January and API holding June produced `{2026-01-01, 2026-06-30}` with `status: 'ok'` and no indication that February through May is a hole.

Added `uncoveredRanges` to the `ok` result, derived from the actual data windows of the reports that actually contributed rows. `availableRange` is now documented as an outer bound, with `uncoveredRanges` as the honest signal.

The CLI's `Incomplete Data` warning now reads that field instead of re-deriving gaps from returned row dates. That old approach had a false-positive: a report can legitimately cover a date and carry no rows because nothing happened that day, and those quiet days were reported as missing data under a message claiming the data "may have expired". The new computation measures what the message actually says, and MCP consumers get the same signal instead of nothing.

## Also fixed: aliasing bug in `mergeDateRanges`

Found while building on it. `[...ranges]` is a shallow copy, so seeding the accumulator with `sorted[0]` and extending `last.end` in place wrote through to the caller's own objects:

```
input before: [{start: 2026-01-01, end: 2026-01-10}, {start: 2026-01-11, end: 2026-01-20}]
input after : [{start: 2026-01-01, end: 2026-01-20}, {start: 2026-01-11, end: 2026-01-20}]
```

`analyzeCacheCoverage` passes the same `{start,end}` objects to `findDateGaps` that it afterwards classifies as fully/partially covered. Merging two adjacent cached reports therefore widened the first report's end date before classification, which pushed a too-wide range into `fullyCovered`, loaded the same cached report twice, and inflated the "Retrieved N cached report(s)" count plus its expiration notices. Row data itself was spared by the existing byte-identical dedup.

## Consolidation

`reports.ts` had reimplemented cache.ts's metadata-first date resolution inline. Both now call the exported `getActualDates`, so the two cannot drift.

## Test plan

- [x] `bun run type-check` clean
- [x] `bun run lint` clean (4 pre-existing `any` warnings, untouched)
- [x] `bun run build` clean
- [x] `bun test` 87 pass / 0 fail (was 68; +19 new in `tests/cache.test.ts`)
- [x] **Regression test verified by reverting the fix**: `mergeDateRanges > does not mutate the caller's range objects` fails without it, passes with it
- [x] New tests cover the #155 disjoint-island case, leading/trailing/single-day gaps, adjacent-is-gapless, and coverage outside the window
- [ ] Live verification against a real expired-report job not performed (requires a dormant job with expired API reports plus a populated archive; the #154 path is exercised by unit-level reasoning and type-checking only)

Refs #154, #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Report results now identify explicit date ranges with missing source coverage.
  - Archived local reports can be used when API results are unavailable.
  - Coverage summaries distinguish covered days, gaps, and dates with no activity.
  - Video-specific queries no longer display coverage warnings.

- **Documentation**
  - Updated reporting guidance and tool descriptions to explain coverage boundaries, archived data, and uncovered ranges.

- **Bug Fixes**
  - Improved date-range handling and prevented range merging from altering existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->