### PR TITLE
fix(#167): send tfmt so get-caption --format actually converts

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -447,7 +447,7 @@ program
   .command('get-caption')
   .description('Download caption content to stdout (get caption ID from list-captions)')
   .requiredOption('--caption-id <id>', 'Caption ID')
-  .option('--format <format>', 'Caption format: srt, vtt, sbv, scc, ttml, json (default: json)', 'json')
+  .option('--format <format>', 'Caption format: raw, srt, vtt, sbv, ttml (default: raw)', 'raw')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('get-caption', getCaptionCommand));
 

--- a/commands/get-caption.ts
+++ b/commands/get-caption.ts
@@ -1,6 +1,6 @@
 import { downloadCaption } from '../lib/youtube';
-import { debug, initCommand, createSpinner } from '../lib/utils';
-import { GetCaptionOptions, CAPTION_FORMATS } from '../types';
+import { debug, initCommand, createSpinner, writeStdout } from '../lib/utils';
+import { GetCaptionOptions, CAPTION_FORMATS, CAPTION_FORMAT_ALIASES, CaptionFormat } from '../types';
 
 async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
   initCommand(options);
@@ -11,13 +11,25 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
     throw new Error('Required: --caption-id');
   }
 
-  if (options.format && !(CAPTION_FORMATS as readonly string[]).includes(options.format)) {
+  // `scc` used to be advertised but the API rejects it with HTTP 404 on every
+  // track tried (manual, ASR, several languages), so name the reason instead
+  // of listing it as merely invalid.
+  if (options.format === 'scc') {
+    throw new Error(
+      "Format 'scc' is not supported: the YouTube API rejects scc conversion " +
+      'for caption tracks (HTTP 404).\n' +
+      `Valid formats: ${CAPTION_FORMATS.join(', ')}`
+    );
+  }
+
+  const requested = options.format || 'raw';
+  const format: CaptionFormat = CAPTION_FORMAT_ALIASES[requested] ?? (requested as CaptionFormat);
+
+  if (!(CAPTION_FORMATS as readonly string[]).includes(format)) {
     throw new Error(`Invalid format '${options.format}'. Valid: ${CAPTION_FORMATS.join(', ')}`);
   }
 
   // Note: For caption metadata, use list-captions --video-id <videoId>
-  // This command focuses on downloading caption content
-  const format = options.format || 'json';
   const spinner = createSpinner(`Downloading caption (${format})...`).start();
 
   try {
@@ -26,8 +38,11 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
 
     spinner.succeed('Caption downloaded');
 
-    // Output caption content to stdout (allows redirection)
-    console.log(content);
+    // Must be writeStdout, not console.log: redirecting to a file is this
+    // command's primary use, and console.log silently truncates piped output
+    // at 65536 bytes with exit 0 (issue #161). Caption files cross that
+    // easily, ttml most of all.
+    await writeStdout(content.endsWith('\n') ? content : content + '\n');
   } catch (err) {
     spinner.fail('Failed to download caption');
     const errMessage = (err as Error).message;

--- a/commands/get-caption.ts
+++ b/commands/get-caption.ts
@@ -38,10 +38,16 @@ async function getCaptionCommand(options: GetCaptionOptions): Promise<void> {
 
     spinner.succeed('Caption downloaded');
 
+    // The contract here is byte fidelity, not newline normalization: this
+    // output is a caption file. srt, vtt and sbv end with two newlines, and
+    // that trailing blank line terminates the final cue, so collapsing it to
+    // one would corrupt the format. The conditional only guards against
+    // leaving a shell prompt mid-line if a format ever returns no trailing
+    // newline; every format observed live returns at least one.
+    //
     // Must be writeStdout, not console.log: redirecting to a file is this
     // command's primary use, and console.log silently truncates piped output
-    // at 65536 bytes with exit 0 (issue #161). Caption files cross that
-    // easily, ttml most of all.
+    // at 65536 bytes with exit 0 (issue #161). ttml on a long video crosses it.
     await writeStdout(content.endsWith('\n') ? content : content + '\n');
   } catch (err) {
     spinner.fail('Failed to download caption');

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -211,7 +211,7 @@ regardless of how the track was originally uploaded.
 > because `json` was the previous default, but it never produced JSON and the
 > API rejects `tfmt=json` outright. Parse the timed text formats instead. This
 > is why the older `--format json | jq '.[].text'` recipes do not work.
-
+>
 > **`scc` is not available.** The API rejects scc conversion for caption tracks
 > with HTTP 404 on every track type, so the CLI declines it up front rather
 > than forwarding a request that cannot succeed.
@@ -221,7 +221,7 @@ regardless of how the track was originally uploaded.
 Caption IDs are opaque strings assigned by YouTube, roughly 44 to 56
 characters, and they encode nothing you can construct by hand:
 
-```
+```text
 AUieDaZbd2DZ0wKrWG97SNiRKW7wUMhu8EHRLSSSOCGt3nWyK-SuEhLW
 ```
 

--- a/docs/commands/engagement.md
+++ b/docs/commands/engagement.md
@@ -170,7 +170,7 @@ staqan-yt get-caption --caption-id <captionId>
 
 - `--caption-id <id>` - Caption track ID (get from `list-captions`) (required)
 
-- `--format <format>` - Caption format: srt, vtt, sbv, scc, ttml, json (default: json)
+- `--format <format>` - Caption format: raw, srt, vtt, sbv, ttml (default: raw)
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
 
@@ -182,70 +182,81 @@ staqan-yt get-caption --caption-id <captionId>
 # List captions on one of your own videos to get the caption ID
 staqan-yt list-captions --video-id <your-video-id>
 
-# Download captions (JSON format by default)
+# Download the track in the format it was uploaded in
 staqan-yt get-caption --caption-id <caption-id>
 
 # Download as SRT (subtitle file format)
 staqan-yt get-caption --caption-id <caption-id> --format srt > captions.srt
 
-# Download as VTT
+# Download as VTT (web players)
 staqan-yt get-caption --caption-id <caption-id> --format vtt > captions.vtt
 
-# Download as text
-staqan-yt get-caption --caption-id <caption-id> --format json | jq -r '.[].text'
+# Extract plain text from the SRT output
+staqan-yt get-caption --caption-id <caption-id> --format srt | \
+  grep -v -E '^[0-9]+$|-->|^$'
 ```
 
 ### Caption Formats
 
-**Text formats:**
-- `json` - Structured JSON with timing (default)
-- `scc` - Scenarist Closed Caption format
+The API performs the conversion, so the requested format is what comes back
+regardless of how the track was originally uploaded.
 
-**Subtitle formats:**
+- `raw` (default) - the track exactly as uploaded, no conversion requested
 - `srt` - SubRip format (most players)
 - `vtt` - WebVTT format (web players)
 - `sbv` - YouTube subtitle format
-- `ttml` - TTML format (professional)
+- `ttml` - TTML format (professional, XML)
+
+> **No JSON output.** `--format json` is accepted as an alias for `raw`,
+> because `json` was the previous default, but it never produced JSON and the
+> API rejects `tfmt=json` outright. Parse the timed text formats instead. This
+> is why the older `--format json | jq '.[].text'` recipes do not work.
+
+> **`scc` is not available.** The API rejects scc conversion for caption tracks
+> with HTTP 404 on every track type, so the CLI declines it up front rather
+> than forwarding a request that cannot succeed.
 
 ### Caption ID Format
 
-Caption IDs typically follow the format:
-```
-<language_code>.<video_id>
-```
+Caption IDs are opaque strings assigned by YouTube, roughly 44 to 56
+characters, and they encode nothing you can construct by hand:
 
-Examples:
-- `en.<video-id>` - English captions
-- `ja.<video-id>` - Japanese captions
-- `en.<video-id>.3` - Multiple English tracks
+```
+AUieDaZbd2DZ0wKrWG97SNiRKW7wUMhu8EHRLSSSOCGt3nWyK-SuEhLW
+```
 
 Use `staqan-yt list-captions --video-id <your-video-id>` to get the exact caption ID for your videos.
 
 ### Working with Captions
 
+These use `--format srt` and strip the cue numbers, timestamps and blank lines
+that SRT puts between the text. Ask for `srt` explicitly rather than relying on
+the default, since `raw` returns whatever format the track happens to be in.
+
 **Extract plain text:**
 
 ```bash
-staqan-yt get-caption --caption-id <caption-id> --format json | \
-  jq -r '.[].text' > transcript.txt
+staqan-yt get-caption --caption-id <caption-id> --format srt | \
+  grep -v -E '^[0-9]+$|-->|^$' > transcript.txt
 ```
 
 **Create word cloud:**
 
 ```bash
-staqan-yt get-caption --caption-id <caption-id> --format json | \
-  jq -r '.[].text' | \
+staqan-yt get-caption --caption-id <caption-id> --format srt | \
+  grep -v -E '^[0-9]+$|-->|^$' | \
   tr '[:upper:]' '[:lower:]' | \
   tr -d '[:punct:]' | \
   tr ' ' '\n' | \
+  grep -v '^$' | \
   sort | uniq -c | sort -rn
 ```
 
 **Find mentions:**
 
 ```bash
-staqan-yt get-caption --caption-id <caption-id> --format json | \
-  jq -r '.[].text' | \
+staqan-yt get-caption --caption-id <caption-id> --format srt | \
+  grep -v -E '^[0-9]+$|-->|^$' | \
   grep -i '@\|twitter\|instagram'
 ```
 
@@ -312,28 +323,31 @@ staqan-yt list-comments --video-id VIDEO_ID --output json | \
 # Get plain text transcript from captions
 staqan-yt list-captions --video-id VIDEO_ID --output json | \
   jq -r '.[0].id' | \
-  xargs staqan-yt get-caption --caption-id --format json | \
-  jq -r '.[].text' > transcript.txt
+  xargs -I{} staqan-yt get-caption --caption-id {} --format srt | \
+  grep -v -E '^[0-9]+$|-->|^$' > transcript.txt
 ```
 
 ### Download Multiple Captions
 
+Take the language from the listing, not from the caption ID. IDs are opaque and
+carry no language prefix. The track kind is in the filename too, since a video
+can carry both a manual and an auto-generated track in the same language.
+
 ```bash
 # Download all available caption tracks
 staqan-yt list-captions --video-id VIDEO_ID --output json | \
-  jq -r '.[].id' | \
-  while read caption_id; do
-    language=$(echo $caption_id | cut -d. -f1)
-    staqan-yt get-caption --caption-id "$caption_id" --format srt > "${language}.srt"
+  jq -r '.[] | "\(.id)\t\(.language)\t\(.trackKind)"' | \
+  while IFS=$'\t' read -r caption_id language kind; do
+    staqan-yt get-caption --caption-id "$caption_id" --format srt > "${language}-${kind}.srt"
   done
 ```
 
 ### Caption Search
 
 ```bash
-# Search for specific terms in captions
-staqan-yt get-caption --caption-id en.VIDEO_ID --format json | \
-  jq -r '.[] | select(.text | contains("keyword"))'
+# Search for specific terms in captions, with the timestamp above each hit
+staqan-yt get-caption --caption-id <caption-id> --format srt | \
+  grep -i -B 2 'keyword'
 ```
 
 ### Comment Frequency Analysis

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -298,7 +298,7 @@ _staqa_nyt_completion() {
     --sort|-s)
       COMPREPLY=( \$(compgen -W "top new" -- "\${cur}") ); return ;;
     --format)
-      COMPREPLY=( \$(compgen -W "srt vtt sbv scc ttml json" -- "\${cur}") ); return ;;
+      COMPREPLY=( \$(compgen -W "raw srt vtt sbv ttml" -- "\${cur}") ); return ;;
     --dimensions)
       COMPREPLY=( \$(compgen -W "video day month insightTrafficSourceType insightTrafficSourceDetail creatorContentType country province city deviceType operatingSystem insightPlaybackLocationType insightPlayerLocationType subscribedStatus" -- "\${cur}") ); return ;;
     staqan-yt)
@@ -801,7 +801,7 @@ ${commandList}
       local CURRENT=\$((\$CURRENT - 1))
       _arguments \\
         '--caption-id[Caption ID]:id:( )' \\
-        '--format[Caption format]:format:(srt vtt sbv scc ttml json)' \\
+        '--format[Caption format]:format:(raw srt vtt sbv ttml)' \\
         '--verbose[Enable verbose output]'
       ;;
     put-caption)

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -1026,30 +1026,26 @@ async function listCaptions(videoId: string): Promise<CaptionInfo[]> {
 /**
  * Download caption content
  * @param captionId - Caption track ID
- * @param format - Output format (srt, vtt, sbv, scc, ttml, or json for raw)
+ * @param format - `raw` for the track's original format, or a format the API
+ *                 converts to (srt, vtt, sbv, ttml)
  * @returns Caption content as string
  */
-async function downloadCaption(captionId: string, format: CaptionFormat = 'json'): Promise<string> {
+async function downloadCaption(captionId: string, format: CaptionFormat = 'raw'): Promise<string> {
   debug(`Downloading caption: ${captionId}, format: ${format}`);
   const youtube = await getYouTubeClient();
 
-  // YouTube API downloads caption content
-  // The download endpoint returns the caption content
-  const response = await youtube.captions.download({
-    id: captionId,
-  }, { responseType: 'text' });
-
-  // The response is the actual caption content
-  const content = response.data as string;
-
-  // If format is json, just return the raw content
-  if (format === 'json') {
-    return content;
+  // `tfmt` is the only thing that makes --format do anything. Omitting it
+  // returns the track in whatever format it was uploaded in, which is what
+  // `raw` means. This used to be omitted unconditionally, so every --format
+  // value returned byte-identical content (issue #167).
+  const params: youtube_v3.Params$Resource$Captions$Download = { id: captionId };
+  if (format !== 'raw') {
+    params.tfmt = format;
   }
 
-  // For other formats, YouTube returns the format that was uploaded
-  // The user would need to convert if needed
-  return content;
+  const response = await youtube.captions.download(params, { responseType: 'text' });
+
+  return response.data as string;
 }
 
 export interface UploadedCaption {

--- a/tests/captions.test.ts
+++ b/tests/captions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { youtube_v3 } from 'googleapis';
 import { mapCaptionItem } from '../lib/youtube';
+import { CAPTION_FORMATS, CAPTION_TFMT_FORMATS, CAPTION_FORMAT_ALIASES } from '../types';
 
 function makeCaption(
   trackKind: string | undefined = 'standard',
@@ -157,5 +158,37 @@ describe('mapCaptionItem track state', () => {
     expect(mapCaptionItem(makeCaption('standard', 'unknown', { lastUpdated: '2026-07-12T09:27:27.554754Z' })).lastUpdated)
       .toBe('2026-07-12T09:27:27.554754Z');
     expect(mapCaptionItem(makeCaption('standard')).lastUpdated).toBeNull();
+  });
+});
+
+// Issue #167: --format was validated and then discarded, because tfmt was
+// never sent. These pin the format contract that makes the flag mean something.
+describe('caption format contract', () => {
+  it('offers only formats the API actually converts to, plus raw', () => {
+    expect([...CAPTION_FORMATS]).toEqual(['raw', 'srt', 'vtt', 'sbv', 'ttml']);
+  });
+
+  it('excludes scc, which the API rejects with 404 on every track type', () => {
+    expect(CAPTION_FORMATS as readonly string[]).not.toContain('scc');
+  });
+
+  it('excludes json, which is an HTTP 400 as a tfmt value', () => {
+    expect(CAPTION_FORMATS as readonly string[]).not.toContain('json');
+  });
+
+  it('keeps json working as an alias for raw, since it was the old default', () => {
+    expect(CAPTION_FORMAT_ALIASES.json).toBe('raw');
+  });
+
+  it('lists every tfmt format as an accepted format', () => {
+    for (const fmt of CAPTION_TFMT_FORMATS) {
+      expect(CAPTION_FORMATS as readonly string[]).toContain(fmt);
+    }
+  });
+
+  it('treats raw as the only non-tfmt format', () => {
+    const nonTfmt = (CAPTION_FORMATS as readonly string[])
+      .filter(f => !(CAPTION_TFMT_FORMATS as readonly string[]).includes(f));
+    expect(nonTfmt).toEqual(['raw']);
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -301,8 +301,23 @@ export type CaptionTrackStatus = 'serving' | 'syncing' | 'failed' | 'unknown';
 // `descriptive` is audio description, `commentary` is a commentary track.
 export type CaptionAudioTrackType = 'unknown' | 'primary' | 'commentary' | 'descriptive';
 
-export const CAPTION_FORMATS = ['srt', 'vtt', 'sbv', 'scc', 'ttml', 'json'] as const;
+// Formats the API converts to, passed straight through as `tfmt` on
+// captions.download. Live-verified: these four return genuinely different
+// bytes, and `scc` is rejected with HTTP 404 on every track type tried
+// (manual, ASR, multiple languages), so it is not offered (issue #167).
+export const CAPTION_TFMT_FORMATS = ['srt', 'vtt', 'sbv', 'ttml'] as const;
+export type CaptionTfmtFormat = typeof CAPTION_TFMT_FORMATS[number];
+
+// Values accepted by `get-caption --format`. `raw` omits `tfmt` entirely,
+// which returns the track in whatever format it was uploaded in.
+export const CAPTION_FORMATS = ['raw', 'srt', 'vtt', 'sbv', 'ttml'] as const;
 export type CaptionFormat = typeof CAPTION_FORMATS[number];
+
+// `json` was the previous default and never produced JSON: with `tfmt` never
+// sent, it returned the track's original format. `tfmt=json` is in fact an
+// HTTP 400. Kept as an alias for `raw` so existing scripts keep working
+// rather than failing on a renamed default.
+export const CAPTION_FORMAT_ALIASES: Record<string, CaptionFormat> = { json: 'raw' };
 
 // File extensions accepted for caption uploads (put-caption). The API
 // accepts any bytes and only fails during processing, so uploads are
@@ -338,7 +353,11 @@ export interface ListCaptionsOptions extends OutputOption, VerboseOption, VideoI
 
 export interface GetCaptionOptions extends OutputOption, VerboseOption, CaptionIdOption {
   download?: boolean;
-  format?: CaptionFormat;
+  // Raw user input, narrowed to CaptionFormat by the command after alias
+  // resolution. Typing this as CaptionFormat would claim commander validates
+  // it, which it does not, and hides retired values like `scc` from the
+  // client-side check.
+  format?: string;
 }
 
 export interface PutCaptionOptions extends OutputOption, VerboseOption, VideoIdOption {


### PR DESCRIPTION
Closes #167.

## The bug

`downloadCaption()` never passed `tfmt` to `captions.download`, so every value of `--format` returned byte-identical content: whatever format the track was uploaded in. `--format vtt` returned SRT. The flag was validated, threaded through the call, and then never read.

Exit status was 0 throughout. The documented `--format vtt > captions.vtt` recipe wrote SRT bytes into a `.vtt` file, and the failure surfaced later in a different tool with nothing pointing back at this command.

## Verification

One download per format, same track, live API:

| `--format` | before | after | first line |
|---|---|---|---|
| `raw` | 8698, md5 `7f488731` | 8697, md5 `4e322db6` | `1` |
| `srt` | 8698, md5 `7f488731` | 8238, md5 `8fa29c79` | `1` |
| `vtt` | 8698, md5 `7f488731` | 7990, md5 `81ed25e4` | `WEBVTT` |
| `sbv` | 8698, md5 `7f488731` | 7336, md5 `1293b6c2` | `0:00:13.847,0:00:15.147` |
| `ttml` | n/a | 11687, md5 `0b156114` | `<?xml version="1.0" encoding="utf-8" ?>` |
| `json` | 8698, md5 `7f488731` | 8697, md5 `4e322db6` | alias, byte-identical to `raw` |

Before, one md5 for everything. After, each format is distinct and correct. The no-flag default is byte-identical to `raw`, so existing behavior is unchanged.

## Format list reconciled with the API

Two advertised values were never real `tfmt` values:

- **`scc`** is rejected with HTTP 404 on every track tried (manual, ASR, two languages). Now declined client-side naming that reason, rather than listed as merely invalid.
- **`json`** is an HTTP 400 as a `tfmt` value. It was the default and only "worked" because `tfmt` was never sent, which returns the original format. That behavior is now spelled `raw`, with `json` kept as an alias so existing scripts keep running.

A fix that forwards `tfmt: format` unconditionally would break the default, which is why the mapping is explicit.

## Also in this PR

**`console.log` to `writeStdout` for the content write.** Redirecting to a file is this command's primary use, and `console.log` truncates piped output at 65536 bytes with exit 0 (#161). This is **latent, not active**: the largest caption on the channel is 11.7KB, so no current track crosses the threshold, but ttml on a long video would. The mechanism is already covered by the #161 regression guard, so no duplicate test is added.

**`GetCaptionOptions.format` is now `string`, not `CaptionFormat`.** Commander does not validate it, and typing it as the narrow union hid retired values like `scc` from the client-side check entirely.

## Docs

Every `get-caption` recipe in `docs/commands/engagement.md` was broken, independently of the `tfmt` bug. All are rewritten and run against the live API:

- Three `jq` recipes parsed output that was never JSON.
- One `xargs` recipe appended the ID *after* `--format json`, so `--caption-id` consumed the `--format` flag as its value.
- The multi-track downloader derived the language with `cut -d. -f1` from an ID format that does not exist. Real IDs are opaque, so every track of a video collided into one filename. It now takes the language from the listing, and includes `trackKind`, since a video can carry a manual and an auto-generated track in the same language.
- The "Caption ID Format" section documented that same fictional `<language_code>.<video_id>` shape.

Recipes verified end to end on a video with three tracks:

```
en-automatic.srt  10116 bytes
en-manual.srt      8238 bytes
ja-manual.srt      8892 bytes
```

Three distinct files, which is exactly what the old `cut -d. -f1` version could not produce.

`type-check` clean, `lint` clean (4 pre-existing `no-explicit-any` warnings elsewhere), tests 153 -> 159.

## Related

Same class as #147: a value is fetched or accepted, quietly discarded, and replaced with something shaped like a correct answer. #80 added the client-side `--format` validation without making the flag do anything, which is why it read as supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Caption downloads now default to the original (`raw`) format.
  - Added support for SRT, VTT, SBV, and TTML conversions.
  - `json` remains supported as an alias for `raw`.
  - Improved format validation, caption output preservation, and handling of unsupported SCC downloads.

- **Documentation**
  - Updated caption download guidance, examples, filtering workflows, and multi-caption instructions.
  - Refreshed shell completion options to match supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->