### PR TITLE
fix(#105): accept any BCP-47 language tag

### DIFF
--- a/docs/commands/metadata-management.md
+++ b/docs/commands/metadata-management.md
@@ -104,10 +104,25 @@ staqan-yt get-video-localization --video-id dQw4w9WgXcQ --language ja --output j
 
 ### Language Specification
 
-Accepts any of these formats:
-- Language code: `ja`, `en`, `ru`
-- Language name: `Japanese`, `English`, `Russian`
-- Full locale: `ja-JP`, `en-US`
+Any BCP-47 language tag is accepted:
+
+- Language code: `ja`, `ko`, `vi`, `ar`, `es`
+- Script or region subtags: `zh-Hans`, `pt-BR`, `en-US`
+- Language name, for the channel's three main languages only: `Japanese`,
+  `English`, `Russian` (plus short forms like `jp`, `eng`, `rus`)
+
+Tags are canonicalized, so `EN` becomes `en` and `zh-hans` becomes `zh-Hans`.
+
+A tag that is well-formed but names no actual language is rejected up front:
+
+```bash
+$ staqan-yt put-video-localization --video-id VIDEO_ID --language bogus ...
+✗ Invalid language: bogus. Pass a BCP-47 tag (ja, ko, zh-Hans, pt-BR) or one of the aliases: en, ja, ru.
+```
+
+> Before v2.1.x these commands accepted only `en`, `ja` and `ru` and rejected
+> everything else with `Invalid language`, which blocked localizing into
+> languages a channel might already publish captions in.
 
 ### What is a Localization?
 

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -32,6 +32,33 @@ function canonicalizeTag(tag: string): string | null {
   }
 }
 
