### PR TITLE
fix(#170): assert pipe truncation as a band, not an exact byte count

### DIFF
--- a/tests/stdout-flush.test.ts
+++ b/tests/stdout-flush.test.ts
@@ -23,6 +23,11 @@ import os from 'os';
 import path from 'path';
 
 const PIPE_BUFFER_BYTES = 65536;
+// How far past the buffer a truncated write may land. The cut point is a race
+// between process exit and the pipe drain, so it is not exactly the buffer
+// size every time; CI has been seen at 65537. Kept far below the full payload
+// so the band still distinguishes truncation from a complete write.
+const TRUNCATION_SLOP_BYTES = 64;
 const ROWS = 4000;
 const UTILS = path.resolve('lib/utils');
 // Absolute specifiers: the scripts run from a temp dir, where a bare 'ora'
@@ -68,7 +73,15 @@ describe('writeStdout under the ora exit hooks (issue #161)', () => {
       `import ora from '${ORA}';
        ora('spinner');
        console.log(${PAYLOAD});`));
-    expect(out.stdout.length).toBe(PIPE_BUFFER_BYTES);
+
+    // Asserted as a band, not as exactly PIPE_BUFFER_BYTES (issue #170). Where
+    // the write is cut is a race between process exit and the pipe drain, so
+    // CI intermittently observed 65537 and failed PRs that touched nothing
+    // near this code. The claim being pinned is "truncated, at the pipe
+    // boundary", and the full payload is roughly 4.7x the buffer, so the band
+    // cannot be reached by anything except truncation right there.
+    expect(out.stdout.length).toBeGreaterThanOrEqual(PIPE_BUFFER_BYTES);
+    expect(out.stdout.length).toBeLessThan(PIPE_BUFFER_BYTES + TRUNCATION_SLOP_BYTES);
   });
 
   it('the same payload is complete without ora, which is why this was missed', async () => {


### PR DESCRIPTION
Closes #170.

## The problem

The #161 regression guard asserted that a truncated `console.log` payload is **exactly** the pipe buffer size:

```ts
expect(out.stdout.length).toBe(PIPE_BUFFER_BYTES);   // 65536
```

Where the write gets cut is a race between process exit and the kernel draining the pipe. That number is an observation, not a guarantee, and CI intermittently saw 65537.

Confirmed flaky rather than a real failure: run `32054828596` **failed** on its first attempt and **passed** on a re-run of the same commit, on a branch that touches neither this file nor anything it imports. The cost is not the re-run: a red `checks` job in a file the author never touched trains everyone to assume CI is broken, which is what lets a real regression through later.

## The fix

The claim this test exists to pin, in its own comment, is that truncation still happens. Exactness was never part of that claim. Asserted as a band:

```ts
expect(out.stdout.length).toBeGreaterThanOrEqual(PIPE_BUFFER_BYTES);
expect(out.stdout.length).toBeLessThan(PIPE_BUFFER_BYTES + TRUNCATION_SLOP_BYTES);
```

The full payload is **310892 bytes**, roughly 4.7x the buffer, so nothing except truncation at the pipe boundary can land inside a 64-byte band above 65536. The guard does not weaken.

## Verification

Band checked against the values that matter:

| observed length | verdict | meaning |
|---|---|---|
| 65536 | pass | what macOS produces |
| 65537 | pass | the CI flake |
| 65599 | pass | last accepted |
| 65600 | fail | first rejected |
| 310892 | fail | not truncated at all, a real regression |
| 0 | fail | empty output, a real regression |

The truncation test was run 10x locally: 10 pass, 0 fail. It also passed 12/12 locally *before* the change, which is consistent with the flake being Linux/CI timing specific and not reproducible on macOS. Full suite green, 172 tests.

The sibling assertions in this same file were already written as inequalities (`toBeGreaterThan(PIPE_BUFFER_BYTES)`), so this only brings the one exact-match case into line with them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stdout truncation regression coverage to accommodate expected timing variability.
  * Added clearer documentation around acceptable truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->