### PR TITLE
docs(completion): correct and cross-reference the variadic pre-check comments

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -520,6 +520,7 @@ ${commandList}
       local CURRENT=\$((\$CURRENT - 1))
       # Space-separated variadic: walk back to detect if we're inside --video-ids'
       # value list. Exclude already-used IDs via compadd -F.
+      # See docs/development/shell-completion-guide.md#variadic-pre-check-pattern
       if [[ \$words[\$CURRENT] != -* ]]; then
         local j=\$((\$CURRENT - 1))
         local -a _vused=()
@@ -535,6 +536,9 @@ ${commandList}
           esac
         done
       fi
+      # The pre-check owns every --video-ids value, the first one included, so
+      # the _staqan_yt_video_ids action below only ever completes the flag name.
+      # (The singular --video-id flags do reach that helper.)
       _arguments \\
         '--video-ids[Video IDs (variadic)]: :_staqan_yt_video_ids' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
@@ -566,7 +570,8 @@ ${commandList}
     get-video-localizations)
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
-      # Same variadic pre-check as get-videos
+      # Same variadic pre-check as get-videos.
+      # See docs/development/shell-completion-guide.md#variadic-pre-check-pattern
       if [[ \$words[\$CURRENT] != -* ]]; then
         local j=\$((\$CURRENT - 1))
         local -a _vused=()
@@ -707,6 +712,7 @@ ${commandList}
       # Space-separated variadic: walk back to detect if we're inside --privacy's
       # value list. Pattern from Docker/_docker: use \${words[(r)val]} to check
       # already-used values, then offer only the remaining ones.
+      # See docs/development/shell-completion-guide.md#variadic-pre-check-pattern
       if [[ \$words[\$CURRENT] != -* ]]; then
         local j=\$((\$CURRENT - 1))
         local -a _pused=()
@@ -726,6 +732,11 @@ ${commandList}
           esac
         done
       fi
+      # Value completion for --privacy never reaches _arguments. The words slice
+      # above drops the empty word being completed, so \$words[\$CURRENT] is empty
+      # (never -*) and the pre-check runs for the first value as well as later
+      # ones. The inline (public private unlisted) action is still required: it
+      # is what completes the flag name and supplies its description.
       _arguments \\
         '--channel[Channel handle or ID]:channel:' \\
         '--limit[Limit number of results]:n:' \\
@@ -737,7 +748,8 @@ ${commandList}
     list-playlists)
       local words=(\$words[1] \$words[3,-1])
       local CURRENT=\$((\$CURRENT - 1))
-      # Same space-separated variadic pre-check as list-videos
+      # Same space-separated variadic pre-check as list-videos.
+      # See docs/development/shell-completion-guide.md#variadic-pre-check-pattern
       if [[ \$words[\$CURRENT] != -* ]]; then
         local j=\$((\$CURRENT - 1))
         local -a _pused=()
@@ -757,6 +769,8 @@ ${commandList}
           esac
         done
       fi
+      # Same division of labour as list-videos: the pre-check owns every
+      # --privacy value, the inline action only completes the flag name.
       _arguments \\
         '--channel[Channel handle or ID]:channel:' \\
         '--limit[Limit number of results]:n:' \\


### PR DESCRIPTION
## Why

`lib/completion.ts` builds each zsh command arm as a backwards-walk pre-check followed by an `_arguments` call. Both can complete the same flag's values, and nothing in the file recorded which one actually wins. That ambiguity is a live editing hazard: a reader tuning the `(public private unlisted)` action on the `_arguments` spec would see no effect at all and have no way to know why.

## What the runtime says

Instrumenting the two paths to emit distinguishable candidates and driving the generated script through a pty settles it:

| completion attempted | candidates offered | path |
|---|---|---|
| `list-videos --privacy <TAB>` | `PRE_*` | pre-check |
| `list-videos --privacy public <TAB>` | `PRE_*` | pre-check |
| `list-videos --priv<TAB>` | `--privacy` | `_arguments` |
| `get-videos --video-ids <TAB>` | `PRE_*` | pre-check |
| `get-video --video-id <TAB>` | `ARGS_*` | `_arguments` |

So the pre-check owns **every** value of a variadic flag, the first one included. The `_arguments` action for that flag only ever completes the flag name.

The mechanism is not obvious from reading. `local words=($words[1] $words[3,-1])` re-slices the array, and unquoted array expansion in zsh drops empty elements. The empty word being completed is exactly such an element, so `$words[$CURRENT]` ends up empty rather than holding the flag. The `!= -*` guard therefore passes even immediately after `--privacy`, and the walk-back returns before `_arguments` runs.

The inline action is still load-bearing and must not be deleted: it is what completes the flag name and supplies its description.

## Change

Comments only, at the four pre-check sites (`get-videos`, `get-video-localizations`, `list-videos`, `list-playlists`): state the division of labour, and point each site at `shell-completion-guide.md#variadic-pre-check-pattern`, which already documents the pattern but was not linked from the code.

## Verification

- `bun run type-check`, `bun run lint` (0 errors), `bun run build`, `bun test` (143 pass, 0 fail)
- Generated bash and zsh scripts diffed before and after: identical apart from comment lines
- Live pty re-check on the regenerated script: first value offers all three, `--privacy public <TAB>` correctly narrows to `private unlisted`, `--priv<TAB>` completes the flag name


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated zsh completion comments to clarify pre-check behavior for video IDs and privacy values.
  * Documented how pre-check logic works with argument actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->