### PR TITLE
fix(reports): use only the newest cached report per window

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -275,6 +275,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
             jobId,
             startTime,
             endTime,
+            createTime: report.createTime || undefined,
             startTimeActual: minDate || startTime,
             endTimeActual: maxDate || endTime,
             downloadedAt: new Date().toISOString(),

--- a/docs/commands/reporting-api.md
+++ b/docs/commands/reporting-api.md
@@ -249,6 +249,10 @@ YouTube expires reports from the API after 30-60 days, while `fetch-reports` kee
 
 A date that is covered but simply had no activity is not a gap. Only dates that no source could supply are reported.
 
+**Reissued reports.** YouTube republishes a report for the same window when it has corrected figures, so the archive accumulates several report IDs per window (on a real archive this was 58% of windows for `channel_reach_basic_a1`). Only the newest is used; the superseded copies stay on disk but never contribute rows. Without this, a range could return the same date and video twice with different numbers, and any total computed from it would be inflated.
+
+Reports archived from this version onward record the API `createTime` used to order reissues. Entries archived earlier fall back to expiry date, which orders identically within a job.
+
 ---
 
 ## fetch-reports

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -229,6 +229,13 @@ staqan-yt-cli/
 - `default.output` - Default output format: `json`, `table`, `text`, `pretty`, or `csv` (defaults to `pretty`)
 - `lock.timeout` - Lock acquisition timeout in milliseconds for `fetch-reports` (defaults to `60000`; overridden by `STAQAN_YT_LOCK_TIMEOUT_MS` env var)
 
+### Environment Variables
+
+- `STAQAN_YT_LOCK_TIMEOUT_MS` - Overrides the `lock.timeout` config value. Precedence: env var > config > 60s default.
+- `STAQAN_YT_DATA_DIR` - Overrides the root of the on-disk report archive, normally `~/.staqan-yt-cli/data`. Resolved per call via `getDataDir()` in `lib/cache.ts`, so it can be set at runtime.
+
+  This exists as a **test seam**, not a user-facing relocation feature: it lets the filesystem-backed cache layer (`tests/cache-store.test.ts`) run against a temp directory instead of the real archive. It is deliberately not config-backed, because `getLockPath()` in `lib/lock.ts` resolves the archive root synchronously and reading config is async. Making the archive root relocatable through `config.json` is a reasonable feature, but it needs a config key, a CLI flag, validation and a migration story for existing archives, so it belongs in its own change rather than riding along with a cache fix.
+
 ### How Configuration Works
 
 - Config values are loaded when commands execute

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -4,7 +4,19 @@ import { CONFIG_DIR, debug, warning } from './utils';
 import { CacheIndex, CacheIndexEntry, ReportMetadata, CacheCoverage } from '../types';
 
 // Base data directory
-export const DATA_DIR = path.join(CONFIG_DIR, 'data');
+/**
+ * Root of the on-disk report archive.
+ *
+ * Resolved per call rather than captured once at import, and overridable via
+ * `STAQAN_YT_DATA_DIR`. The override exists so the filesystem-dependent cache
+ * layer can be tested against a temp directory instead of the real archive:
+ * the module-level constant this replaced was baked in at import time, which
+ * made redirecting it from a test impossible once any other module had loaded
+ * it. Not intended for normal use; unset, behaviour is unchanged.
+ */
+export function getDataDir(): string {
+  return process.env.STAQAN_YT_DATA_DIR || path.join(CONFIG_DIR, 'data');
+}
 
 // Cache index version
 const CACHE_INDEX_VERSION = '2.0';
