### PR TITLE
fix(#143): reconcile the --dimensions allowlist with the live API

### DIFF
--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -62,14 +62,17 @@ staqan-yt get-video-analytics --video-id dQw4w9WgXcQ --output json
 
 ### Default Metrics
 
-If no `--metrics` specified, fetches:
+If no `--metrics` specified, fetches these eight (`DEFAULT_VIDEO_METRICS` in `lib/analytics.ts`):
 - `views` - Total views
 - `estimatedMinutesWatched` - Total watch time
 - `averageViewDuration` - Average view duration (seconds)
-- `subscribersGained` - Subscribers gained
-- `subscribersLost` - Subscribers lost
+- `averageViewPercentage` - Average share of the video watched
 - `likes` - Total likes
 - `dislikes` - Total dislikes (if available)
+- `comments` - Total comments
+- `shares` - Total shares
+
+The last four are unavailable for most dimensions, so pass `--metrics views` when using `--dimensions`. See [Dimension Compatibility Guide](../dimension-compatibility.md#metrics-decide-more-than-dimensions-do).
 
 ### Available Metrics
 

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -97,15 +97,21 @@ By default, queries aggregate by `video` (the only dimension when `--dimensions`
 
 Supported dimensions for video-level queries:
 
-- `day`, `month` — Time buckets
-- `insightTrafficSourceType`, `insightTrafficSourceDetail` — Traffic sources (aggregate and per-referrer)
-- `creatorContentType` — `SHORT`, `LONG_FORM`, `LIVE`
-- `country`, `province`, `city` — Geography
-- `deviceType`, `operatingSystem` — Device
-- `insightPlaybackLocationType`, `insightPlayerLocationType` — Where playback happened
-- `subscribedStatus` — Subscribed vs non-subscribed viewers
+- `day`, `month` - Time buckets (`month` needs first-of-month dates at both ends)
+- `insightTrafficSourceType` - Traffic sources
+- `creatorContentType` - `SHORT`, `LONG_FORM`, `LIVE`
+- `liveOrOnDemand` - Live vs on-demand playback
+- `country`, `dma` - Geography
+- `deviceType`, `operatingSystem` - Device
+- `youtubeProduct` - Core YouTube, Music, Kids, Gaming
+- `insightPlaybackLocationType` - Where playback happened
+- `subscribedStatus` - Subscribed vs non-subscribed viewers
 
-Combine multiple dimensions with commas (e.g. `--dimensions day,country`). The CLI rejects unknown dimensions and known-bad combinations (e.g. `creatorContentType + insightTrafficSourceDetail` — see #88, fixed in PR #90) with a clear error before any API call.
+Combine multiple dimensions with commas (e.g. `--dimensions day,deviceType`). The CLI rejects unknown dimensions and known-bad combinations (e.g. `country + day`) with a clear error before any API call.
+
+**Most dimensions need `--metrics` narrowed.** The default metric set includes `likes`, `dislikes`, `comments` and `shares`, which the API only offers for a few dimensions, so `--dimensions deviceType` fails until you pass something like `--metrics views`. This is the most common cause of `The query is not supported`.
+
+**→ See [Dimension Compatibility Guide](../dimension-compatibility.md)** for the measured dimension/metric matrix, the rejected combinations, and the `month` date rule.
 
 ---
 

--- a/docs/dimension-compatibility.md
+++ b/docs/dimension-compatibility.md
@@ -1,319 +1,190 @@
 # YouTube Analytics Dimension Compatibility Guide
 
+Which `--dimensions` values `get-video-analytics` accepts, and why some
+combinations are refused before the request is sent.
+
 ## Overview
 
-This guide documents which dimension combinations work with the YouTube Analytics API v2 for video-level queries. These findings are based on comprehensive testing with both regular videos and Shorts.
+Every claim in this guide was measured against the live Analytics API. Where an
+earlier revision of this document guessed, the guess is called out and
+corrected, because two of them were wrong in ways that cost real queries.
 
-**Key Finding:** Maximum **4 dimensions** can be combined in a single API call (this is the largest combination tested that works reliably - the API may have technical constraints that limit combinations).
+**The single most important fact:** compatibility is a property of the
+**dimensions and the metrics together**, not of the dimensions alone. Most
+"this dimension does not work" reports are actually the default metric set being
+incompatible with that dimension. See [Metrics decide more than dimensions
+do](#metrics-decide-more-than-dimensions-do).
 
-**Important:** YouTube Analytics API docs list "core dimensions" (ageGroup, channel, country, day, gender, month, sharingService, uploaderType, video), but this does NOT mean all core dimensions can be combined. In fact, most core dimension combinations are incompatible for video-level queries.
+## Metrics decide more than dimensions do
 
-## Testing Methodology
+`get-video-analytics` sends eight metrics by default:
 
-- **Test Videos:**
-  - Regular video: `IerglMlrGUc` (2 years old, established data)
-  - Shorts video: `eeYl2dxv57g` (recent, for comparison)
-- **Test Period:** 2024-01-01 to 2024-01-07 (7 days); 2024-01-01 to 2024-03-01 (3 months for month dimension)
-- **Tests Run:** 100+ combinations tested
-- **Test Coverage:** All single dimensions, all pairs, working triples, working quadruples
-- **API Coverage:** All 24 dimensions from YouTube Analytics API v2 docs tested; 11 supported (all that work for video queries)
-
-## Dimension Categories
-
-### YouTube API "Core Dimensions" - What Works for Video Queries?
-
-The YouTube Analytics API documentation lists these as "core dimensions":
-- `ageGroup` - Channel-level only (NOT for video queries)
-- `channel` - Not applicable for video queries
-- `country` - ✅ Works for video queries
-- `day` - ✅ Works for video queries
-- `gender` - Channel-level only (NOT for video queries)
-- `month` - ✅ Works for video queries (with full calendar month date ranges)
-- `sharingService` - Channel-level only (NOT for video queries)
-- `uploaderType` - Not applicable for video queries
-- `video` - This is a filter, not a breakdown dimension
-
-**Critical Limitation:** Even though `country`, `day`, and `month` are all "core dimensions" that work for video queries, they CANNOT be combined:
-- ❌ `country + day` - REJECTED by API
-- ❌ `country + month` - Not tested (likely rejected)
-- ❌ `day + month` - REJECTED (conflicting time granularities)
-- ❌ `country + day + month` - REJECTED
-
-**Lesson:** "Core dimensions" means they're important/frequently used, NOT that they're compatible with each other.
-
-### ✅ Always Works (Single Dimensions)
-
-These dimensions work individually:
-- `country` - Two-letter ISO country code
-- `day` - Daily breakdown (YYYY-MM-DD)
-- `deviceType` - Desktop, mobile, tablet, TV, game console, etc.
-- `operatingSystem` - Android, iOS, Windows, macOS, etc.
-- `subscribedStatus` - Subscribed vs. unsubscribed viewers
-- `insightTrafficSourceType` - Search, suggested, external, browse, etc.
-- `insightPlaybackLocationType` - Watch page, embedded, channel page, etc.
-- `creatorContentType` - Livestream, shorts, story, video on demand
-- `youtubeProduct` - Core YouTube, Gaming, Kids, Music
-
-### ⚠️ Conditionally Works
-
-- `month` - Requires date range spanning full calendar months (start on 1st, end on last day)
-- `liveOrOnDemand` - Works with some dimensions, not others
-
-### ❌ Channel-Level Only (Not for Video Queries)
-
-- `ageGroup` - Viewer age brackets (18-24, 25-34, etc.)
-- `gender` - Viewer gender (male, female)
-- `sharingService` - Platform used to share the video
-
-### ❌ Requires Additional Filters
-
-- `province` - US state (requires `country==US` filter)
-- `dma` - Nielsen market area (requires additional filters)
-- `city` - City-level (requires additional filters)
-
-## Proven Working Combinations
-
-### Maximum Combination (4 Dimensions)
-
-**✅ Best maximum-coverage combination:**
 ```text
-country,creatorContentType,subscribedStatus,youtubeProduct
+views, estimatedMinutesWatched, averageViewDuration, averageViewPercentage,
+likes, dislikes, comments, shares
 ```
 
-This combination:
-- Works with both regular videos and Shorts
-- Works across different time periods
-- Provides good coverage of audience, content, and platform dimensions
-- Tested and confirmed reliable
+The four engagement metrics (`likes`, `dislikes`, `comments`, `shares`) are only
+available for a few dimensions. Measured on 2026-08-20, one metric at a time,
+against a video-level query:
 
-### Other Working 4-Dimension Combinations
+| dimension | views | estimatedMinutesWatched | averageViewDuration | averageViewPercentage | likes | dislikes | comments | shares |
+|---|---|---|---|---|---|---|---|---|
+| `day` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `subscribedStatus` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| `deviceType` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `youtubeProduct` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
-Based on test results, these also work:
-- `country, creatorContentType, subscribedStatus, youtubeProduct` ✅
-- `day, deviceType, operatingSystem, subscribedStatus` ✅
-- `creatorContentType, day, deviceType, subscribedStatus` ✅
-- `creatorContentType, deviceType, operatingSystem, subscribedStatus` ✅
+Because the default set contains all eight, `--dimensions deviceType` fails
+with the default metrics even though `deviceType` is a perfectly valid
+dimension. Pass a compatible metric set:
 
-### Working 3-Dimension Combinations
-
-Many 3-dimension combinations work. Examples:
-- `country, creatorContentType, subscribedStatus` ✅
-- `country, subscribedStatus, youtubeProduct` ✅
-- `day, deviceType, operatingSystem` ✅
-- `deviceType, operatingSystem, subscribedStatus` ✅
-- `creatorContentType, day, deviceType` ✅
-
-### Working 2-Dimension Combinations
-
-Most pairs work, except when `country` is combined with time-based dimensions:
-- ✅ `day, deviceType`
-- ✅ `day, operatingSystem`
-- ✅ `day, subscribedStatus`
-- ✅ `deviceType, operatingSystem`
-- ✅ `deviceType, subscribedStatus`
-- ✅ `operatingSystem, subscribedStatus`
-- ❌ `country, day` (REJECTED)
-- ❌ `country, deviceType` (REJECTED)
-- ❌ `country, operatingSystem` (REJECTED)
-
-## Incompatible Combinations
-
-### ❌ Country + Time/Device Dimensions
-
-`country` cannot be combined with:
-- `day`
-- `deviceType`
-- `operatingSystem`
-
-**Error:** "The query is not supported. Check the documentation at https://developers.google.com/youtube/analytics/v2/available_reports for a list of supported queries."
-
-**Workaround:** Use separate queries or choose a different dimension combination.
-
-### ❌ 5+ Dimensions
-
-Any combination of 5 or more dimensions will be rejected by the API.
-
-**Example:** `country, creatorContentType, subscribedStatus, youtubeProduct, day` → REJECTED
-
-### ❌ Specific Dimension Conflicts
-
-- `insightTrafficSourceType` conflicts with many device/time dimensions
-- `insightPlaybackLocationType` conflicts with many device/time dimensions
-- `liveOrOnDemand` conflicts with many device/time dimensions
-
-## Recommendations
-
-### For Maximum Coverage
-
-Use the proven 4-dimension combination:
 ```bash
 staqan-yt get-video-analytics --video-id VIDEO_ID \
-  --dimensions country,creatorContentType,subscribedStatus,youtubeProduct
+  --dimensions deviceType,operatingSystem --metrics views
 ```
 
-This provides:
-- Geographic breakdown (`country`)
-- Content type (`creatorContentType`)
-- Subscription status (`subscribedStatus`)
-- Platform (`youtubeProduct`)
+The client-side allowlist deliberately does **not** model this. It answers only
+"can this dimension ever work", so it is validated with the most permissive
+metric set (`views`). A dimension rejected there is rejected for every metric
+set; one accepted there may still need `--metrics` narrowed.
 
-### For Time-Based Analysis
+## Supported dimensions
 
-Use time-based dimensions separately:
+These are accepted for a video-level query with no extra filters, which is the
+only query shape this CLI sends:
+
+`video`, `day`, `month`, `country`, `dma`, `deviceType`, `operatingSystem`,
+`subscribedStatus`, `youtubeProduct`, `liveOrOnDemand`, `creatorContentType`,
+`insightTrafficSourceType`, `insightPlaybackLocationType`
+
+`month` carries a date-range rule, described below.
+
+## Not supported, and why
+
+| dimension | reason |
+|---|---|
+| `province` | Needs a `country==US` filter. Works when supplied, but the CLI has no way to send one. |
+| `city` | Rejected for video queries even with a `country==US` filter. |
+| `insightTrafficSourceDetail` | Rejected for video queries even with an `insightTrafficSourceType` filter. |
+| `insightPlaybackLocationDetail` | Rejected even with an `insightPlaybackLocationType` filter. |
+| `insightPlayerLocationType` | Not a real identifier. The API answers `Unknown identifier`. |
+| `ageGroup`, `gender`, `sharingService` | Channel-level only. Use `get-channel-analytics`. |
+| `channel`, `playlist`, `group`, `uploaderType` | Not applicable to video queries. |
+| `continent`, `subContinent` | Filter-only, not breakdown dimensions. |
+
+`province`, `city` and `insightTrafficSourceDetail` used to be allowlisted. They
+could never succeed, so the only thing that changed by removing them is that the
+error now names the problem instead of returning the API's generic "query is not
+supported".
+
+## The `month` dimension needs first-of-month dates
+
+**Both** `--start-date` and `--end-date` must be the first day of a month. The
+end date is *not* the last day of the range's final month, which is what an
+earlier revision of this guide advised and what the API rejects.
+
+| range | result |
+|---|---|
+| `2026-07-01` .. `2026-07-31` | ❌ `end-date does not align to chosen date dimension` |
+| `2026-06-01` .. `2026-06-30` | ❌ same |
+| `2026-07-05` .. `2026-07-20` | ❌ `start-date does not align` |
+| `2026-07-01` .. `2026-08-01` | ✅ 2 rows |
+| `2026-06-01` .. `2026-08-01` | ✅ 2 rows |
+| `2026-07-01` .. `2026-07-01` | ✅ 1 row |
+
+## Rejected combinations
+
+These are refused client-side, so they cost no quota. Each was measured as
+rejected with `--metrics views`, meaning no metric set can rescue them.
+
+**Geography does not cross with daily, device or insight breakdowns:**
+
+- `country` + `day`
+- `country` + `deviceType`
+- `country` + `operatingSystem`
+- `country` + `insightTrafficSourceType`
+- `country` + `insightPlaybackLocationType`
+- `country` + `dma`
+
+**Two time granularities cannot be requested at once:**
+
+- `day` + `month`
+
+**Device breakdowns do not cross with monthly or insight breakdowns:**
+
+- `month` + `deviceType`
+- `insightTrafficSourceType` + `deviceType`
+- `insightPlaybackLocationType` + `deviceType`
+
+This table is measured, not exhaustive. A pair that is absent is passed through,
+and the API's own error surfaces if it dislikes the request.
+
+### `country` + `month` is allowed
+
+Worth stating explicitly, because an earlier revision guessed it was rejected.
+It returns data given first-of-month dates:
+
 ```bash
-# Daily breakdown with device type
 staqan-yt get-video-analytics --video-id VIDEO_ID \
-  --dimensions day,deviceType,operatingSystem,subscribedStatus
-
-# Daily breakdown only
-staqan-yt get-video-analytics --video-id VIDEO_ID \
-  --dimensions day
+  --dimensions country,month --start-date 2026-06-01 --end-date 2026-08-01
 ```
 
-### For Geographic Analysis
+## There is no four-dimension ceiling
 
-Use `country` with compatible dimensions:
+Earlier revisions of this guide stated a maximum of 4 dimensions. That was a
+misattribution. The 5-dimension example used to demonstrate it was
+`country,creatorContentType,subscribedStatus,youtubeProduct,day`, which contains
+`country,day`, and that pair fails on its own at 2 dimensions.
+
+Seven dimensions in one query is accepted:
+
 ```bash
-# Country by subscription status and platform
-staqan-yt get-video-analytics --video-id VIDEO_ID \
+staqan-yt get-video-analytics --video-id VIDEO_ID --metrics views \
+  --dimensions day,deviceType,operatingSystem,subscribedStatus,youtubeProduct,creatorContentType,liveOrOnDemand
+```
+
+Measured: 465 rows. No arity limit was found, so none is enforced.
+
+## Useful combinations
+
+All are shown with a compatible metric set.
+
+```bash
+# Geography by audience and platform
+staqan-yt get-video-analytics --video-id VIDEO_ID --metrics views \
   --dimensions country,subscribedStatus,youtubeProduct
 
-# Country by content type
-staqan-yt get-video-analytics --video-id VIDEO_ID \
-  --dimensions country,creatorContentType
+# Daily trend with device detail
+staqan-yt get-video-analytics --video-id VIDEO_ID --metrics views \
+  --dimensions day,deviceType,operatingSystem
+
+# Full engagement over time (day supports every default metric)
+staqan-yt get-video-analytics --video-id VIDEO_ID --dimensions day
 ```
 
-### For Device/OS Analysis
+## Common errors
 
-Use device and OS dimensions together:
-```bash
-# Device and OS breakdown
-staqan-yt get-video-analytics --video-id VIDEO_ID \
-  --dimensions deviceType,operatingSystem,subscribedStatus
-```
-
-## Testing Your Combinations
-
-The CLI validates `--dimensions` against a client-side allowlist first (fast, clear errors for typos and one known-bad combination — see below); combinations that pass the allowlist but that the API rejects surface the API's own error directly, so you always have accurate information about what the API supports.
-
-### Shipped allowlist vs. this tested matrix
-
-The current `get-video-analytics --dimensions` allowlist is: `video`, `day`, `month`, `insightTrafficSourceType`, `insightTrafficSourceDetail`, `creatorContentType`, `country`, `province`, `city`, `deviceType`, `operatingSystem`, `insightPlaybackLocationType`, `insightPlayerLocationType`, `subscribedStatus`. Known gaps against this matrix (tracked in a follow-up issue):
-
-- `youtubeProduct` and `liveOrOnDemand` **work** for video queries per this testing but are not yet allowlisted.
-- `country + day` / `country + deviceType` / `country + operatingSystem` pass the allowlist but are **rejected by the API** (documented above).
-
-### Quick Test
-
-```bash
-staqan-yt get-video-analytics --video-id YOUR_VIDEO_ID \
-  --dimensions dimension1 dimension2 dimension3 \
-  --start-date=2024-01-01 \
-  --end-date=2024-01-07
-```
-
-**If compatible:** You'll see data output
-**If incompatible:** You'll see the API error message
-
-## Common Error Messages
-
-### "The query is not supported"
-
-**Cause:** Incompatible dimension combination
-
-**Solution:**
-1. Try fewer dimensions (max 4)
-2. Remove `country` if combined with time/device dimensions
-3. Avoid mixing `insightTrafficSourceType` with device dimensions
-
-### "Invalid combination of dimensions for the specified filters"
-
-**Cause:** Dimension requires additional filters
-
-**Solution:**
-- Use YouTube Analytics API directly for dimensions requiring additional filters
-- Remove the problematic dimension
-
-### "The requested dates are not valid for the requested month dimension"
-
-**Cause:** Date range doesn't span full calendar months
-
-**Solution:**
-- Use `day` dimension for partial months
-- Adjust date range to start on 1st of month and end on last day of month
-
-## Dimension Compatibility Matrix
-
-| Dimension | country | day | deviceType | operatingSystem | subscribedStatus | insightTrafficSourceType | insightPlaybackLocationType | liveOrOnDemand | creatorContentType | youtubeProduct |
-|-----------|---------|-----|------------|-----------------|------------------|-------------------------|----------------------------|----------------|--------------------|----------------|
-| **country** | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| **day** | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | ✅ |
-| **deviceType** | ❌ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ |
-| **operatingSystem** | ❌ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ |
-| **subscribedStatus** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ✅ | ✅ |
-| **insightTrafficSourceType** | ❌ | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ |
-| **insightPlaybackLocationType** | ❌ | ✅ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ | ⚠️ |
-| **liveOrOnDemand** | ❌ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ |
-| **creatorContentType** | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ |
-| **youtubeProduct** | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ | ✅ |
-
-Legend:
-- ✅ = Tested and works
-- ⚠️ = May work in some combinations
-- ❌ = Incompatible or requires additional filters
-
-## API Quota Considerations
-
-- **Single dimension query:** 1 API call
-- **4 dimensions (max):** 1 API call
-- **Multiple separate queries:** N API calls
-
-**Optimization:** Use compatible dimension combinations to reduce API calls while getting the data you need.
-
-## Best Practices
-
-1. **Start with fewer dimensions** - Test with 2-3 dimensions first
-2. **Use the proven 4-dimension combination** - `country,creatorContentType,subscribedStatus,youtubeProduct` for maximum coverage
-3. **Export to CSV/JSON** - For further analysis and filtering
-4. **Check error messages** - The API error messages are informative
-5. **Test new combinations** - The API may change over time
+| message | cause | fix |
+|---|---|---|
+| `Invalid --dimensions value: "x"` | Not in the allowlist. | Check the supported list above. |
+| `Invalid --dimensions combination: a + b` | Known-bad pair, refused locally. | Split into separate queries. |
+| `The query is not supported` | Usually the metric set, not the dimensions. | Retry with `--metrics views`. |
+| `does not align to chosen date dimension` | `month` with dates that are not the 1st. | Use first-of-month for both dates. |
+| `Unknown identifier (x)` | Not a real dimension. | Check spelling against the supported list. |
 
 ## Notes
 
-- **Data delay:** Analytics data is typically 24-48 hours delayed
-- **Date limits:** YouTube Analytics API limits date ranges to ~500 days
-- **Video ownership:** Some analytics require channel ownership
-- **API transparency:** This CLI shows actual API errors, not pre-validation
-
-## YouTube Analytics API v2 Dimension Coverage
-
-The YouTube Analytics API v2 documentation lists 24 dimensions. This CLI supports 11 of them for video-level queries.
-
-### Supported Dimensions (11)
-- `country`, `day`, `month`, `deviceType`, `operatingSystem`, `subscribedStatus`, `insightTrafficSourceType`, `insightPlaybackLocationType`, `liveOrOnDemand`, `creatorContentType`, `youtubeProduct`
-
-### Not Supported (13) - Why They Don't Work for Video Queries
-
-**Channel-level only (use `get-channel-analytics` instead):**
-- `ageGroup`, `gender`, `sharingService`
-
-**Not applicable to video queries:**
-- `channel`, `group`, `playlist`
-
-**Require additional filters not supported via CLI:**
-- `city`, `province`, `dma` (need geographic filters)
-
-**Filter-only dimensions (not breakdown dimensions):**
-- `continent`, `subContinent`
-
-**Tested and rejected by API for video queries:**
-- `insightPlaybackLocationDetail` (tested: API rejects)
-- `insightTrafficSourceDetail` (tested: API rejects)
-
-**Coverage:** We support 100% of dimensions that are actually usable for video-level analytics queries.
+- **Data delay:** analytics are typically 24-48 hours behind.
+- **Date limits:** the API caps ranges at roughly 500 days. The CLI chunks
+  longer ranges into 90-day windows automatically.
+- **Ownership:** video-level analytics require channel ownership.
+- **Quota:** one query costs the same whether it carries 1 or 7 dimensions, so
+  prefer one wide query over several narrow ones.
 
 ---
 
-**Last Updated:** 2026-04-08
-**Tested With:** YouTube Analytics API v2
-**Test Coverage:** 100+ dimension combinations tested
+**Last updated:** 2026-08-20
+**Method:** live queries against the Analytics API v2, video-level
+(`filters: video==<id>`), verifying each dimension singly, the pairs above, and
+each default metric in isolation.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -17,32 +17,56 @@ import { chunkDateRange, debug, parseChannelHandle, parseDuration, toLocalYmd, v
  * Allowlist of Analytics API dimensions valid for video-level queries.
  * See https://developers.google.com/youtube/v3/docs/analytics_api/dimensions/dims
  * and docs/dimension-compatibility.md for the live-tested combination matrix.
+ *
+ * Membership is decided by one question: does the API accept this dimension for
+ * the query this file actually sends (`filters: video==<id>`, no extra filters)?
+ * Dimensions that only work alongside a filter the CLI cannot express are
+ * excluded, because allowlisting them just defers the same failure to the API
+ * and returns the opaque "query is not supported" instead of a clear message.
  */
 export const VIDEO_DIMENSIONS: ReadonlySet<string> = new Set([
   'video',
   'day',
   'month',
   'insightTrafficSourceType',
-  'insightTrafficSourceDetail',
   'creatorContentType',
   'country',
-  'province',
-  'city',
+  'dma',
   'deviceType',
   'operatingSystem',
   'insightPlaybackLocationType',
-  'insightPlayerLocationType',
   'subscribedStatus',
+  'youtubeProduct',
+  'liveOrOnDemand',
 ]);
 
 /**
  * Known-bad dimension combinations the Analytics API rejects at runtime.
  * Checking up-front gives a clean error message instead of an API error.
+ *
+ * Measured, not exhaustive: pairs absent from this table are passed through and
+ * the API's own error surfaces if it dislikes them. Three structural conflicts
+ * account for every entry below.
+ *
+ * There is no arity limit to enforce alongside them. A 7-dimension query is
+ * accepted; the "max 4 dimensions" folklore came from a 5-dimension example
+ * that happened to contain `country,day`.
  */
 export const INVALID_DIMENSION_COMBOS: ReadonlyArray<ReadonlyArray<string>> = [
-  // creatorContentType is not a valid dimension for traffic-source detail reports
-  // (see PR #90 — original issue: get-channel-search-terms #88).
-  ['creatorContentType', 'insightTrafficSourceDetail'],
+  // 1. Geography does not cross with daily, device or insight breakdowns.
+  //    `country,month` is NOT here: it is accepted, given aligned dates.
+  ['country', 'day'],
+  ['country', 'deviceType'],
+  ['country', 'operatingSystem'],
+  ['country', 'insightTrafficSourceType'],
+  ['country', 'insightPlaybackLocationType'],
+  ['country', 'dma'],
+  // 2. Two time granularities cannot be requested at once.
+  ['day', 'month'],
+  // 3. Device breakdowns do not cross with monthly or insight breakdowns.
+  ['month', 'deviceType'],
+  ['insightTrafficSourceType', 'deviceType'],
+  ['insightPlaybackLocationType', 'deviceType'],
 ];
 
 /**

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  VIDEO_DIMENSIONS,
+  INVALID_DIMENSION_COMBOS,
+  validateVideoDimensions,
+} from '../lib/analytics';
+
+/**
+ * Every expectation here was measured against the live Analytics API on
+ * 2026-08-20 with `filters: video==<id>` and no extra filters, which is the
+ * only query shape this CLI sends. See docs/dimension-compatibility.md.
+ */
+describe('validateVideoDimensions', () => {
+  it('accepts the documented single dimensions', () => {
+    for (const d of ['video', 'day', 'country', 'deviceType', 'subscribedStatus']) {
+      expect(validateVideoDimensions(d)).toBe(d);
+    }
+  });
+
+  it('trims whitespace and normalizes the separator', () => {
+    expect(validateVideoDimensions(' day , deviceType ')).toBe('day,deviceType');
+  });
+
+  it('rejects an empty value', () => {
+    expect(() => validateVideoDimensions('')).toThrow('--dimensions cannot be empty');
+    expect(() => validateVideoDimensions('  ,  ')).toThrow('--dimensions cannot be empty');
+  });
+
+  it('rejects unknown dimensions and names the valid ones', () => {
+    expect(() => validateVideoDimensions('bogus')).toThrow(/Invalid --dimensions value: "bogus"/);
+    expect(() => validateVideoDimensions('day,bogus')).toThrow(/Invalid --dimensions value/);
+  });
+
+  // Issue #143: these are accepted by the API for video queries but the
+  // allowlist rejected them client-side, so the CLI refused work the API
+  // would have done.
+  it('accepts youtubeProduct and liveOrOnDemand (#143)', () => {
+    expect(validateVideoDimensions('youtubeProduct')).toBe('youtubeProduct');
+    expect(validateVideoDimensions('liveOrOnDemand')).toBe('liveOrOnDemand');
+    expect(validateVideoDimensions('country,youtubeProduct')).toBe('country,youtubeProduct');
+    expect(validateVideoDimensions('liveOrOnDemand,day')).toBe('liveOrOnDemand,day');
+  });
+
+  // Issue #143: allowlisted, but the API rejects them for the query shape this
+  // CLI sends. They only ever produced the opaque "query is not supported".
+  it('rejects dimensions the API refuses for video queries (#143)', () => {
+    for (const d of ['province', 'city', 'insightTrafficSourceDetail', 'insightPlayerLocationType']) {
+      expect(() => validateVideoDimensions(d)).toThrow(/Invalid --dimensions value/);
+    }
+  });
+
+  it('rejects country paired with daily, device or insight breakdowns (#143)', () => {
+    for (const combo of [
+      'country,day',
+      'country,deviceType',
+      'country,operatingSystem',
+      'country,insightTrafficSourceType',
+      'country,insightPlaybackLocationType',
+      'country,dma',
+    ]) {
+      expect(() => validateVideoDimensions(combo)).toThrow(/Invalid --dimensions combination/);
+    }
+  });
+
+  it('rejects two time granularities at once', () => {
+    expect(() => validateVideoDimensions('day,month')).toThrow(/Invalid --dimensions combination/);
+  });
+
+  it('rejects device breakdowns crossed with monthly or insight breakdowns', () => {
+    for (const combo of [
+      'month,deviceType',
+      'insightTrafficSourceType,deviceType',
+      'insightPlaybackLocationType,deviceType',
+    ]) {
+      expect(() => validateVideoDimensions(combo)).toThrow(/Invalid --dimensions combination/);
+    }
+  });
+
+  it('detects an invalid combination regardless of order or extra dimensions', () => {
+    expect(() => validateVideoDimensions('day,country')).toThrow(/Invalid --dimensions combination/);
+    expect(() => validateVideoDimensions('country,subscribedStatus,day')).toThrow(
+      /Invalid --dimensions combination/,
+    );
+  });
+
+  it('accepts the country pairings the API does allow', () => {
+    expect(validateVideoDimensions('country,subscribedStatus')).toBe('country,subscribedStatus');
+    expect(validateVideoDimensions('country,creatorContentType')).toBe('country,creatorContentType');
+    expect(validateVideoDimensions('country,liveOrOnDemand')).toBe('country,liveOrOnDemand');
+    expect(validateVideoDimensions('country,month')).toBe('country,month');
+  });
+
+  // The "max 4 dimensions" note in the old matrix was a misattribution: the
+  // 5-dimension example that failed contained country,day. 7 dimensions is
+  // accepted, so no arity ceiling is enforced.
+  it('does not impose an arity ceiling (#143)', () => {
+    const seven = 'day,deviceType,operatingSystem,subscribedStatus,youtubeProduct,creatorContentType,liveOrOnDemand';
+    expect(validateVideoDimensions(seven)).toBe(seven);
+  });
+});
+
+describe('dimension tables', () => {
+  it('lists only dimensions the API accepts unfiltered', () => {
+    for (const d of ['province', 'city', 'insightTrafficSourceDetail', 'insightPlayerLocationType']) {
+      expect(VIDEO_DIMENSIONS.has(d)).toBe(false);
+    }
+    for (const d of ['youtubeProduct', 'liveOrOnDemand', 'dma']) {
+      expect(VIDEO_DIMENSIONS.has(d)).toBe(true);
+    }
+  });
+
+  it('keeps every combo entry reachable through the allowlist', () => {
+    // A combo naming a non-allowlisted dimension is dead code: the per-dimension
+    // check throws first and the combo message can never be reached.
+    for (const combo of INVALID_DIMENSION_COMBOS) {
+      for (const d of combo) {
+        expect(VIDEO_DIMENSIONS.has(d)).toBe(true);
+      }
+    }
+  });
+});

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -118,4 +118,22 @@ describe('dimension tables', () => {
       }
     }
   });
+
+  // Pinned rather than merely sanity-checked: reachability alone would still
+  // pass if a measured pair were dropped, or if an unmeasured one were added
+  // and started rejecting queries the API actually serves.
+  it('pins the measured combination matrix exactly', () => {
+    expect(INVALID_DIMENSION_COMBOS.map(c => c.join('+')).sort()).toEqual([
+      'country+day',
+      'country+deviceType',
+      'country+dma',
+      'country+insightPlaybackLocationType',
+      'country+insightTrafficSourceType',
+      'country+operatingSystem',
+      'day+month',
+      'insightPlaybackLocationType+deviceType',
+      'insightTrafficSourceType+deviceType',
+      'month+deviceType',
+    ].sort());
+  });
 });


### PR DESCRIPTION
Closes #143.

## Why

The client-side `--dimensions` allowlist exists so a typo costs nothing and a
known-bad request never spends quota. It only pays for itself if it agrees with
the API. It disagreed in both directions, so it refused work the API would do
and waved through work it would not.

Every claim below was measured against the live Analytics API on 2026-08-20
with a video-level query (`filters: video==<id>`), not taken from the previous
matrix, which turned out to be wrong on two points.

## What changed

**Now accepted (the API supports them; the CLI did not):** `youtubeProduct`,
`liveOrOnDemand`, `dma`. These were unreachable through the CLI at any metric
setting.

**Now rejected (the CLI allowed them; the API never did):**

| dimension | why it could never work |
|---|---|
| `province` | needs a `country==US` filter, which the CLI has no flag to send |
| `city` | refused for video queries even with that filter supplied |
| `insightTrafficSourceDetail` | refused even with an `insightTrafficSourceType` filter |
| `insightPlayerLocationType` | not a real identifier; the API answers `Unknown identifier` |

All four previously produced the API's generic "query is not supported". The
error now names the cause.

**Known-bad combinations: 1 to 10.** Six `country` pairings, `day + month`, and
three device pairings. Each was measured as rejected with `--metrics views`,
the most permissive metric set, so no metric choice rescues them. The previous
lone entry (`creatorContentType + insightTrafficSourceDetail`) is dropped: it
named a dimension no longer on the allowlist, so the per-dimension check threw
first and the combo branch was unreachable. A test now asserts that every combo
entry references only allowlisted dimensions, so this cannot silently recur.

## Two things the issue asked for that the measurements refuted

**The 4-dimension ceiling does not exist.** #143 asked for a `>4` check. The
5-dimension example that justified the limit was
`country,creatorContentType,subscribedStatus,youtubeProduct,day`, which contains
`country,day` and already fails at 2 dimensions. Seven dimensions returns 465
rows. Enforcing the ceiling would have broken working queries, so it is not
enforced.

**`country + month` is valid**, not rejected as the old guide guessed. It is
explicitly excluded from the combo table and covered by a test.

## The larger finding: metrics, not dimensions

Compatibility is a property of the dimensions **and** the metrics together. The
default metric set includes `likes`, `dislikes`, `comments` and `shares`, which
the API offers for only a few dimensions:

| dimension | views / watch-time metrics | likes | dislikes | comments | shares |
|---|---|---|---|---|---|
| `day` | ✅ | ✅ | ✅ | ✅ | ✅ |
| `subscribedStatus` | ✅ | ✅ | ✅ | ❌ | ✅ |
| `deviceType` | ✅ | ❌ | ❌ | ❌ | ❌ |
| `youtubeProduct` | ✅ | ❌ | ❌ | ❌ | ❌ |

So `--dimensions deviceType` fails with the default metrics even though
`deviceType` is valid, and has done so independently of this issue. That is a
separate defect, filed as #173, and deliberately not fixed here: narrowing the
default metric set changes what every user gets back by default.

The allowlist deliberately does not model the interaction. It is validated
against the most permissive metric set and answers only "can this dimension
ever work", which is documented at the definition.

## E2E proof

Identical script on `main` (e2f4cba) and on this branch, 30 real invocations.
Read-only analytics queries; no mutating command involved.

Dimensions this PR unblocks, run with `--metrics views`:

```text
                                    before (main)             after
youtubeProduct                      exit=1 CLIENT-REJECT  ->  exit=0  14 rows
liveOrOnDemand                      exit=1 CLIENT-REJECT  ->  exit=0  15 rows
country,youtubeProduct              exit=1 CLIENT-REJECT  ->  exit=0  18 rows
youtubeProduct,liveOrOnDemand       exit=1 CLIENT-REJECT  ->  exit=0  20 rows
7 dimensions at once                exit=1 CLIENT-REJECT  ->  exit=0 465 rows
dma                                 exit=1 CLIENT-REJECT  ->  exit=0  13 rows
```

Opaque API errors replaced by named client-side errors (exit code unchanged at
1, but no quota spent and the message identifies the problem):

```text
country,day / country,deviceType / country,operatingSystem / day,month
province / city / insightTrafficSourceDetail / insightPlayerLocationType
        API-REJECT  ->  CLIENT-REJECT
```

Controls, all identical before and after:

```text
positive:  --dimensions day                       exit=0  52 rows
           --dimensions country                   exit=0  36 rows
           no --dimensions (default)              exit=0  35 rows
           deviceType,operatingSystem + views     exit=0  38 rows
           country,subscribedStatus + views       exit=0  22 rows
negative:  --dimensions bogus                     exit=1  rejected
           --dimensions ageGroup                  exit=1  rejected
           --dimensions ""                        exit=1  "cannot be empty"
```

18 of 30 lines changed; the other 12 are the controls above.

`bun run type-check`, `bun run lint` (0 errors) and `bun test` all green.
Tests 172 to 186: a new `tests/analytics.test.ts` covering the allowlist, every
combo, the absent arity ceiling, and the reachability invariant.

## Docs

`docs/dimension-compatibility.md` rewritten from the measurements, including the
metric matrix, the corrected `month` date rule, and explicit notes where the
previous revision guessed wrong. `docs/commands/analytics.md` had listed the
removed dimensions and used `--dimensions day,country` as its example, which
this PR now rejects; both are corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated video Analytics dimension guidance to reflect current API support.
  - Added coverage for time-bucket requirements, valid dimension combinations, metric compatibility, validation errors, quotas, dates, and ownership.
  - Clarified that supported queries are not limited to four dimensions.

- **Bug Fixes**
  - Improved validation for unsupported dimensions and conflicting geography, time, and device combinations.
  - Added support for DMA, YouTube product, and live/on-demand dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