+/**
+ * Display name for an already-canonical tag, or null when it names no
+ * language. Never throws.
+ *
+ * `of()` is stricter than `getCanonicalLocales`: it raises RangeError
+ * ("argument is not a language id") for extension and private-use subtags that
+ * canonicalize perfectly well, including legitimate tags like
+ * `de-DE-u-co-phonebk` and `en-x-private`. Those still name a real language, so
+ * the extensions are dropped and the base subtag is named instead, rather than
+ * leaking an ICU error message for valid input.
+ */
+function resolveDisplayName(canonical: string): string | null {
+  try {
+    return displayNames.of(canonical) ?? null;
+  } catch {
+    const base = canonical.split('-')[0];
+    if (!base || base === canonical) {
+      return null;
+    }
+    try {
+      return displayNames.of(base) ?? null;
+    } catch {
+      return null;
+    }
+  }
+}
+
 const LANGUAGE_MAP: LanguageMap = {
   'en': {
     code: 'en',
@@ -87,7 +114,7 @@ function normalizeLanguage(input: string | undefined | null): string | null {
 
   // Well-formed but not a language the platform recognizes. Passing it through
   // would trade a clear client-side error for an opaque one from the API.
-  if (!displayNames.of(canonical)) {
+  if (!resolveDisplayName(canonical)) {
     return null;
   }
 
@@ -139,7 +166,7 @@ function getLanguageName(code: string): string | null {
     return null;
   }
 
-  return displayNames.of(canonical) ?? null;
+  return resolveDisplayName(canonical);
 }
 
 /**

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -1,9 +1,36 @@
 /**
- * Language mapping and normalization utility for YouTube video localizations
- * Supports English, Japanese, and Russian with case-insensitive matching
+ * Language normalization for YouTube localizations and captions.
+ *
+ * Accepts any BCP-47 language tag (issue #105). The alias table below is a
+ * convenience layer for the channel's three main languages, so `japanese`,
+ * `jpn` and `jp` all resolve to `ja`; everything else is validated and named
+ * through `Intl`, which carries CLDR data for every tag the platform knows.
+ *
+ * This used to accept only `en`/`ja`/`ru` and throw `Invalid language` for
+ * anything else, which blocked localizing into languages the channel already
+ * publishes captions in.
  */
 
 import { LanguageMap } from '../types';
+
+// `fallback: 'none'` is the point of this: for a structurally well-formed tag
+// that is not a real language (`bogus`, `xx`), `of()` returns undefined rather
+// than echoing the input back. That is what separates a language code from an
+// arbitrary string, since BCP-47 syntax alone accepts any 2-8 letter subtag.
+const displayNames = new Intl.DisplayNames(['en'], { type: 'language', fallback: 'none' });
+
+/**
+ * Canonical BCP-47 form of a tag, or null when it is not well-formed.
+ * Fixes case and separators: `EN` becomes `en`, `zh-hans` becomes `zh-Hans`.
+ */
+function canonicalizeTag(tag: string): string | null {
+  try {
+    return Intl.getCanonicalLocales(tag)[0] ?? null;
+  } catch {
+    // RangeError: not a structurally valid tag (empty, digits, single letter).
+    return null;
+  }
+}
 
 const LANGUAGE_MAP: LanguageMap = {
   'en': {
@@ -24,75 +51,121 @@ const LANGUAGE_MAP: LanguageMap = {
 };
 
 /**
- * Normalize language input to ISO 639-1 code
- * @param input - Human-readable name or ISO code (case-insensitive)
- * @returns ISO code (en, ja, ru) or null if invalid
+ * Normalize language input to a canonical BCP-47 tag.
+ * @param input - Alias (`japanese`) or BCP-47 tag (`ja`, `zh-Hans`), any case
+ * @returns Canonical tag, or null if it is not a real language
  *
  * @example
- * normalizeLanguage('JAPANESE') // => 'ja'
- * normalizeLanguage('english') // => 'en'
- * normalizeLanguage('ru') // => 'ru'
- * normalizeLanguage('invalid') // => null
+ * normalizeLanguage('JAPANESE')  // => 'ja'
+ * normalizeLanguage('ko')        // => 'ko'
+ * normalizeLanguage('zh-hans')   // => 'zh-Hans'
+ * normalizeLanguage('bogus')     // => null  (well-formed, not a language)
+ * normalizeLanguage('123')       // => null  (not well-formed)
  */
 function normalizeLanguage(input: string | undefined | null): string | null {
   if (!input || typeof input !== 'string') {
     return null;
   }
 
-  const normalized = input.toLowerCase().trim();
+  const trimmed = input.trim();
+  const normalized = trimmed.toLowerCase();
 
+  // Aliases first, and not only for convenience: `jp` is a well-formed tag
+  // (and a region subtag) but not a language code, so canonicalization alone
+  // would accept it and then fail at the API. The table also collapses `eng`
+  // and `english` to the two-letter form the channel's metadata uses.
   for (const [code, data] of Object.entries(LANGUAGE_MAP)) {
     if (data.aliases.includes(normalized)) {
       return code;
     }
   }
 
-  return null;
+  const canonical = canonicalizeTag(trimmed);
+  if (!canonical) {
+    return null;
+  }
+
+  // Well-formed but not a language the platform recognizes. Passing it through
+  // would trade a clear client-side error for an opaque one from the API.
+  if (!displayNames.of(canonical)) {
+    return null;
+  }
+
+  return canonical;
 }
 
 /**
- * Validate if language is supported
- * @param input - Language to validate
- * @returns True if language is supported
+ * Validate that input names a real language.
+ * @param input - Alias or BCP-47 tag
+ * @returns True when it resolves to a language
  *
  * @example
- * isValidLanguage('ja') // => true
+ * isValidLanguage('ja')       // => true
  * isValidLanguage('Japanese') // => true
- * isValidLanguage('invalid') // => false
+ * isValidLanguage('vi')       // => true
+ * isValidLanguage('bogus')    // => false
  */
 function isValidLanguage(input: string | undefined | null): boolean {
   return normalizeLanguage(input) !== null;
 }
 
 /**
- * Get human-readable name from ISO code
- * @param code - ISO language code
- * @returns Human-readable name or null
+ * Human-readable name for a language code.
+ * @param code - BCP-47 tag (a code, not an alias)
+ * @returns Name, or null when the code names no language
  *
  * @example
- * getLanguageName('ja') // => 'Japanese'
- * getLanguageName('en') // => 'English'
- * getLanguageName('invalid') // => null
+ * getLanguageName('ja')      // => 'Japanese'
+ * getLanguageName('vi')      // => 'Vietnamese'
+ * getLanguageName('zh-Hans') // => 'Chinese, Simplified'
+ * getLanguageName('bogus')   // => null
  */
 function getLanguageName(code: string): string | null {
-  return LANGUAGE_MAP[code]?.name || null;
+  if (!code || typeof code !== 'string') {
+    return null;
+  }
+
+  // The alias table wins so the three main languages keep their established
+  // names regardless of what CLDR calls them in a future ICU version.
+  if (LANGUAGE_MAP[code]) {
+    return LANGUAGE_MAP[code].name;
+  }
+
+  const canonical = canonicalizeTag(code);
+  if (!canonical) {
+    return null;
+  }
+
+  return displayNames.of(canonical) ?? null;
 }
 
 /**
- * Get all supported language codes
- * @returns Array of ISO codes
+ * Language codes that have a friendly alias (`japanese`, `jp`, `eng`, ...).
+ *
+ * NOT the set of accepted languages: any BCP-47 tag is accepted since #105.
+ * This is the shortcut list, used for help text and as a smoke-test set.
  *
  * @example
- * getSupportedLanguages() // => ['en', 'ja', 'ru']
+ * getAliasedLanguages() // => ['en', 'ja', 'ru']
+ */
+function getAliasedLanguages(): string[] {
+  return Object.keys(LANGUAGE_MAP);
+}
+
+/**
+ * @deprecated Misleading since #105: the CLI accepts any BCP-47 tag, so there
+ * is no finite supported set. Kept as an alias for {@link getAliasedLanguages}
+ * so existing callers keep working. Use `isValidLanguage` to test one tag.
  */
 function getSupportedLanguages(): string[] {
-  return Object.keys(LANGUAGE_MAP);
+  return getAliasedLanguages();
 }
 
 export {
   normalizeLanguage,
   isValidLanguage,
   getLanguageName,
+  getAliasedLanguages,
   getSupportedLanguages,
   LANGUAGE_MAP
 };

--- a/lib/language.ts
+++ b/lib/language.ts
@@ -126,7 +126,10 @@ function getLanguageName(code: string): string | null {
   }
 
   // The alias table wins so the three main languages keep their established
-  // names regardless of what CLDR calls them in a future ICU version.
+  // names regardless of ICU version or platform. CLDR wording genuinely does
+  // differ between the two: macOS names zh-Hans "Chinese, Simplified" while
+  // Linux names it "Simplified Chinese". Display names are therefore for
+  // humans to read, never for callers to compare against.
   if (LANGUAGE_MAP[code]) {
     return LANGUAGE_MAP[code].name;
   }

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -2,7 +2,7 @@ import { google, youtube_v3 } from 'googleapis';
 import { promises as fs, createReadStream } from 'fs';
 import path from 'path';
 import { getAuthenticatedClient } from './auth';
-import { normalizeLanguage, getLanguageName } from './language';
+import { normalizeLanguage, getLanguageName, getAliasedLanguages } from './language';
 import { acquireLock, getLockPath } from './lock';
 import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PrivacyStatus, PlaylistInfo, PlaylistListItem, CommentInfo, ChannelInfo, CaptionInfo, CaptionFormat, CaptionTrackStatus, CaptionAudioTrackType } from '../types';
 import { debug, warning, CACHE_DIR } from './utils';
@@ -545,7 +545,10 @@ async function getVideoLocalization(videoId: string, language?: string): Promise
   } else {
     const normalized = normalizeLanguage(language);
     if (!normalized) {
-      throw new Error(`Invalid language: ${language}`);
+      throw new Error(
+      `Invalid language: ${language}. Pass a BCP-47 tag (ja, ko, zh-Hans, pt-BR) ` +
+      `or one of the aliases: ${getAliasedLanguages().join(', ')}.`
+    );
     }
     langCode = normalized;
   }
@@ -594,7 +597,10 @@ async function getAllVideoLocalizations(videoId: string, languageFilter: string[
   if (languageFilter && languageFilter.length > 0) {
     filterCodes = languageFilter.map(lang => normalizeLanguage(lang)).filter((code): code is string => code !== null);
     if (filterCodes.length === 0) {
-      throw new Error('No valid languages provided in filter');
+      throw new Error(
+      `No valid languages in filter: ${languageFilter.join(', ')}. ` +
+      'Pass BCP-47 tags (ja, ko, zh-Hans, pt-BR).'
+    );
     }
   }
 
@@ -647,7 +653,10 @@ async function putVideoLocalization(videoId: string, language: string, title: st
   const langCode = normalizeLanguage(language);
 
   if (!langCode) {
-    throw new Error(`Invalid language: ${language}`);
+    throw new Error(
+      `Invalid language: ${language}. Pass a BCP-47 tag (ja, ko, zh-Hans, pt-BR) ` +
+      `or one of the aliases: ${getAliasedLanguages().join(', ')}.`
+    );
   }
 
   debug(`Normalized language code: ${langCode}`);
@@ -708,7 +717,10 @@ async function updateVideoLocalization(videoId: string, language: string, title:
   const langCode = normalizeLanguage(language);
 
   if (!langCode) {
-    throw new Error(`Invalid language: ${language}`);
+    throw new Error(
+      `Invalid language: ${language}. Pass a BCP-47 tag (ja, ko, zh-Hans, pt-BR) ` +
+      `or one of the aliases: ${getAliasedLanguages().join(', ')}.`
+    );
   }
 
   debug(`Normalized language code: ${langCode}`);

--- a/tests/captions.test.ts
+++ b/tests/captions.test.ts
@@ -148,8 +148,13 @@ describe('mapCaptionItem track state', () => {
 
   it('resolves languageName to a human-readable name, falling back to the code', () => {
     expect(mapCaptionItem(makeCaption('standard', 'unknown', { language: 'ja' })).languageName).toBe('Japanese');
-    // getLanguageName only maps the localization languages (issue #105).
-    expect(mapCaptionItem(makeCaption('standard', 'unknown', { language: 'ko' })).languageName).toBe('ko');
+    // Every BCP-47 tag now resolves (issue #105). This previously fell back to
+    // the bare code for anything outside en/ja/ru, so the channel's real vi and
+    // ar caption tracks displayed as `vi (vi)` and `ar (ar)`.
+    expect(mapCaptionItem(makeCaption('standard', 'unknown', { language: 'ko' })).languageName).toBe('Korean');
+    expect(mapCaptionItem(makeCaption('standard', 'unknown', { language: 'vi' })).languageName).toBe('Vietnamese');
+    // The fallback still applies to codes that name no language, including the
+    // 'unknown' placeholder used when the API omits the field entirely.
     expect(mapCaptionItem(makeCaption('standard', 'unknown', { language: undefined })).languageName).toBe('unknown');
   });
 

--- a/tests/language.test.ts
+++ b/tests/language.test.ts
@@ -44,6 +44,26 @@ describe('normalizeLanguage', () => {
     expect(getLanguageName('tlh')).toBe('Klingon');
   });
 
+  // Intl.DisplayNames.of() is stricter than getCanonicalLocales: it raises
+  // RangeError for extension and private-use subtags that canonicalize fine.
+  // Unguarded, that surfaced as the raw ICU text "argument is not a language
+  // id" for input that is perfectly valid BCP-47.
+  it('accepts tags carrying extension or private-use subtags', () => {
+    expect(normalizeLanguage('en-x-private')).toBe('en-x-private');
+    expect(normalizeLanguage('de-DE-u-co-phonebk')).toBe('de-DE-u-co-phonebk');
+    expect(normalizeLanguage('en-US-x-foo')).toBe('en-US-x-foo');
+  });
+
+  it('names those tags from the base subtag instead of throwing', () => {
+    expect(getLanguageName('en-x-private')).toMatch(/english/i);
+    expect(getLanguageName('de-DE-u-co-phonebk')).toMatch(/german/i);
+  });
+
+  it('still rejects an extension tag whose base names no language', () => {
+    expect(normalizeLanguage('bogus-x-private')).toBeNull();
+    expect(getLanguageName('bogus-x-private')).toBeNull();
+  });
+
   it('returns null for malformed or empty input', () => {
     expect(normalizeLanguage('123')).toBeNull();
     expect(normalizeLanguage('x')).toBeNull();

--- a/tests/language.test.ts
+++ b/tests/language.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { normalizeLanguage, isValidLanguage, getLanguageName, getSupportedLanguages } from '../lib/language';
+import {
+  normalizeLanguage,
+  isValidLanguage,
+  getLanguageName,
+  getAliasedLanguages,
+  getSupportedLanguages,
+} from '../lib/language';
 
 describe('normalizeLanguage', () => {
   it('normalizes names and codes case-insensitively', () => {
@@ -9,23 +15,87 @@ describe('normalizeLanguage', () => {
     expect(normalizeLanguage(' ru ')).toBe('ru');
   });
 
-  it('returns null for unsupported input', () => {
-    // NOTE: this pins the current hardcoded en/ja/ru limitation — when #105
-    // (accept any BCP-47) lands, this expectation must flip.
-    expect(normalizeLanguage('ko')).toBeNull();
+  // Issue #105: this used to reject everything outside en/ja/ru, which blocked
+  // localizing into languages the channel already publishes captions in.
+  it('accepts any BCP-47 tag, not just the aliased three', () => {
+    expect(normalizeLanguage('ko')).toBe('ko');
+    expect(normalizeLanguage('vi')).toBe('vi');
+    expect(normalizeLanguage('ar')).toBe('ar');
+  });
+
+  it('canonicalizes case and script/region subtags', () => {
+    expect(normalizeLanguage('EN')).toBe('en');
+    expect(normalizeLanguage('zh-hans')).toBe('zh-Hans');
+    expect(normalizeLanguage('pt-br')).toBe('pt-BR');
+    expect(normalizeLanguage('en-us')).toBe('en-US');
+  });
+
+  it('rejects well-formed tags that name no language', () => {
+    // BCP-47 syntax alone accepts any 2-8 letter subtag, so canonicalization
+    // is not enough on its own: these are structurally valid and still wrong.
+    expect(normalizeLanguage('bogus')).toBeNull();
+    expect(normalizeLanguage('xx')).toBeNull();
+    expect(normalizeLanguage('klingon')).toBeNull();
+  });
+
+  it('still resolves a real code for an obscure language', () => {
+    // The rejection above is about unassigned tags, not about obscurity.
+    expect(normalizeLanguage('tlh')).toBe('tlh');
+    expect(getLanguageName('tlh')).toBe('Klingon');
+  });
+
+  it('returns null for malformed or empty input', () => {
+    expect(normalizeLanguage('123')).toBeNull();
+    expect(normalizeLanguage('x')).toBeNull();
     expect(normalizeLanguage('')).toBeNull();
     expect(normalizeLanguage(null)).toBeNull();
     expect(normalizeLanguage(undefined)).toBeNull();
   });
+
+  it('prefers the alias table over canonicalization', () => {
+    // `jp` is a well-formed tag and a region subtag, but not a language code.
+    // Without the alias it would canonicalize and then fail at the API.
+    expect(normalizeLanguage('jp')).toBe('ja');
+    expect(normalizeLanguage('eng')).toBe('en');
+  });
 });
 
-describe('isValidLanguage / getLanguageName / getSupportedLanguages', () => {
+describe('getLanguageName', () => {
+  it('names languages outside the alias table', () => {
+    expect(getLanguageName('ko')).toBe('Korean');
+    expect(getLanguageName('vi')).toBe('Vietnamese');
+    expect(getLanguageName('ar')).toBe('Arabic');
+  });
+
+  it('names script and region variants', () => {
+    expect(getLanguageName('zh-Hans')).toBe('Chinese, Simplified');
+    expect(getLanguageName('pt-BR')).toBe('Brazilian Portuguese');
+  });
+
+  it('keeps the aliased three stable regardless of CLDR wording', () => {
+    expect(getLanguageName('en')).toBe('English');
+    expect(getLanguageName('ja')).toBe('Japanese');
+    expect(getLanguageName('ru')).toBe('Russian');
+  });
+
+  it('returns null rather than echoing an unknown code back', () => {
+    expect(getLanguageName('klingon')).toBeNull();
+    expect(getLanguageName('bogus')).toBeNull();
+    expect(getLanguageName('')).toBeNull();
+  });
+});
+
+describe('isValidLanguage / getAliasedLanguages', () => {
   it('agree with each other', () => {
-    for (const code of getSupportedLanguages()) {
+    for (const code of getAliasedLanguages()) {
       expect(isValidLanguage(code)).toBe(true);
       expect(getLanguageName(code)).toBeTruthy();
     }
     expect(isValidLanguage('klingon')).toBe(false);
     expect(getLanguageName('klingon')).toBeNull();
+  });
+
+  it('keeps getSupportedLanguages working as a deprecated alias', () => {
+    expect(getSupportedLanguages()).toEqual(getAliasedLanguages());
   });
 });

--- a/tests/language.test.ts
+++ b/tests/language.test.ts
@@ -67,9 +67,21 @@ describe('getLanguageName', () => {
     expect(getLanguageName('ar')).toBe('Arabic');
   });
 
+  // Display strings come from CLDR and their wording varies by ICU version:
+  // macOS returns "Chinese, Simplified" for zh-Hans where Linux CI returns
+  // "Simplified Chinese". Assert what the code guarantees (a resolved name
+  // that is not the raw tag) rather than one platform's phrasing. This is the
+  // same reason the alias table pins the names for en/ja/ru.
   it('names script and region variants', () => {
-    expect(getLanguageName('zh-Hans')).toBe('Chinese, Simplified');
-    expect(getLanguageName('pt-BR')).toBe('Brazilian Portuguese');
+    const zh = getLanguageName('zh-Hans');
+    expect(zh).toBeTruthy();
+    expect(zh).not.toBe('zh-Hans');
+    expect(zh).toMatch(/chinese/i);
+
+    const pt = getLanguageName('pt-BR');
+    expect(pt).toBeTruthy();
+    expect(pt).not.toBe('pt-BR');
+    expect(pt).toMatch(/portuguese/i);
   });
 
   it('keeps the aliased three stable regardless of CLDR wording', () => {


### PR DESCRIPTION
Closes #105.

## Not cosmetic

`normalizeLanguage` matched a hardcoded alias table for `en`/`ja`/`ru` and returned null for everything else, and null is a **throw** at three call sites:

```
$ staqan-yt put-video-localization --video-id <id> --language ko --title x --description y
✗ Invalid language: ko                                    (exit 1)

$ staqan-yt get-video-localizations --video-ids <id> --languages vi
✗ No valid languages provided in filter                   (exit 1)
```

`update-video-localization` took the same path. The channel already publishes caption tracks in `vi` and `ar`, so it could not localize into languages it was already serving. The docs meanwhile advertised `es`, `de` and `fr` as "common language codes", none of which the code accepted.

## Validation via Intl

- `Intl.getCanonicalLocales` rejects malformed input and canonicalizes the rest: `EN` to `en`, `zh-hans` to `zh-Hans`.
- `Intl.DisplayNames` with `fallback: 'none'` returns undefined for a well-formed tag naming no language. That is the part that matters: BCP-47 syntax alone accepts any 2-8 letter subtag, so canonicalization on its own would happily pass `bogus` and `xx`.

| input | before | after |
|---|---|---|
| `ko`, `vi`, `ar`, `es`, `de`, `fr` | rejected | accepted, named |
| `zh-hans` | rejected | `zh-Hans`, named as Chinese |
| `pt-br` | rejected | `pt-BR`, named as Portuguese |
| `EN` | rejected | `en` |
| `tlh` | rejected | `tlh`, "Klingon" |
| `bogus`, `xx`, `klingon` | rejected | still rejected |
| `123`, `x`, `''` | rejected | still rejected |

The alias table is kept and checked **first**, for correctness as much as convenience: `jp` is a well-formed tag and a region subtag, but not a language code. Canonicalization alone would accept it and then fail at the API.

`getLanguageName` now names any tag, with the alias table winning for `en`/`ja`/`ru` so those stay stable across ICU versions.

`getSupportedLanguages` became misleading once any tag is accepted, so it is renamed `getAliasedLanguages` with the old name kept as a deprecated alias.

## Knock-on fix to list-captions

`list-captions` resolves `languageName` through the same helper, so the channel's real `vi` and `ar` tracks displayed as `vi (vi)` and `ar (ar)`. Now:

```
1. Vietnamese (vi)
   Caption ID: AUieDaaC9YNO10zMR56eDUT9moi4DvaDwpXzhsrp2K6PUADIuTY
   Source:     automatic (YouTube-generated)
   Visibility: serving (visible to viewers)
```

The #147 test that pinned the old fallback is updated, which is the intended direction: it carried a note saying this expectation must flip when #105 lands.

## Verification

Read paths, live: `--languages vi` and `--languages es,de,fr` now exit 0 where they exited 1; `bogus` is still rejected, with a message that names the expected format.

Write paths, live: a `ko` localization was created, read back, and updated through `put-video-localization` / `get-video-localizations` / `update-video-localization`, then the video was restored to its **exact** original state (`diff` clean against a full pre-capture of `snippet` + `localizations`). This was done on an unlisted internal-use video, never a published one.

One note from that round-trip, since it is a real trap: an incomplete `snippet` on `videos.update` causes YouTube to re-derive omitted fields. A first restore attempt that sent only title/description/categoryId/tags/defaultLanguage silently flipped `defaultAudioLanguage` from `en` to `en-US`. The CLI does not have this bug: `putVideoLocalization` spreads the full `...video.snippet`. It was my restore script, and the field was set back.

## Portability note, caught by CI

The first push passed locally and failed CI. CLDR display strings differ by ICU version and platform: macOS names `zh-Hans` "Chinese, Simplified", Linux names it "Simplified Chinese". The test asserted one platform's phrasing.

Fixed in `155e6ac` by asserting what the code guarantees for script and region variants (a resolved name that is not the raw tag, naming the right language) rather than an exact string. Single-word names like Korean and Vietnamese pass identically on both platforms and are unchanged.

This is the same reasoning that already justified the alias table pinning `en`/`ja`/`ru`; it just had not been carried into the test. Display names are for humans to read, never for callers to compare against, and that is now stated at `getLanguageName`.

`type-check` clean, `lint` clean (4 pre-existing `no-explicit-any` warnings elsewhere), tests 159 -> 163.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Localization commands now support recognized BCP-47 language tags, including regional and extended variants.
  * Language tags are automatically canonicalized and displayed with human-readable names.
  * Existing channel-language aliases remain supported for compatibility.
* **Bug Fixes**
  * Invalid or unrecognized language inputs are rejected earlier with clearer guidance and examples.
  * Caption language names now resolve correctly for additional languages, including Korean and Vietnamese.
* **Documentation**
  * Updated localization command documentation to describe supported language tags, aliases, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->