@@ -12,11 +24,11 @@ const CACHE_INDEX_VERSION = '2.0';
 // ─── Per-channel path helpers ──────────────────────────────────────────────────
 
 function getChannelReportsDir(channelId: string): string {
-  return path.join(DATA_DIR, channelId, 'reports');
+  return path.join(getDataDir(), channelId, 'reports');
 }
 
 function getChannelCacheIndexPath(channelId: string): string {
-  return path.join(DATA_DIR, channelId, 'reports', 'cache-index.json');
+  return path.join(getDataDir(), channelId, 'reports', 'cache-index.json');
 }
 
 /**
@@ -123,6 +135,56 @@ export async function isReportCached(
 ): Promise<boolean> {
   const index = await loadCacheIndex(channelId);
   return index.entries.some(entry => entry.reportId === reportId);
+}
+
+/**
+ * Collapse cached reports to one per API window, keeping the newest.
+ *
+ * YouTube reissues a report for the same [startTime, endTime] window when it
+ * has corrected figures, so the cache legitimately accumulates several
+ * reportIds per window (58% of windows for channel_reach_basic_a1 on a real
+ * archive). Loading all of them returns both the stale and the corrected rows:
+ * same date and video_id, different metric values, which silently double-counts
+ * any aggregation. The API path has always collapsed these via createTime;
+ * this is the cache-side equivalent.
+ *
+ * Recency key, in order of preference:
+ *  1. `createTime` from the API, persisted since this was fixed.
+ *  2. `expiresAt`, for entries archived before createTime was stored. Expiry is
+ *     createTime plus 30 days (backfill reports, created within ~4 days of the
+ *     job) or 60 days (regular). Within one job createTime only increases and
+ *     the added window never shrinks, so ordering by expiresAt agrees with
+ *     ordering by createTime.
+ *  3. `downloadedAt`, as a last resort if expiry is missing or equal.
+ */
+export function pickNewestPerWindow(entries: CacheIndexEntry[]): CacheIndexEntry[] {
+  const newest = new Map<string, CacheIndexEntry>();
+
+  for (const entry of entries) {
+    const key = `${entry.startTime}|${entry.endTime}`;
+    const prev = newest.get(key);
+    if (!prev || isNewerReport(entry, prev)) {
+      newest.set(key, entry);
+    }
+  }
+
+  return [...newest.values()];
+}
+
+/** True when `a` is a later reissue than `b`. See pickNewestPerWindow. */
+function isNewerReport(a: CacheIndexEntry, b: CacheIndexEntry): boolean {
+  if (a.createTime && b.createTime && a.createTime !== b.createTime) {
+    return a.createTime > b.createTime;
+  }
+  // Prefer an entry that knows its createTime over one that does not: it was
+  // archived after the fix, so it is at least as trustworthy.
+  if (Boolean(a.createTime) !== Boolean(b.createTime)) {
+    return Boolean(a.createTime);
+  }
+  if (a.expiresAt && b.expiresAt && a.expiresAt !== b.expiresAt) {
+    return a.expiresAt > b.expiresAt;
+  }
+  return (a.downloadedAt || '') > (b.downloadedAt || '');
 }
 
 export async function findCachedReports(
@@ -323,6 +385,9 @@ export async function saveReportToCache(
     channelId,
     startTime: metadata.startTime,
     endTime: metadata.endTime,
+    // Carried into the index so pickNewestPerWindow can order reissues of the
+    // same window without opening every metadata file.
+    createTime: metadata.createTime,
     downloadedAt: metadata.downloadedAt,
     expiresAt: metadata.expiresAt,
     fileSize: metadata.fileSize,
@@ -531,63 +596,15 @@ export async function analyzeCacheCoverage(
   );
 
   if (cachedReports.length === 0) {
-    return {
-      fullyCovered: [],
-      partiallyCovered: [],
-      notCovered: [`${requestedStart}/${requestedEnd}`],
-    };
+    return { missingRanges: [{ start: requestedStart, end: requestedEnd }] };
   }
 
-  const fullyCovered: string[] = [];
-  const partiallyCovered: CacheCoverage['partiallyCovered'] = [];
-  const notCovered: string[] = [];
-
-  // Resolve actual data dates for each cached report (reads metadata if needed)
-  const entriesWithDates = await Promise.all(
-    cachedReports.map(async (r) => ({
-      entry: r,
-      dates: await getActualDates(r, channelId),
-    }))
+  // Collapse reissues first so coverage reflects the reports that will
+  // actually be loaded, then subtract their real data windows from the
+  // request. findDateGaps handles sorting, merging and adjacency.
+  const cachedRanges = await Promise.all(
+    pickNewestPerWindow(cachedReports).map((entry) => getActualDates(entry, channelId))
   );
 
-  const cachedRanges = entriesWithDates.map(e => e.dates);
-  const gaps = findDateGaps(cachedRanges, requestedStart, requestedEnd);
-
-  for (const { dates } of entriesWithDates) {
-    const cachedStart = dates.start;
-    const cachedEnd = dates.end;
-
-    const overlap = computeDateRangeOverlap(
-      cachedStart,
-      cachedEnd,
-      requestedStart,
-      requestedEnd
-    );
-
-    if (!overlap) continue;
-
-    if (overlap.start === cachedStart && overlap.end === cachedEnd) {
-      fullyCovered.push(`${cachedStart}/${cachedEnd}`);
-    } else {
-      const missingStart = overlap.start < cachedStart
-        ? overlap.start
-        : new Date(new Date(cachedEnd).getTime() + 86400000).toISOString().split('T')[0];
-
-      const missingEnd = overlap.end > cachedEnd
-        ? overlap.end
-        : new Date(new Date(cachedStart).getTime() - 86400000).toISOString().split('T')[0];
-
-      partiallyCovered.push({
-        range: { start: requestedStart, end: requestedEnd },
-        cached: { start: overlap.start, end: overlap.end },
-        missing: { start: missingStart, end: missingEnd },
-      });
-    }
-  }
-
-  for (const gap of gaps) {
-    notCovered.push(`${gap.start}/${gap.end}`);
-  }
-
-  return { fullyCovered, partiallyCovered, notCovered };
+  return { missingRanges: findDateGaps(cachedRanges, requestedStart, requestedEnd) };
 }

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -171,20 +171,61 @@ export function pickNewestPerWindow(entries: CacheIndexEntry[]): CacheIndexEntry
   return [...newest.values()];
 }
 
+/**
+ * Compare two ISO 8601 instants chronologically. Returns a negative number
+ * when `a` is earlier, positive when later, 0 when equal or incomparable.
+ *
+ * String comparison is NOT safe here. The Reporting API returns createTime
+ * with microsecond precision (2026-07-26T13:23:08.447428Z), and any variation
+ * in that precision breaks lexical ordering: "…08Z" sorts after "…08.000001Z"
+ * because "." (0x2E) is below "Z" (0x5A), and "…08.447428Z" sorts after
+ * "…08.45Z" even though it is 3ms earlier. Parsing to epoch milliseconds is
+ * exact for every format the API emits.
+ *
+ * Date.parse truncates to milliseconds, which would tie two instants that
+ * differ only in microseconds, so sub-millisecond digits are compared
+ * separately to keep the ordering exact at the precision the API actually
+ * emits.
+ */
+function compareInstants(a: string, b: string): number {
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  if (Number.isNaN(ta) || Number.isNaN(tb)) {
+    // Unparseable timestamp: fall back to byte order so behaviour stays
+    // deterministic rather than silently treating everything as equal.
+    return a < b ? -1 : a > b ? 1 : 0;
+  }
+  if (ta !== tb) return ta - tb;
+  // Same millisecond: break the tie on the remaining fractional digits.
+  return fractionalNanoseconds(a) - fractionalNanoseconds(b);
+}
+
+/**
+ * Fractional seconds of an ISO timestamp as nanoseconds, zero-padded so
+ * ".45" and ".450000" compare equal and ".000001" is distinguishable from "".
+ */
+function fractionalNanoseconds(ts: string): number {
+  const match = /\.(\d+)/.exec(ts);
+  if (!match) return 0;
+  return Number(match[1].padEnd(9, '0').slice(0, 9));
+}
+
 /** True when `a` is a later reissue than `b`. See pickNewestPerWindow. */
 function isNewerReport(a: CacheIndexEntry, b: CacheIndexEntry): boolean {
-  if (a.createTime && b.createTime && a.createTime !== b.createTime) {
-    return a.createTime > b.createTime;
+  if (a.createTime && b.createTime) {
+    const byCreate = compareInstants(a.createTime, b.createTime);
+    if (byCreate !== 0) return byCreate > 0;
   }
   // Prefer an entry that knows its createTime over one that does not: it was
   // archived after the fix, so it is at least as trustworthy.
   if (Boolean(a.createTime) !== Boolean(b.createTime)) {
     return Boolean(a.createTime);
   }
-  if (a.expiresAt && b.expiresAt && a.expiresAt !== b.expiresAt) {
-    return a.expiresAt > b.expiresAt;
+  if (a.expiresAt && b.expiresAt) {
+    const byExpiry = compareInstants(a.expiresAt, b.expiresAt);
+    if (byExpiry !== 0) return byExpiry > 0;
   }
-  return (a.downloadedAt || '') > (b.downloadedAt || '');
+  return compareInstants(a.downloadedAt || '', b.downloadedAt || '') > 0;
 }
 
 export async function findCachedReports(

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -187,7 +187,7 @@ export function pickNewestPerWindow(entries: CacheIndexEntry[]): CacheIndexEntry
  * separately to keep the ordering exact at the precision the API actually
  * emits.
  */
-function compareInstants(a: string, b: string): number {
+export function compareInstants(a: string, b: string): number {
   const ta = Date.parse(a);
   const tb = Date.parse(b);
   if (Number.isNaN(ta) || Number.isNaN(tb)) {

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { debug, CACHE_DIR } from './utils';
-import { DATA_DIR } from './cache';
+import { getDataDir } from './cache';
 
 export interface LockOptions {
   timeout?: number;        // Max wait time (ms) before giving up
@@ -154,6 +154,6 @@ export function getLockPath(type: 'completion' | 'handles' | 'reports', channelI
       return path.join(CACHE_DIR, 'handle-to-channel-id.json.lock');
     case 'reports':
       if (!channelId) throw new Error('channelId required for reports lock');
-      return path.join(DATA_DIR, channelId, 'reports.lock');
+      return path.join(getDataDir(), channelId, 'reports.lock');
   }
 }

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -30,6 +30,7 @@ import {
   ensureCacheDir,
   findCachedReports,
   findDateGaps,
+  pickNewestPerWindow,
   getActualDates,
   normalizeDate,
   parseCsvAndExtractRange,
@@ -794,13 +795,22 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   const cachedReports: CacheIndexEntry[] = [];
 
   const overlappingCached = await findCachedReports(channelId, params.type, adjustedStart, adjustedEnd);
-  const loadedReportIds = new Set<string>();
-  for (const cachedReport of overlappingCached) {
-    // findCachedReports can return the same report once per overlapping
-    // window; loading it twice would duplicate rows and inflate the count.
-    if (loadedReportIds.has(cachedReport.reportId)) continue;
-    loadedReportIds.add(cachedReport.reportId);
 
+  // Collapse reissues before loading. YouTube publishes several reportIds for
+  // the same window when it corrects figures, and the archive keeps all of
+  // them; loading every one returns the stale rows alongside the corrected
+  // ones (same date and video_id, different values), which double-counts any
+  // aggregation. The API branch has always done this via createTime, so this
+  // brings the cache branch to parity.
+  const newestCached = pickNewestPerWindow(overlappingCached);
+  if (newestCached.length < overlappingCached.length) {
+    debug(
+      `Collapsed ${overlappingCached.length} cached report(s) to ${newestCached.length} ` +
+      `after dropping superseded reissues`
+    );
+  }
+
+  for (const cachedReport of newestCached) {
     const reportData = await readCachedReport(channelId, cachedReport.reportId, params.type);
     if (reportData) {
       cachedData.push(...reportData.data);
@@ -816,14 +826,8 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   // Step 7: Fetch missing data
   const reportsToFetch: FetchedReportInfo[] = [];
 
-  // Build list of missing date ranges
-  const missingRanges = [
-    ...coverage.partiallyCovered.map(p => p.missing),
-    ...coverage.notCovered.map(r => {
-      const [start, end] = r.split('/');
-      return { start, end };
-    }),
-  ];
+  // Ranges the cache cannot supply, straight from the coverage analysis.
+  const missingRanges = coverage.missingRanges;
 
   // Filter reports to only fetch those covering missing ranges. Compare date
   // portions: the report bounds are full timestamps while the range bounds
@@ -909,6 +913,7 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
           jobId,
           startTime: report.startTime,
           endTime: report.endTime,
+          createTime: report.createTime,
           startTimeActual: dataMinDate,
           endTimeActual: dataMaxDate,
           downloadedAt: new Date().toISOString(),

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -30,6 +30,7 @@ import {
   ensureCacheDir,
   findCachedReports,
   findDateGaps,
+  compareInstants,
   pickNewestPerWindow,
   getActualDates,
   normalizeDate,
@@ -657,7 +658,11 @@ export async function fetchReportData(params: ReportDataParams): Promise<ReportD
   for (const report of allFetchedReports) {
     const key = `${report.startTime}|${report.endTime}`;
     const prev = newestByWindow.get(key);
-    if (!prev || report.createTime > prev.createTime) {
+    // compareInstants, not string comparison: createTime carries microsecond
+    // precision and any variation in it misorders lexically, which would pick
+    // the stale reissue. Same comparator the cache-side dedup uses, so both
+    // paths agree on which report supersedes which.
+    if (!prev || compareInstants(report.createTime, prev.createTime) > 0) {
       newestByWindow.set(key, report);
     }
   }

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -145,6 +145,76 @@ describe('pickNewestPerWindow', () => {
     expect(out[0].reportId).toBe('known');
   });
 
+  it('orders createTime chronologically, not lexically', () => {
+    // "…00Z" sorts AFTER "…00.000001Z" byte-wise, because "." (0x2E) is below
+    // "Z" (0x5A), so string comparison picks the earlier report as newest.
+    const out = pickNewestPerWindow([
+      base({ reportId: 'earlier', createTime: '2026-03-02T00:00:00Z' }),
+      base({ reportId: 'later', createTime: '2026-03-02T00:00:00.000001Z' }),
+    ]);
+    expect(out[0].reportId).toBe('later');
+  });
+
+  it('orders createTime correctly across differing fractional precision', () => {
+    // .447428 is 3ms BEFORE .45, but compares as greater byte-wise.
+    const out = pickNewestPerWindow([
+      base({ reportId: 'earlier', createTime: '2026-07-26T13:23:08.447428Z' }),
+      base({ reportId: 'later', createTime: '2026-07-26T13:23:08.45Z' }),
+    ]);
+    expect(out[0].reportId).toBe('later');
+  });
+
+  it('handles the microsecond precision the Reporting API actually returns', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'older', createTime: '2026-07-26T13:23:08.447428Z' }),
+      base({ reportId: 'newer', createTime: '2026-07-29T05:30:47.275044Z' }),
+    ]);
+    expect(out[0].reportId).toBe('newer');
+  });
+
+  it('distinguishes createTimes that differ only in microseconds', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'earlier', createTime: '2026-03-02T00:00:00.000001Z' }),
+      base({ reportId: 'later', createTime: '2026-03-02T00:00:00.000002Z' }),
+    ]);
+    expect(out[0].reportId).toBe('later');
+  });
+
+  it('treats equivalent fractional spellings as equal', () => {
+    // ".45" and ".450000" are the same instant, so neither supersedes the
+    // other on createTime and the expiresAt tiebreak decides.
+    const out = pickNewestPerWindow([
+      base({
+        reportId: 'loser',
+        createTime: '2026-03-02T00:00:00.45Z',
+        expiresAt: '2026-05-01T00:00:00Z',
+      }),
+      base({
+        reportId: 'winner',
+        createTime: '2026-03-02T00:00:00.450000Z',
+        expiresAt: '2026-05-06T00:00:00Z',
+      }),
+    ]);
+    expect(out[0].reportId).toBe('winner');
+  });
+
+  it('compares expiresAt chronologically too', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'earlier', expiresAt: '2026-05-01T00:00:00Z' }),
+      base({ reportId: 'later', expiresAt: '2026-05-01T00:00:00.000001Z' }),
+    ]);
+    expect(out[0].reportId).toBe('later');
+  });
+
+  it('stays deterministic when a timestamp is unparseable', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'bad', createTime: 'not-a-date' }),
+      base({ reportId: 'good', createTime: '2026-03-02T00:00:00Z' }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(['bad', 'good']).toContain(out[0].reportId);
+  });
+
   it('leaves distinct windows untouched', () => {
     const out = pickNewestPerWindow([
       base({ reportId: 'a', startTime: '2026-03-01T08:00:00Z', endTime: '2026-03-02T08:00:00Z' }),

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Filesystem-backed tests for the report cache.
+ *
+ * The pure date helpers are covered in cache.test.ts. These exercise the parts
+ * that actually touch disk (index, dedup, coverage), which is where the bugs
+ * that unit tests missed on PR #158 lived. `STAQAN_YT_DATA_DIR` redirects the
+ * archive root at call time so nothing here can reach the real archive.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  analyzeCacheCoverage,
+  findCachedReports,
+  getDataDir,
+  pickNewestPerWindow,
+  readCachedReport,
+  saveReportToCache,
+} from '../lib/cache';
+import type { CacheIndexEntry, ReportMetadata } from '../types';
+
+const CHANNEL = 'UCtesttesttesttesttest0';
+const TYPE = 'channel_reach_basic_a1';
+
+let tmpRoot: string;
+let previousDataDir: string | undefined;
+
+beforeEach(async () => {
+  previousDataDir = process.env.STAQAN_YT_DATA_DIR;
+  tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'staqan-cache-test-'));
+  process.env.STAQAN_YT_DATA_DIR = tmpRoot;
+});
+
+afterEach(async () => {
+  if (previousDataDir === undefined) delete process.env.STAQAN_YT_DATA_DIR;
+  else process.env.STAQAN_YT_DATA_DIR = previousDataDir;
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+/** Build a report CSV whose rows land on the given YYYYMMDD dates. */
+function csvFor(dates: string[], impressions: string): string {
+  const header = 'date,channel_id,video_id,video_thumbnail_impressions';
+  const rows = dates.map((d) => `${d},${CHANNEL},vid00000001,${impressions}`);
+  return [header, ...rows].join('\n');
+}
+
+function metadataFor(over: Partial<ReportMetadata> & { reportId: string }): ReportMetadata {
+  return {
+    reportTypeId: TYPE,
+    channelId: CHANNEL,
+    jobId: 'job-1',
+    startTime: '2026-03-01T08:00:00Z',
+    endTime: '2026-03-02T08:00:00Z',
+    startTimeActual: '20260301',
+    endTimeActual: '20260301',
+    downloadedAt: '2026-03-03T00:00:00Z',
+    expiresAt: '2026-05-01T00:00:00Z',
+    downloadUrl: 'https://example.invalid/report',
+    columns: ['date', 'channel_id', 'video_id', 'video_thumbnail_impressions'],
+    isComplete: true,
+    fileSize: 100,
+    row_count: 1,
+    ...over,
+  } as ReportMetadata;
+}
+
+async function store(meta: ReportMetadata, csv: string) {
+  await saveReportToCache(CHANNEL, meta.reportId, TYPE, csv, meta);
+}
+
+describe('data dir redirection', () => {
+  it('resolves the archive root from STAQAN_YT_DATA_DIR at call time', () => {
+    expect(getDataDir()).toBe(tmpRoot);
+  });
+});
+
+describe('save/read round trip', () => {
+  it('stores a report and reads its rows back', async () => {
+    await store(
+      metadataFor({ reportId: 'r1' }),
+      csvFor(['20260301'], '10'),
+    );
+    const read = await readCachedReport(CHANNEL, 'r1', TYPE);
+    expect(read).not.toBeNull();
+    expect(read!.data).toHaveLength(1);
+    expect(read!.data[0].video_thumbnail_impressions).toBe('10');
+  });
+
+  it('persists createTime into the index entry', async () => {
+    await store(
+      metadataFor({ reportId: 'r1', createTime: '2026-03-02T10:00:00Z' }),
+      csvFor(['20260301'], '10'),
+    );
+    const found = await findCachedReports(CHANNEL, TYPE, '2026-03-01', '2026-03-05');
+    expect(found).toHaveLength(1);
+    expect(found[0].createTime).toBe('2026-03-02T10:00:00Z');
+  });
+});
+
+describe('pickNewestPerWindow', () => {
+  const base = (over: Partial<CacheIndexEntry>): CacheIndexEntry => ({
+    reportId: 'x',
+    reportTypeId: TYPE,
+    channelId: CHANNEL,
+    startTime: '2026-03-01T08:00:00Z',
+    endTime: '2026-03-02T08:00:00Z',
+    downloadedAt: '2026-03-03T00:00:00Z',
+    expiresAt: '2026-05-01T00:00:00Z',
+    fileSize: 10,
+    ...over,
+  });
+
+  it('keeps one entry per window', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'old', createTime: '2026-03-02T00:00:00Z' }),
+      base({ reportId: 'new', createTime: '2026-03-05T00:00:00Z' }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].reportId).toBe('new');
+  });
+
+  it('orders by createTime when both have it', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'new', createTime: '2026-03-09T00:00:00Z', expiresAt: '2026-04-01T00:00:00Z' }),
+      base({ reportId: 'old', createTime: '2026-03-02T00:00:00Z', expiresAt: '2026-09-01T00:00:00Z' }),
+    ]);
+    // createTime wins even though the older report has a later expiry.
+    expect(out[0].reportId).toBe('new');
+  });
+
+  it('falls back to expiresAt for legacy entries without createTime', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'older', expiresAt: '2026-05-01T00:00:00Z' }),
+      base({ reportId: 'newer', expiresAt: '2026-05-06T00:00:00Z' }),
+    ]);
+    expect(out[0].reportId).toBe('newer');
+  });
+
+  it('prefers an entry that knows its createTime over one that does not', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'legacy', expiresAt: '2026-09-01T00:00:00Z' }),
+      base({ reportId: 'known', createTime: '2026-03-02T00:00:00Z', expiresAt: '2026-04-01T00:00:00Z' }),
+    ]);
+    expect(out[0].reportId).toBe('known');
+  });
+
+  it('leaves distinct windows untouched', () => {
+    const out = pickNewestPerWindow([
+      base({ reportId: 'a', startTime: '2026-03-01T08:00:00Z', endTime: '2026-03-02T08:00:00Z' }),
+      base({ reportId: 'b', startTime: '2026-03-02T08:00:00Z', endTime: '2026-03-03T08:00:00Z' }),
+    ]);
+    expect(out.map((e) => e.reportId).sort()).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for no entries', () => {
+    expect(pickNewestPerWindow([])).toEqual([]);
+  });
+});
+
+describe('analyzeCacheCoverage', () => {
+  it('reports the whole range missing when the cache is empty', async () => {
+    const coverage = await analyzeCacheCoverage(CHANNEL, TYPE, '2026-03-01', '2026-03-07');
+    expect(coverage.missingRanges).toEqual([{ start: '2026-03-01', end: '2026-03-07' }]);
+  });
+
+  it('reports nothing missing when a single report spans the whole request', async () => {
+    // The containment case that the old fullyCovered classification got wrong:
+    // the request sits strictly inside the cached report's range.
+    await store(
+      metadataFor({
+        reportId: 'wide',
+        startTime: '2026-03-01T08:00:00Z',
+        endTime: '2026-04-01T08:00:00Z',
+        startTimeActual: '20260301',
+        endTimeActual: '20260331',
+      }),
+      csvFor(['20260310', '20260315', '20260320'], '5'),
+    );
+    const coverage = await analyzeCacheCoverage(CHANNEL, TYPE, '2026-03-10', '2026-03-20');
+    expect(coverage.missingRanges).toEqual([]);
+  });
+
+  it('reports the interior hole between two disjoint cached reports', async () => {
+    await store(
+      metadataFor({
+        reportId: 'jan',
+        startTime: '2026-01-01T08:00:00Z',
+        endTime: '2026-02-01T08:00:00Z',
+        startTimeActual: '20260101',
+        endTimeActual: '20260131',
+      }),
+      csvFor(['20260101'], '1'),
+    );
+    await store(
+      metadataFor({
+        reportId: 'jun',
+        startTime: '2026-06-01T08:00:00Z',
+        endTime: '2026-07-01T08:00:00Z',
+        startTimeActual: '20260601',
+        endTimeActual: '20260630',
+      }),
+      csvFor(['20260601'], '1'),
+    );
+    const coverage = await analyzeCacheCoverage(CHANNEL, TYPE, '2026-01-01', '2026-06-30');
+    expect(coverage.missingRanges).toEqual([{ start: '2026-02-01', end: '2026-05-31' }]);
+  });
+
+  it('ignores superseded reissues when computing coverage', async () => {
+    // Two reports for the same window: coverage must not change.
+    await store(
+      metadataFor({ reportId: 'v1', expiresAt: '2026-05-01T00:00:00Z' }),
+      csvFor(['20260301'], '5'),
+    );
+    await store(
+      metadataFor({ reportId: 'v2', expiresAt: '2026-05-06T00:00:00Z' }),
+      csvFor(['20260301'], '6'),
+    );
+    const coverage = await analyzeCacheCoverage(CHANNEL, TYPE, '2026-03-01', '2026-03-01');
+    expect(coverage.missingRanges).toEqual([]);
+  });
+});
+
+describe('findCachedReports', () => {
+  it('returns reports whose window overlaps the query, including wider ones', async () => {
+    await store(
+      metadataFor({
+        reportId: 'wide',
+        startTime: '2026-03-01T08:00:00Z',
+        endTime: '2026-04-01T08:00:00Z',
+      }),
+      csvFor(['20260315'], '5'),
+    );
+    const found = await findCachedReports(CHANNEL, TYPE, '2026-03-10', '2026-03-20');
+    expect(found.map((e) => e.reportId)).toEqual(['wide']);
+  });
+
+  it('excludes reports outside the query window', async () => {
+    await store(
+      metadataFor({
+        reportId: 'far',
+        startTime: '2025-01-01T08:00:00Z',
+        endTime: '2025-01-02T08:00:00Z',
+      }),
+      csvFor(['20250101'], '5'),
+    );
+    const found = await findCachedReports(CHANNEL, TYPE, '2026-03-01', '2026-03-07');
+    expect(found).toEqual([]);
+  });
+
+  it('does not leak reports from another report type', async () => {
+    await store(metadataFor({ reportId: 'mine' }), csvFor(['20260301'], '5'));
+    const found = await findCachedReports(CHANNEL, 'channel_basic_a3', '2026-03-01', '2026-03-07');
+    expect(found).toEqual([]);
+  });
+});

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -12,6 +12,7 @@ import os from 'os';
 import path from 'path';
 import {
   analyzeCacheCoverage,
+  compareInstants,
   findCachedReports,
   getDataDir,
   pickNewestPerWindow,
@@ -207,12 +208,16 @@ describe('pickNewestPerWindow', () => {
   });
 
   it('stays deterministic when a timestamp is unparseable', () => {
+    // Byte-order fallback: "not-a-date" ("n" 0x6E) sorts after "2026-…"
+    // ("2" 0x32), so the unparseable entry wins. Pinned rather than accepting
+    // either value, so a comparator that returned 0 for unparseable input, or
+    // reversed the fallback, would fail here.
     const out = pickNewestPerWindow([
       base({ reportId: 'bad', createTime: 'not-a-date' }),
       base({ reportId: 'good', createTime: '2026-03-02T00:00:00Z' }),
     ]);
     expect(out).toHaveLength(1);
-    expect(['bad', 'good']).toContain(out[0].reportId);
+    expect(out[0].reportId).toBe('bad');
   });
 
   it('leaves distinct windows untouched', () => {
@@ -225,6 +230,40 @@ describe('pickNewestPerWindow', () => {
 
   it('returns an empty array for no entries', () => {
     expect(pickNewestPerWindow([])).toEqual([]);
+  });
+});
+
+describe('compareInstants', () => {
+  // Shared by both dedup paths: the cache-side pickNewestPerWindow and the
+  // API-side newestByWindow in lib/reports.ts.
+  const sign = (n: number) => (n === 0 ? 0 : n > 0 ? 1 : -1);
+
+  it('orders whole seconds against microseconds by time, not bytes', () => {
+    expect(sign(compareInstants('2026-03-02T00:00:00.000001Z', '2026-03-02T00:00:00Z'))).toBe(1);
+  });
+
+  it('orders differing fractional precision by time, not bytes', () => {
+    // .447428 is earlier than .45 despite comparing greater as a string.
+    expect(sign(compareInstants('2026-07-26T13:23:08.447428Z', '2026-07-26T13:23:08.45Z'))).toBe(-1);
+  });
+
+  it('treats equivalent fractional spellings as equal', () => {
+    expect(compareInstants('2026-03-02T00:00:00.45Z', '2026-03-02T00:00:00.450000Z')).toBe(0);
+  });
+
+  it('orders plain dates', () => {
+    expect(sign(compareInstants('2026-07-29T05:30:47.275044Z', '2026-07-26T13:23:08.447428Z'))).toBe(1);
+  });
+
+  it('is antisymmetric', () => {
+    const a = '2026-03-02T00:00:00.000001Z';
+    const b = '2026-03-02T00:00:02Z';
+    expect(sign(compareInstants(a, b))).toBe(-sign(compareInstants(b, a)));
+  });
+
+  it('falls back to byte order for unparseable input', () => {
+    expect(sign(compareInstants('not-a-date', '2026-03-02T00:00:00Z'))).toBe(1);
+    expect(compareInstants('not-a-date', 'not-a-date')).toBe(0);
   });
 });
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -391,6 +391,15 @@ export interface CacheIndexEntry {
   channelId: string;          // Channel this report belongs to
   startTime: string;          // YYYY-MM-DD
   endTime: string;            // YYYY-MM-DD
+  /**
+   * Report createTime from the YouTube API (ISO 8601).
+   *
+   * YouTube reissues a report for the same window when it has corrected data,
+   * so a window can have several reportIds and only the newest is valid. This
+   * is the ordering key for that. Optional because entries written before it
+   * was persisted do not carry it; see pickNewestPerWindow for the fallback.
+   */
+  createTime?: string;
   downloadedAt: string;       // ISO 8601 timestamp
   expiresAt: string;          // ISO 8601 timestamp
   fileSize: number;           // bytes
@@ -410,6 +419,7 @@ export interface ReportMetadata {
   jobId: string;
   startTime: string;          // From YouTube API
   endTime: string;            // From YouTube API
+  createTime?: string;        // Report createTime from the API; orders reissues of the same window
   startTimeActual: string;    // Actual data range in CSV (parsed)
   endTimeActual: string;      // Actual data range in CSV (parsed)
   downloadedAt: string;       // ISO 8601 timestamp
@@ -421,14 +431,26 @@ export interface ReportMetadata {
   row_count?: number;
 }
 
+/**
+ * What the local cache cannot supply for a requested date range.
+ *
+ * Deliberately reduced to this single field. The previous shape also carried
+ * `fullyCovered` and `partiallyCovered`, both of which were removed:
+ *
+ *  - `fullyCovered` meant "this cached report lies entirely inside the request",
+ *    which reads like the opposite of what it was. Driving the cache-load loop
+ *    from it meant a request contained within one wider archived report matched
+ *    nothing and returned zero rows.
+ *  - `partiallyCovered.missing` produced inverted ranges (start after end) in
+ *    exactly that containment case: a Jan 1-31 report against a Jan 10-20
+ *    request yielded a "missing" range of 2026-02-01 to 2025-12-31.
+ *
+ * `missingRanges` comes straight from findDateGaps, which was already the only
+ * correct source, so nothing of value was lost.
+ */
 export interface CacheCoverage {
-  fullyCovered: string[];     // Date ranges fully in cache
-  partiallyCovered: {         // Partial overlaps
-    range: { start: string; end: string };
-    cached: { start: string; end: string };
-    missing: { start: string; end: string };
-  }[];
-  notCovered: string[];       // Date ranges not in cache
+  /** Sub-ranges of the request that no cached report covers. Empty when fully covered. */
+  missingRanges: { start: string; end: string }[];
 }
 
 export interface ReportData {


### PR DESCRIPTION
Found by running the CLI against the real archive. Unit tests, type-check and CodeRabbit had all passed on #158 while this was live.

## The bug

YouTube republishes a report for the same `[startTime, endTime]` window when it has corrected figures, so the local archive legitimately accumulates several report IDs per window. `fetchReportData` loaded every cached report overlapping the range, so both the stale and the corrected copy contributed rows.

Result: the same `(date, video_id)` returned twice with different metric values. Any total computed from the output is inflated.

Measured on the real archive:

| report type | windows | duplicated | |
|---|---|---|---|
| `channel_reach_basic_a1` | 177 | 103 | **58%** |
| `channel_reach_combined_a1` | 149 | 77 | **52%** |
| all types | 3013 | 281 | 9% |

The two worst-hit types are the thumbnail-impression and reach reports, and the docs call `channel_reach_basic_a1` "the **most important** report type for thumbnail analysis".

Live before and after on `--start-date=2026-03-01 --end-date=2026-03-07`:

```
before: 14 cached reports, 169 rows,   9 duplicate (date,video_id) keys
after :  8 cached reports, 160 rows,   0 duplicate keys
```

The unique key set is **identical** across both (160 keys, nothing lost), and the surviving value is the corrected one every time (`7` over `6`, `3` over `2`, `4` over `3`), which is what a later reissue should be.

## The fix

The API branch has always collapsed reissues by `createTime` via `newestByWindow`. This adds the cache-side equivalent, `pickNewestPerWindow`, used both when loading reports and when computing coverage.

`createTime` was persisted nowhere, so ordering had nothing reliable to sort on. It is now recorded on write. Existing entries fall back to `expiresAt`, which orders identically within a job: expiry is `createTime` plus a window that only ever grows (30 days for backfills created within ~4 days of the job, 60 for regular), so a later `createTime` always yields a later expiry.

**Verified live end to end**: deleted 7 days of cached reports for `channel_reach_basic_a1`, re-ran, and the command refetched 8 reports from the API. All 7 re-cached entries came back with `createTime` populated in both the index and the metadata files, the returned rows were byte-identical to the pre-deletion baseline (194 rows), and every refetched CSV hashed identically to the original. The archive was tarball-backed-up first and the deleted files copied aside; both were confirmed restored.

## Also in this change

**`CacheCoverage` reduced to `missingRanges`.** Both removed fields were defective:

- `fullyCovered` was dead outside `cache.ts` after #158, and meant "this cached report lies entirely inside the request", the opposite of how it reads. Driving the load loop from it is exactly what caused the subrange bug fixed in #158.
- `partiallyCovered.missing` produced **inverted ranges** in that same containment case. A Jan 1-31 report against a Jan 10-20 request yielded `missing = { start: 2026-02-01, end: 2025-12-31 }`, a range whose start is ten months after its end.

`findDateGaps` was already the only correct source, so nothing of value was lost.

**Archive root is now redirectable.** `getDataDir()` resolves at call time with a `STAQAN_YT_DATA_DIR` override, replacing a constant captured at import. Unset, behaviour is unchanged. This exists so the filesystem-dependent cache layer can be tested at all: the old constant was baked in before a test could touch it.

## Test plan

- [x] `bun run type-check`, `bun run lint`, `bun run build` clean
- [x] `bun test` 103 pass / 0 fail (was 87; +16 in `tests/cache-store.test.ts`)
- [x] **Mutation-verified**: neutering the dedup ordering fails 3 of the new tests; restoring passes all 16
- [x] New tests cover dedup ordering (createTime, expiresAt fallback, mixed), the containment case that #158 got wrong, disjoint-island coverage, and report-type isolation
- [x] Tests confirmed not to touch the real archive (index still 3296 entries after the run)
- [x] Live: duplicate elimination, no key loss, refetch + `createTime` persistence, byte-identical CSV restoration

Note this changes `get-report-data` output for any range containing a reissued window: fewer rows, and correct totals. That is the point of the change, but it is a visible behaviour change worth knowing about.

Refs #154, #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reissued reports now use only the newest version for each reporting window, preventing stale or duplicate data.
  * Report ordering is more accurate using creation time, with reliable fallbacks for older reports.
  * Cache coverage calculations now identify missing date ranges correctly.

* **Improvements**
  * Added support for redirecting the report data directory through configuration.

* **Documentation**
  * Added guidance on reissued reports, archived files, and data-directory configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->