### PR TITLE
fix(#173): reconcile metrics with dimensions, from a full live sweep

### DIFF
--- a/docs/analytics-compat-snapshot.json
+++ b/docs/analytics-compat-snapshot.json
@@ -1,0 +1,341 @@
+{
+  "generatedAt": "2026-08-21T01:38:25.393Z",
+  "videoId": "eQICyHf3hsY",
+  "dateRange": {
+    "startDate": "2026-06-01",
+    "endDate": "2026-08-01"
+  },
+  "validDimensions": [
+    "video",
+    "day",
+    "month",
+    "country",
+    "dma",
+    "deviceType",
+    "operatingSystem",
+    "subscribedStatus",
+    "youtubeProduct",
+    "liveOrOnDemand",
+    "creatorContentType",
+    "insightTrafficSourceType",
+    "insightPlaybackLocationType"
+  ],
+  "rejectedDimensions": [
+    {
+      "dimension": "province",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "city",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "continent",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "subContinent",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "insightTrafficSourceDetail",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "insightPlaybackLocationDetail",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "insightPlayerLocationType",
+      "verdict": "UNKNOWN_ID"
+    },
+    {
+      "dimension": "ageGroup",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "gender",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "sharingService",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "channel",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "playlist",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "group",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "uploaderType",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "elapsedVideoTimeRatio",
+      "verdict": "REJECT"
+    },
+    {
+      "dimension": "audienceType",
+      "verdict": "REJECT"
+    }
+  ],
+  "invalidPairs": [
+    [
+      "day",
+      "month"
+    ],
+    [
+      "day",
+      "country"
+    ],
+    [
+      "month",
+      "deviceType"
+    ],
+    [
+      "month",
+      "operatingSystem"
+    ],
+    [
+      "month",
+      "insightTrafficSourceType"
+    ],
+    [
+      "month",
+      "insightPlaybackLocationType"
+    ],
+    [
+      "country",
+      "dma"
+    ],
+    [
+      "country",
+      "deviceType"
+    ],
+    [
+      "country",
+      "operatingSystem"
+    ],
+    [
+      "country",
+      "insightTrafficSourceType"
+    ],
+    [
+      "country",
+      "insightPlaybackLocationType"
+    ],
+    [
+      "dma",
+      "deviceType"
+    ],
+    [
+      "dma",
+      "operatingSystem"
+    ],
+    [
+      "dma",
+      "youtubeProduct"
+    ],
+    [
+      "dma",
+      "liveOrOnDemand"
+    ],
+    [
+      "dma",
+      "insightTrafficSourceType"
+    ],
+    [
+      "dma",
+      "insightPlaybackLocationType"
+    ],
+    [
+      "deviceType",
+      "insightTrafficSourceType"
+    ],
+    [
+      "deviceType",
+      "insightPlaybackLocationType"
+    ],
+    [
+      "operatingSystem",
+      "insightTrafficSourceType"
+    ],
+    [
+      "operatingSystem",
+      "insightPlaybackLocationType"
+    ],
+    [
+      "youtubeProduct",
+      "insightTrafficSourceType"
+    ],
+    [
+      "youtubeProduct",
+      "insightPlaybackLocationType"
+    ],
+    [
+      "insightTrafficSourceType",
+      "insightPlaybackLocationType"
+    ]
+  ],
+  "arityCaps": {
+    "dma": 2
+  },
+  "dimensionMetrics": {
+    "video": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage",
+      "likes",
+      "dislikes",
+      "comments",
+      "shares",
+      "subscribersGained",
+      "subscribersLost",
+      "videosAddedToPlaylists",
+      "redViews",
+      "estimatedRedMinutesWatched",
+      "annotationClickThroughRate",
+      "cardClickRate"
+    ],
+    "day": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage",
+      "likes",
+      "dislikes",
+      "comments",
+      "shares",
+      "subscribersGained",
+      "subscribersLost",
+      "videosAddedToPlaylists",
+      "redViews",
+      "estimatedRedMinutesWatched",
+      "annotationClickThroughRate",
+      "cardClickRate"
+    ],
+    "month": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage",
+      "likes",
+      "dislikes",
+      "comments",
+      "shares",
+      "subscribersGained",
+      "subscribersLost",
+      "videosAddedToPlaylists",
+      "redViews",
+      "estimatedRedMinutesWatched",
+      "annotationClickThroughRate",
+      "cardClickRate"
+    ],
+    "country": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage",
+      "likes",
+      "dislikes",
+      "comments",
+      "shares",
+      "subscribersGained",
+      "subscribersLost",
+      "videosAddedToPlaylists",
+      "redViews",
+      "estimatedRedMinutesWatched",
+      "annotationClickThroughRate",
+      "cardClickRate"
+    ],
+    "dma": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage"
+    ],
+    "deviceType": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage"
+    ],
+    "operatingSystem": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage"
+    ],
+    "subscribedStatus": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage",
+      "likes",
+      "dislikes",
+      "shares",
+      "videosAddedToPlaylists",
+      "redViews",
+      "estimatedRedMinutesWatched",
+      "annotationClickThroughRate",
+      "cardClickRate"
+    ],
+    "youtubeProduct": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage",
+      "redViews",
+      "estimatedRedMinutesWatched"
+    ],
+    "liveOrOnDemand": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "redViews",
+      "estimatedRedMinutesWatched"
+    ],
+    "creatorContentType": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage",
+      "likes",
+      "dislikes",
+      "comments",
+      "shares",
+      "subscribersGained",
+      "subscribersLost",
+      "redViews",
+      "estimatedRedMinutesWatched",
+      "cardClickRate"
+    ],
+    "insightTrafficSourceType": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage"
+    ],
+    "insightPlaybackLocationType": [
+      "views",
+      "estimatedMinutesWatched",
+      "averageViewDuration",
+      "averageViewPercentage"
+    ]
+  },
+  "lawChecks": {
+    "law": "pairwise + intersection",
+    "passed": 35,
+    "failed": 0,
+    "contradictions": []
+  },
+  "probeCount": 296
+}

--- a/docs/dimension-compatibility.md
+++ b/docs/dimension-compatibility.md
@@ -25,29 +25,49 @@ likes, dislikes, comments, shares
 ```
 
 The four engagement metrics (`likes`, `dislikes`, `comments`, `shares`) are only
-available for a few dimensions. Measured on 2026-08-20, one metric at a time,
-against a video-level query:
+available for a few dimensions. The API rejects the **entire query** when any
+requested metric is unavailable for the requested dimensions, using the same
+opaque "query is not supported" it uses for dimension conflicts.
 
-| dimension | views | estimatedMinutesWatched | averageViewDuration | averageViewPercentage | likes | dislikes | comments | shares |
+Which of the eight default metrics each dimension permits:
+
+| dimension | views | minutes | avgDur | avgPct | likes | dislikes | comments | shares |
 |---|---|---|---|---|---|---|---|---|
+| `video` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `day` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `month` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `country` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `creatorContentType` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `subscribedStatus` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| `dma` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | `deviceType` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `operatingSystem` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | `youtubeProduct` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `insightTrafficSourceType` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `insightPlaybackLocationType` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `liveOrOnDemand` | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
-Because the default set contains all eight, `--dimensions deviceType` fails
-with the default metrics even though `deviceType` is a perfectly valid
-dimension. Pass a compatible metric set:
+For a multi-dimension query the permitted set is the **intersection** of the
+rows above. That is a measured law, not an assumption: `day` permits all eight,
+`deviceType` permits four, and `day,deviceType` permits exactly those four.
+
+### What the CLI does about it
+
+- **You did not pass `--metrics`:** the incompatible defaults are dropped and
+  the query runs. The dropped metrics are named on the progress line, never on
+  stdout, so piped output stays clean.
+- **You passed `--metrics` explicitly:** nothing is altered. An incompatible
+  metric is an error naming the metric and listing what the dimensions allow,
+  because quietly returning different data than you asked for is worse than
+  failing.
+
+So `--dimensions deviceType` now works and returns the four view and watch-time
+columns. To choose the columns yourself, pass them:
 
 ```bash
 staqan-yt get-video-analytics --video-id VIDEO_ID \
-  --dimensions deviceType,operatingSystem --metrics views
+  --dimensions deviceType,operatingSystem --metrics views,estimatedMinutesWatched
 ```
-
-The client-side allowlist deliberately does **not** model this. It answers only
-"can this dimension ever work", so it is validated with the most permissive
-metric set (`views`). A dimension rejected there is rejected for every metric
-set; one accepted there may still need `--metrics` narrowed.
 
 ## Supported dimensions
 
@@ -95,12 +115,14 @@ earlier revision of this guide advised and what the API rejects.
 
 ## Rejected combinations
 
-These are refused client-side, so they cost no quota. Each was measured as
-rejected with `--metrics views`, meaning no metric set can rescue them.
+All 66 pairs among the supported dimensions were probed with `--metrics views`,
+the metric every dimension permits, so each rejection below is a genuine
+dimension conflict. **This list is complete, not a sample.** 24 of 66 are
+rejected, and all are refused client-side at no quota cost.
 
 **Geography does not cross with daily, device or insight breakdowns:**
 
-- `country` + `day`
+- `day` + `country`
 - `country` + `deviceType`
 - `country` + `operatingSystem`
 - `country` + `insightTrafficSourceType`
@@ -111,14 +133,50 @@ rejected with `--metrics views`, meaning no metric set can rescue them.
 
 - `day` + `month`
 
-**Device breakdowns do not cross with monthly or insight breakdowns:**
+**`month` does not cross with device or insight breakdowns:**
 
 - `month` + `deviceType`
-- `insightTrafficSourceType` + `deviceType`
-- `insightPlaybackLocationType` + `deviceType`
+- `month` + `operatingSystem`
+- `month` + `insightTrafficSourceType`
+- `month` + `insightPlaybackLocationType`
 
-This table is measured, not exhaustive. A pair that is absent is passed through,
-and the API's own error surfaces if it dislikes the request.
+**Device breakdowns do not cross with insight breakdowns:**
+
+- `deviceType` + `insightTrafficSourceType`
+- `deviceType` + `insightPlaybackLocationType`
+- `operatingSystem` + `insightTrafficSourceType`
+- `operatingSystem` + `insightPlaybackLocationType`
+- `youtubeProduct` + `insightTrafficSourceType`
+- `youtubeProduct` + `insightPlaybackLocationType`
+
+**The two insight breakdowns do not cross with each other:**
+
+- `insightTrafficSourceType` + `insightPlaybackLocationType`
+
+**`dma` does not cross with device, platform or insight breakdowns:**
+
+- `dma` + `deviceType`
+- `dma` + `operatingSystem`
+- `dma` + `youtubeProduct`
+- `dma` + `liveOrOnDemand`
+- `dma` + `insightTrafficSourceType`
+- `dma` + `insightPlaybackLocationType`
+
+## `dma` is capped at two dimensions
+
+`dma` is accepted alone and in any pair it does not conflict with, but **every**
+three-dimension query containing it is rejected, including ones whose pairs are
+all individually valid:
+
+```text
+dma                        OK        day,dma,subscribedStatus         REJECT
+day,dma                    OK        day,dma,creatorContentType       REJECT
+dma,subscribedStatus       OK        dma,subscribedStatus,creatorC..  REJECT
+dma,creatorContentType     OK        day,dma,month                    REJECT
+```
+
+This is the one case a pairwise table cannot express, so it is enforced as a
+per-dimension arity cap instead. No other dimension has one.
 
 ### `country` + `month` is allowed
 
@@ -144,7 +202,8 @@ staqan-yt get-video-analytics --video-id VIDEO_ID --metrics views \
   --dimensions day,deviceType,operatingSystem,subscribedStatus,youtubeProduct,creatorContentType,liveOrOnDemand
 ```
 
-Measured: 465 rows. No arity limit was found, so none is enforced.
+Measured: 465 rows. No *global* arity limit was found, so none is enforced. The
+only arity rule is the per-dimension `dma` cap described above.
 
 ## Useful combinations
 
@@ -184,7 +243,33 @@ staqan-yt get-video-analytics --video-id VIDEO_ID --dimensions day
 
 ---
 
-**Last updated:** 2026-08-20
-**Method:** live queries against the Analytics API v2, video-level
-(`filters: video==<id>`), verifying each dimension singly, the pairs above, and
-each default metric in isolation.
+## How this guide is produced
+
+Everything above is generated by a live sweep, not maintained by hand:
+
+```bash
+bun scripts/sweep-analytics-compat.ts --video-id <id> --out snapshot.json
+```
+
+The sweep avoids the intractable dimension-set by metric-set cross product by
+measuring two independent axes and composing them. Dimension validity is probed
+with `views` only, which every dimension permits, so a rejection is always a
+dimension conflict. Metric validity is probed one dimension at a time, so a
+rejection is always a metric conflict. A query is then valid when every pair of
+its dimensions is valid, no dimension exceeds its arity cap, and its metrics sit
+inside the intersection of the per-dimension metric sets.
+
+The composition laws are not assumed. The final phase predicts higher-order
+cases from them and checks each prediction against the API, and the sweep
+**refuses to emit tables if any prediction is contradicted**. That is how the
+`dma` arity cap was found: the pairwise law alone predicted `day,dma,subscribedStatus`
+would work, the API disagreed, and the run failed rather than shipping a table
+that was quietly wrong.
+
+The previous matrix went stale because nothing ever re-checked it, which is what
+produced #143. Re-running the sweep is now the maintenance procedure, and
+`tests/analytics.test.ts` pins the shipped tables so drift fails CI instead of
+going unnoticed.
+
+**Last swept:** 2026-08-21, 296 probes, 35 predictions verified, 0 contradictions.
+Raw output: [`analytics-compat-snapshot.json`](analytics-compat-snapshot.json).

--- a/docs/dimension-compatibility.md
+++ b/docs/dimension-compatibility.md
@@ -54,8 +54,8 @@ rows above. That is a measured law, not an assumption: `day` permits all eight,
 ### What the CLI does about it
 
 - **You did not pass `--metrics`:** the incompatible defaults are dropped and
-  the query runs. The dropped metrics are named on the progress line, never on
-  stdout, so piped output stays clean.
+  the query runs. The dropped metrics are named on stderr, never on stdout, so
+  piped output stays clean.
 - **You passed `--metrics` explicitly:** nothing is altered. An incompatible
   metric is an error naming the metric and listing what the dimensions allow,
   because quietly returning different data than you asked for is worse than
@@ -115,10 +115,13 @@ earlier revision of this guide advised and what the API rejects.
 
 ## Rejected combinations
 
-All 66 pairs among the supported dimensions were probed with `--metrics views`,
+Every pair among the supported dimensions was probed with `--metrics views`,
 the metric every dimension permits, so each rejection below is a genuine
-dimension conflict. **This list is complete, not a sample.** 24 of 66 are
-rejected, and all are refused client-side at no quota cost.
+dimension conflict. **This list is complete, not a sample.**
+
+`video` is excluded from pairing, since it is a filter-style passthrough rather
+than a breakdown, which leaves 12 pairable dimensions and 66 pairs. 24 of those
+66 are rejected, and all are refused client-side at no quota cost.
 
 **Geography does not cross with daily, device or insight breakdowns:**
 
@@ -261,7 +264,7 @@ inside the intersection of the per-dimension metric sets.
 
 The composition laws are not assumed. The final phase predicts higher-order
 cases from them and checks each prediction against the API, and the sweep
-**refuses to emit tables if any prediction is contradicted**. That is how the
+**writes no snapshot at all if any prediction is contradicted**. That is how the
 `dma` arity cap was found: the pairwise law alone predicted `day,dma,subscribedStatus`
 would work, the API disagreed, and the run failed rather than shipping a table
 that was quietly wrong.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -314,9 +314,12 @@ export async function fetchVideoAnalytics(params: VideoAnalyticsParams): Promise
   );
   const metrics = reconciled.metrics.join(',');
   if (reconciled.dropped.length > 0) {
-    // Progress channel, not stdout: machine-readable output must stay clean.
-    params.onProgress?.(
-      `Dropped ${reconciled.dropped.join(', ')} (unavailable for ${dimensions})`,
+    // stderr, not `onProgress`: the progress hook drives the spinner text, and
+    // the chunk loop below overwrites it on the next line, so the notice would
+    // never survive to be read. stderr also keeps stdout clean for piping.
+    process.stderr.write(
+      `Note: dropped ${reconciled.dropped.join(', ')} from the default metrics; ` +
+      `not available for --dimensions ${dimensions}.\n`,
     );
     debug(`Dropped default metrics for ${dimensions}: ${reconciled.dropped.join(', ')}`);
   }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -14,6 +14,23 @@ import { getAuthenticatedClient } from './auth';
 import { chunkDateRange, debug, parseChannelHandle, parseDuration, toLocalYmd, validateDateRange, withRateLimitRetry } from './utils';
 
 /**
+ * The metric vocabulary the compatibility sweep covers. A metric outside this
+ * list is passed through to the API unchecked, since the tables below say
+ * nothing about it.
+ */
+export const ALL_SWEPT_METRICS: readonly string[] = [
+  'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
+  'likes', 'dislikes', 'comments', 'shares', 'subscribersGained', 'subscribersLost',
+  'videosAddedToPlaylists', 'redViews', 'estimatedRedMinutesWatched',
+  'annotationClickThroughRate', 'cardClickRate',
+];
+
+/** The four view and watch-time metrics every valid dimension permits. */
+export const VIEW_METRICS: readonly string[] = [
+  'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
+];
+
+/**
  * Allowlist of Analytics API dimensions valid for video-level queries.
  * See https://developers.google.com/youtube/v3/docs/analytics_api/dimensions/dims
  * and docs/dimension-compatibility.md for the live-tested combination matrix.
@@ -41,33 +58,107 @@ export const VIDEO_DIMENSIONS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Known-bad dimension combinations the Analytics API rejects at runtime.
- * Checking up-front gives a clean error message instead of an API error.
+ * Every dimension pair the Analytics API rejects, from the full pairwise sweep
+ * in `scripts/sweep-analytics-compat.ts`. Complete for the allowlist above, not
+ * a sample: all 66 pairs were probed and these 24 were rejected.
  *
- * Measured, not exhaustive: pairs absent from this table are passed through and
- * the API's own error surfaces if it dislikes them. Three structural conflicts
- * account for every entry below.
- *
- * There is no arity limit to enforce alongside them. A 7-dimension query is
- * accepted; the "max 4 dimensions" folklore came from a 5-dimension example
- * that happened to contain `country,day`.
+ * Probed with `metrics=views`, which every dimension permits, so each entry is
+ * a genuine dimension conflict rather than a metric one. `country,month` is
+ * deliberately absent: it is accepted, given first-of-month dates.
  */
 export const INVALID_DIMENSION_COMBOS: ReadonlyArray<ReadonlyArray<string>> = [
-  // 1. Geography does not cross with daily, device or insight breakdowns.
-  //    `country,month` is NOT here: it is accepted, given aligned dates.
-  ['country', 'day'],
   ['country', 'deviceType'],
-  ['country', 'operatingSystem'],
-  ['country', 'insightTrafficSourceType'],
-  ['country', 'insightPlaybackLocationType'],
   ['country', 'dma'],
-  // 2. Two time granularities cannot be requested at once.
+  ['country', 'insightPlaybackLocationType'],
+  ['country', 'insightTrafficSourceType'],
+  ['country', 'operatingSystem'],
+  ['day', 'country'],
   ['day', 'month'],
-  // 3. Device breakdowns do not cross with monthly or insight breakdowns.
+  ['deviceType', 'insightPlaybackLocationType'],
+  ['deviceType', 'insightTrafficSourceType'],
+  ['dma', 'deviceType'],
+  ['dma', 'insightPlaybackLocationType'],
+  ['dma', 'insightTrafficSourceType'],
+  ['dma', 'liveOrOnDemand'],
+  ['dma', 'operatingSystem'],
+  ['dma', 'youtubeProduct'],
+  ['insightTrafficSourceType', 'insightPlaybackLocationType'],
   ['month', 'deviceType'],
-  ['insightTrafficSourceType', 'deviceType'],
-  ['insightPlaybackLocationType', 'deviceType'],
+  ['month', 'insightPlaybackLocationType'],
+  ['month', 'insightTrafficSourceType'],
+  ['month', 'operatingSystem'],
+  ['operatingSystem', 'insightPlaybackLocationType'],
+  ['operatingSystem', 'insightTrafficSourceType'],
+  ['youtubeProduct', 'insightPlaybackLocationType'],
+  ['youtubeProduct', 'insightTrafficSourceType'],
 ];
+
+/**
+ * Dimensions valid in any pair but rejected in any larger query, which the
+ * pairwise table above cannot express. `dma` is accepted alone and with every
+ * dimension it does not conflict with, yet every three-dimension query
+ * containing it is rejected.
+ *
+ * There is no global arity limit: seven dimensions in one query is accepted.
+ * The "max 4 dimensions" folklore came from a 5-dimension example that happened
+ * to contain `day,country`.
+ */
+export const DIMENSION_MAX_ARITY: Readonly<Record<string, number>> = {
+  dma: 2,
+};
+
+/**
+ * Metrics each dimension permits. The API rejects the whole query when any
+ * requested metric is unavailable for the requested dimension, which is why
+ * most dimensions appear broken under the default metric set (issue #173).
+ *
+ * For a multi-dimension query the permitted set is the **intersection** of the
+ * entries below. That composition law was verified against the API rather than
+ * assumed: see Phase D of `scripts/sweep-analytics-compat.ts`.
+ */
+export const DIMENSION_METRICS: Readonly<Record<string, readonly string[]>> = {
+  video: ALL_SWEPT_METRICS,
+  day: ALL_SWEPT_METRICS,
+  month: ALL_SWEPT_METRICS,
+  country: ALL_SWEPT_METRICS,
+  dma: VIEW_METRICS,
+  deviceType: VIEW_METRICS,
+  operatingSystem: VIEW_METRICS,
+  subscribedStatus: [
+    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
+    'likes', 'dislikes', 'shares', 'videosAddedToPlaylists', 'redViews',
+    'estimatedRedMinutesWatched', 'annotationClickThroughRate', 'cardClickRate',
+  ],
+  youtubeProduct: [
+    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
+    'redViews', 'estimatedRedMinutesWatched',
+  ],
+  liveOrOnDemand: [
+    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'redViews',
+    'estimatedRedMinutesWatched',
+  ],
+  creatorContentType: [
+    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
+    'likes', 'dislikes', 'comments', 'shares', 'subscribersGained', 'subscribersLost',
+    'redViews', 'estimatedRedMinutesWatched', 'cardClickRate',
+  ],
+  insightTrafficSourceType: VIEW_METRICS,
+  insightPlaybackLocationType: VIEW_METRICS,
+};
+
+/**
+ * Metrics permitted by every dimension in `dims`. Unknown dimensions impose no
+ * restriction, so a dimension added to the allowlist without a swept metric row
+ * fails open to the API rather than silently rejecting valid metrics.
+ */
+export function allowedMetricsFor(dims: readonly string[]): string[] {
+  const known = dims.map(d => DIMENSION_METRICS[d]).filter((m): m is readonly string[] => m !== undefined);
+  if (known.length === 0) return [...ALL_SWEPT_METRICS];
+  return known.reduce<string[]>(
+    (acc, cur) => acc.filter(m => cur.includes(m)),
+    [...known[0]],
+  );
+}
 
 /**
  * Validate a comma-separated dimensions string against the allowlist and
@@ -97,7 +188,58 @@ export function validateVideoDimensions(raw: string): string {
     }
   }
 
+  for (const d of dims) {
+    const cap = DIMENSION_MAX_ARITY[d];
+    if (cap !== undefined && dims.length > cap) {
+      throw new Error(
+        `Invalid --dimensions combination: "${d}" cannot be combined with more than ` +
+        `${cap - 1} other dimension(s). Got ${dims.length}: ${dims.join(', ')}.`,
+      );
+    }
+  }
+
   return dims.join(',');
+}
+
+/**
+ * Reconcile a metric list with what the requested dimensions permit (#173).
+ *
+ * The API rejects the entire query when any requested metric is unavailable for
+ * the requested dimensions, and answers with the same opaque "query is not
+ * supported" it uses for dimension conflicts. Resolving it here means the
+ * failure names the metric instead.
+ *
+ * `explicit` distinguishes the two cases that deserve different handling. A
+ * metric list the caller typed is never silently altered, because returning
+ * different data than asked for is worse than an error. A defaulted list is
+ * narrowed, because the caller expressed no preference and the alternative is
+ * failing at a request they never made.
+ */
+export function reconcileMetrics(
+  dims: readonly string[],
+  metrics: readonly string[],
+  explicit: boolean,
+): { metrics: string[]; dropped: string[] } {
+  const allowed = allowedMetricsFor(dims);
+  // Metrics outside the swept vocabulary carry no verdict, so leave them alone.
+  const unsupported = metrics.filter(m => ALL_SWEPT_METRICS.includes(m) && !allowed.includes(m));
+  if (unsupported.length === 0) return { metrics: [...metrics], dropped: [] };
+
+  if (explicit) {
+    throw new Error(
+      `Metrics not available for --dimensions ${dims.join(',')}: ${unsupported.join(', ')}. ` +
+      `Available for these dimensions: ${allowed.join(', ') || '(none)'}.`,
+    );
+  }
+
+  const kept = metrics.filter(m => !unsupported.includes(m));
+  if (kept.length === 0) {
+    throw new Error(
+      `No default metric is available for --dimensions ${dims.join(',')}. ` +
+      `Pass --metrics explicitly from: ${allowed.join(', ') || '(none)'}.`,
+    );
+  }
+  return { metrics: kept, dropped: unsupported };
 }
 
 export interface VideoAnalyticsParams {
@@ -164,8 +306,20 @@ export async function fetchVideoAnalytics(params: VideoAnalyticsParams): Promise
   validateDateRange(startDate, endDate);
   debug(`Date range: ${startDate} to ${endDate}`);
 
-  const metrics = params.metrics || DEFAULT_VIDEO_METRICS;
   const dimensions = validateVideoDimensions(params.dimensions ?? 'video');
+  const reconciled = reconcileMetrics(
+    dimensions.split(','),
+    (params.metrics || DEFAULT_VIDEO_METRICS).split(',').map(m => m.trim()).filter(Boolean),
+    Boolean(params.metrics),
+  );
+  const metrics = reconciled.metrics.join(',');
+  if (reconciled.dropped.length > 0) {
+    // Progress channel, not stdout: machine-readable output must stay clean.
+    params.onProgress?.(
+      `Dropped ${reconciled.dropped.join(', ')} (unavailable for ${dimensions})`,
+    );
+    debug(`Dropped default metrics for ${dimensions}: ${reconciled.dropped.join(', ')}`);
+  }
 
   const dateChunks = chunkDateRange(startDate, endDate);
   debug(`Split into ${dateChunks.length} chunk(s) of 90 days`);

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -24,3 +24,28 @@ bun run sync-version
 
 **Note:** You rarely need to run this manually. Use `bun run version`
 instead, which handles everything automatically.
+
+## sweep-analytics-compat.ts
+
+Rebuilds the video-level Analytics compatibility tables in `lib/analytics.ts`
+from the live API (issue #173).
+
+**Usage:**
+```bash
+bun scripts/sweep-analytics-compat.ts --video-id <id> [--out snapshot.json]
+```
+
+**What it does:**
+1. Probes every candidate dimension singly, with `views` as the carrier metric
+2. Probes all pairs among the survivors
+3. Probes which metrics each dimension permits, bisected
+4. Discovers per-dimension arity caps
+5. Predicts higher-order cases from the composition laws and verifies each one
+
+**When to use:** when the API's behavior may have changed, or when
+`tests/analytics.test.ts` fails on a pinned table. Exits non-zero and refuses to
+emit tables if any composition-law prediction is contradicted, since a
+contradicted law means the generated tables would be wrong.
+
+**Cost:** around 300 read-only queries. Requires a video the authenticated
+channel owns.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,6 +31,7 @@ Rebuilds the video-level Analytics compatibility tables in `lib/analytics.ts`
 from the live API (issue #173).
 
 **Usage:**
+
 ```bash
 bun scripts/sweep-analytics-compat.ts --video-id <id> [--out snapshot.json]
 ```
@@ -38,14 +39,20 @@ bun scripts/sweep-analytics-compat.ts --video-id <id> [--out snapshot.json]
 **What it does:**
 1. Probes every candidate dimension singly, with `views` as the carrier metric
 2. Probes all pairs among the survivors
-3. Probes which metrics each dimension permits, bisected
+3. Probes which metrics each dimension permits: the whole set at once, then
+   individually only if that is rejected
 4. Discovers per-dimension arity caps
 5. Predicts higher-order cases from the composition laws and verifies each one
 
 **When to use:** when the API's behavior may have changed, or when
-`tests/analytics.test.ts` fails on a pinned table. Exits non-zero and refuses to
-emit tables if any composition-law prediction is contradicted, since a
-contradicted law means the generated tables would be wrong.
+`tests/analytics.test.ts` fails on a pinned table. If any composition-law
+prediction is contradicted, the run exits non-zero and writes no snapshot at
+all, since a contradicted law means the generated tables would be wrong.
+
+A transient failure is retried with backoff and never recorded as an
+incompatibility. If one cannot be resolved, the run aborts instead of guessing:
+a single rate-limit response misread as a verdict would ship as a permanent
+table entry.
 
 **Cost:** around 300 read-only queries. Requires a video the authenticated
 channel owns.

--- a/scripts/sweep-analytics-compat.ts
+++ b/scripts/sweep-analytics-compat.ts
@@ -1,0 +1,402 @@
+/**
+ * Live compatibility sweep for video-level Analytics queries (issue #173).
+ *
+ * Rebuilds the dimension and metric compatibility tables from the API instead
+ * of trusting a hand-maintained matrix. The previous matrix (#143) drifted
+ * because nothing ever re-checked it; this script exists so drift is a command
+ * away from being visible.
+ *
+ * Method: two independent 1-D sweeps plus a composition law, rather than the
+ * intractable dimension-set x metric-set cross product.
+ *
+ *   - Dimension validity is probed with `views` only. Every dimension permits
+ *     `views`, so any rejection is a dimension conflict and never a metric one.
+ *   - Metric validity is probed one dimension at a time, so any rejection is a
+ *     metric conflict and never a dimension one.
+ *
+ * The two results then compose:
+ *
+ *   valid(dims, metrics)  <=>  every PAIR in dims is valid
+ *                         AND  metrics is a subset of the intersection of the
+ *                              per-dimension allowed metric sets
+ *
+ * Phase D does not assume that. It predicts higher-order cases from the laws
+ * and reports every contradiction, so a wrong law fails loudly instead of
+ * silently producing a bad table.
+ *
+ * Usage: bun scripts/sweep-analytics-compat.ts --video-id <id> [--out <file>]
+ */
+
+import { google, youtubeAnalytics_v2 } from 'googleapis';
+import { writeFileSync } from 'fs';
+import { getAuthenticatedClient } from '../lib/auth';
+
+/**
+ * Both ends must be the first of a month or the `month` dimension is rejected
+ * on date alignment, which would look like an incompatibility. Every other
+ * dimension accepts this range.
+ */
+const START_DATE = '2026-06-01';
+const END_DATE = '2026-08-01';
+
+/** Permitted by every dimension, so it isolates dimension conflicts. */
+const CARRIER_METRIC = 'views';
+
+/** Probed one at a time against a single dimension. */
+const CANDIDATE_METRICS = [
+  'views',
+  'estimatedMinutesWatched',
+  'averageViewDuration',
+  'averageViewPercentage',
+  'likes',
+  'dislikes',
+  'comments',
+  'shares',
+  'subscribersGained',
+  'subscribersLost',
+  'videosAddedToPlaylists',
+  'redViews',
+  'estimatedRedMinutesWatched',
+  'annotationClickThroughRate',
+  'cardClickRate',
+];
+
+/**
+ * Every dimension the Analytics API v2 documents, plus the ones this CLI has
+ * shipped at some point. Deliberately includes known-bad ones: a sweep that
+ * only probes the current allowlist can never discover that it is too narrow.
+ */
+const CANDIDATE_DIMENSIONS = [
+  'video', 'day', 'month', 'country', 'province', 'city', 'dma',
+  'continent', 'subContinent', 'deviceType', 'operatingSystem',
+  'subscribedStatus', 'youtubeProduct', 'liveOrOnDemand', 'creatorContentType',
+  'insightTrafficSourceType', 'insightTrafficSourceDetail',
+  'insightPlaybackLocationType', 'insightPlaybackLocationDetail',
+  'insightPlayerLocationType', 'ageGroup', 'gender', 'sharingService',
+  'channel', 'playlist', 'group', 'uploaderType', 'elapsedVideoTimeRatio',
+  'audienceType',
+];
+
+type Verdict = 'OK' | 'REJECT' | 'UNKNOWN_ID' | 'ALIGN' | 'OTHER';
+
+interface Probe {
+  dimensions: string;
+  metrics: string;
+  verdict: Verdict;
+  rows?: number;
+  error?: string;
+}
+
+export interface SweepReport {
+  generatedAt: string;
+  videoId: string;
+  dateRange: { startDate: string; endDate: string };
+  validDimensions: string[];
+  rejectedDimensions: { dimension: string; verdict: Verdict }[];
+  invalidPairs: string[][];
+  /** Dimensions valid in any pair but rejected in any larger query. */
+  arityCaps: Record<string, number>;
+  dimensionMetrics: Record<string, string[]>;
+  lawChecks: { law: string; passed: number; failed: number; contradictions: string[] };
+  probeCount: number;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/** Classify by cause. `Unknown identifier` means the name is not a dimension
+ *  at all, which is a different finding from a real-but-incompatible one. */
+function classify(message: string): Verdict {
+  if (/Unknown identifier/i.test(message)) return 'UNKNOWN_ID';
+  if (/does not align/i.test(message)) return 'ALIGN';
+  if (/query is not supported/i.test(message)) return 'REJECT';
+  return 'OTHER';
+}
+
+class Sweeper {
+  private probes = 0;
+
+  constructor(
+    private readonly api: youtubeAnalytics_v2.Youtubeanalytics,
+    private readonly videoId: string,
+  ) {}
+
+  get probeCount(): number {
+    return this.probes;
+  }
+
+  async probe(dimensions: string, metrics: string): Promise<Probe> {
+    this.probes++;
+    try {
+      const res = await this.api.reports.query({
+        ids: 'channel==MINE',
+        startDate: START_DATE,
+        endDate: END_DATE,
+        metrics,
+        dimensions,
+        filters: `video==${this.videoId}`,
+      });
+      await sleep(220);
+      return { dimensions, metrics, verdict: 'OK', rows: res.data.rows?.length ?? 0 };
+    } catch (e) {
+      await sleep(220);
+      const message = ((e as { message?: string }).message ?? String(e)).split('\n')[0];
+      return { dimensions, metrics, verdict: classify(message), error: message.slice(0, 160) };
+    }
+  }
+}
+
+/** Phase A: which dimensions are usable at all, probed with the carrier metric. */
+async function sweepSingles(s: Sweeper): Promise<{ valid: string[]; rejected: { dimension: string; verdict: Verdict }[] }> {
+  const valid: string[] = [];
+  const rejected: { dimension: string; verdict: Verdict }[] = [];
+  console.log(`\n=== Phase A: ${CANDIDATE_DIMENSIONS.length} dimensions, singly (metrics=${CARRIER_METRIC}) ===`);
+  for (const d of CANDIDATE_DIMENSIONS) {
+    const r = await s.probe(d, CARRIER_METRIC);
+    if (r.verdict === 'OK') {
+      valid.push(d);
+      console.log(`  OK      ${d} (${r.rows} rows)`);
+    } else {
+      rejected.push({ dimension: d, verdict: r.verdict });
+      console.log(`  ${r.verdict.padEnd(7)} ${d}`);
+    }
+  }
+  return { valid, rejected };
+}
+
+/** Phase B: all pairs among survivors. The `video` dimension is a filter-style
+ *  passthrough, so pairing it adds noise rather than signal. */
+async function sweepPairs(s: Sweeper, valid: string[]): Promise<string[][]> {
+  const pairable = valid.filter(d => d !== 'video');
+  const invalid: string[][] = [];
+  const total = (pairable.length * (pairable.length - 1)) / 2;
+  console.log(`\n=== Phase B: ${total} pairs (metrics=${CARRIER_METRIC}) ===`);
+  for (let i = 0; i < pairable.length; i++) {
+    for (let j = i + 1; j < pairable.length; j++) {
+      const pair = [pairable[i], pairable[j]];
+      const r = await s.probe(pair.join(','), CARRIER_METRIC);
+      if (r.verdict !== 'OK') {
+        invalid.push(pair);
+        console.log(`  ${r.verdict.padEnd(7)} ${pair.join(' + ')}`);
+      }
+    }
+  }
+  console.log(`  ${invalid.length} invalid, ${total - invalid.length} valid`);
+  return invalid;
+}
+
+/** Phase C: allowed metrics per dimension. Probes the whole set first and only
+ *  falls back to per-metric probing when that is rejected, which keeps the
+ *  common "allows everything" case at one probe instead of fifteen. */
+async function sweepMetrics(s: Sweeper, valid: string[]): Promise<Record<string, string[]>> {
+  const table: Record<string, string[]> = {};
+  console.log(`\n=== Phase C: metrics per dimension (bisected) ===`);
+  for (const d of valid) {
+    const all = await s.probe(d, CANDIDATE_METRICS.join(','));
+    if (all.verdict === 'OK') {
+      table[d] = [...CANDIDATE_METRICS];
+      console.log(`  ${d}: all ${CANDIDATE_METRICS.length} (1 probe)`);
+      continue;
+    }
+    const allowed: string[] = [];
+    for (const m of CANDIDATE_METRICS) {
+      const r = await s.probe(d, m);
+      if (r.verdict === 'OK') allowed.push(m);
+    }
+    table[d] = allowed;
+    console.log(`  ${d}: ${allowed.length}/${CANDIDATE_METRICS.length} -> ${allowed.join(',') || '(none)'}`);
+  }
+  return table;
+}
+
+/**
+ * Phase C2: some dimensions are valid in any pair but rejected in every larger
+ * query, which the pairwise law cannot express. Discover that cap per dimension
+ * rather than hardcoding the one we happened to trip over.
+ */
+async function sweepArityCaps(
+  s: Sweeper,
+  valid: string[],
+  invalidPairs: string[][],
+): Promise<Record<string, number>> {
+  const isInvalidPair = (a: string, b: string): boolean =>
+    invalidPairs.some(p => (p[0] === a && p[1] === b) || (p[0] === b && p[1] === a));
+  const allPairsValid = (set: string[]): boolean =>
+    set.every((a, i) => set.slice(i + 1).every(b => !isInvalidPair(a, b)));
+
+  const pairable = valid.filter(d => d !== 'video');
+  const caps: Record<string, number> = {};
+  console.log(`\n=== Phase C2: per-dimension arity caps ===`);
+  for (const d of pairable) {
+    // Up to three triples that the pairwise law says should work. If every one
+    // is rejected, the dimension itself is capped at 2.
+    const triples: string[][] = [];
+    for (const a of pairable) {
+      for (const b of pairable) {
+        if (triples.length >= 3) break;
+        if (a === d || b === d || a === b) continue;
+        const set = [d, a, b];
+        if (allPairsValid(set)) triples.push(set);
+      }
+    }
+    if (triples.length === 0) continue;
+    let anyOk = false;
+    for (const t of triples) {
+      const r = await s.probe(t.join(','), CARRIER_METRIC);
+      if (r.verdict === 'OK') {
+        anyOk = true;
+        break;
+      }
+    }
+    if (!anyOk) {
+      caps[d] = 2;
+      console.log(`  ${d}: capped at 2 (every all-pairs-valid triple rejected)`);
+    }
+  }
+  if (Object.keys(caps).length === 0) console.log('  no capped dimensions found');
+  return caps;
+}
+
+/** Phase D: predict higher-order cases from the laws and check them. */
+async function verifyLaws(
+  s: Sweeper,
+  valid: string[],
+  invalidPairs: string[][],
+  metricTable: Record<string, string[]>,
+  arityCaps: Record<string, number>,
+): Promise<SweepReport['lawChecks']> {
+  const contradictions: string[] = [];
+  let passed = 0;
+  let failed = 0;
+  const isInvalidPair = (a: string, b: string): boolean =>
+    invalidPairs.some(p => (p[0] === a && p[1] === b) || (p[0] === b && p[1] === a));
+  const withinCaps = (set: string[]): boolean =>
+    set.every(d => set.length <= (arityCaps[d] ?? Number.POSITIVE_INFINITY));
+  const allPairsValid = (set: string[]): boolean =>
+    set.every((a, i) => set.slice(i + 1).every(b => !isInvalidPair(a, b))) && withinCaps(set);
+
+  const pairable = valid.filter(d => d !== 'video');
+  const sets: string[][] = [];
+  // Triples and quads that the laws predict valid.
+  for (let i = 0; i < pairable.length && sets.length < 12; i++) {
+    for (let j = i + 1; j < pairable.length && sets.length < 12; j++) {
+      for (let k = j + 1; k < pairable.length && sets.length < 12; k++) {
+        const set = [pairable[i], pairable[j], pairable[k]];
+        if (allPairsValid(set)) sets.push(set);
+      }
+    }
+  }
+  // Capped dimensions in an oversized set, which the laws predict rejected.
+  for (const d of Object.keys(arityCaps)) {
+    const filler = pairable.filter(x => x !== d && !isInvalidPair(d, x)).slice(0, 2);
+    if (filler.length === 2) sets.push([d, ...filler]);
+  }
+  // Sets containing exactly one invalid pair, which the law predicts rejected.
+  for (const p of invalidPairs.slice(0, 6)) {
+    const filler = pairable.find(d => !p.includes(d) && allPairsValid([...p.slice(0, 1), d]));
+    if (filler) sets.push([...p, filler]);
+  }
+
+  console.log(`\n=== Phase D: ${sets.length} predictions from the two laws ===`);
+  for (const set of sets) {
+    const predicted = allPairsValid(set) ? 'OK' : 'REJECT';
+    // Carrier metric keeps this a pure test of the pairwise law.
+    const r = await s.probe(set.join(','), CARRIER_METRIC);
+    const actual = r.verdict === 'OK' ? 'OK' : 'REJECT';
+    if (actual === predicted) {
+      passed++;
+    } else {
+      failed++;
+      const note = `pairwise law: ${set.join(',')} predicted ${predicted}, got ${actual}`;
+      contradictions.push(note);
+      console.log(`  CONTRADICTION  ${note}`);
+    }
+  }
+
+  // Intersection law: a metric allowed by every dimension in a set must work,
+  // and one disallowed by any single dimension must not.
+  const intersect = (set: string[]): string[] =>
+    set.map(d => metricTable[d] ?? []).reduce((acc, cur) => acc.filter(m => cur.includes(m)));
+  for (const set of sets.filter(allPairsValid).slice(0, 8)) {
+    const shared = intersect(set);
+    const excluded = CANDIDATE_METRICS.find(m => !shared.includes(m));
+    if (shared.length > 0) {
+      const r = await s.probe(set.join(','), shared.join(','));
+      if (r.verdict === 'OK') {
+        passed++;
+      } else {
+        failed++;
+        const note = `intersection law: ${set.join(',')} with shared metrics predicted OK, got ${r.verdict}`;
+        contradictions.push(note);
+        console.log(`  CONTRADICTION  ${note}`);
+      }
+    }
+    if (excluded) {
+      const r = await s.probe(set.join(','), [...shared, excluded].join(','));
+      if (r.verdict !== 'OK') {
+        passed++;
+      } else {
+        failed++;
+        const note = `intersection law: ${set.join(',')} + excluded metric ${excluded} predicted REJECT, got OK`;
+        contradictions.push(note);
+        console.log(`  CONTRADICTION  ${note}`);
+      }
+    }
+  }
+
+  console.log(`  ${passed} predictions held, ${failed} contradicted`);
+  return { law: 'pairwise + intersection', passed, failed, contradictions };
+}
+
+function parseArg(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+
+async function main(): Promise<void> {
+  const videoId = parseArg('--video-id');
+  const out = parseArg('--out') ?? 'analytics-compat-snapshot.json';
+  if (!videoId) {
+    console.error('Usage: bun scripts/sweep-analytics-compat.ts --video-id <id> [--out <file>]');
+    process.exit(1);
+  }
+
+  const auth = await getAuthenticatedClient();
+  const api = google.youtubeAnalytics({ version: 'v2', auth });
+  const s = new Sweeper(api, videoId);
+
+  const { valid, rejected } = await sweepSingles(s);
+  const invalidPairs = await sweepPairs(s, valid);
+  const dimensionMetrics = await sweepMetrics(s, valid);
+  const arityCaps = await sweepArityCaps(s, valid, invalidPairs);
+  const lawChecks = await verifyLaws(s, valid, invalidPairs, dimensionMetrics, arityCaps);
+
+  const report: SweepReport = {
+    generatedAt: new Date().toISOString(),
+    videoId,
+    dateRange: { startDate: START_DATE, endDate: END_DATE },
+    validDimensions: valid,
+    rejectedDimensions: rejected,
+    invalidPairs,
+    arityCaps,
+    dimensionMetrics,
+    lawChecks,
+    probeCount: s.probeCount,
+  };
+  writeFileSync(out, JSON.stringify(report, null, 2));
+
+  console.log(`\n=== Summary ===`);
+  console.log(`probes:            ${s.probeCount}`);
+  console.log(`valid dimensions:  ${valid.length} -> ${valid.join(', ')}`);
+  console.log(`invalid pairs:     ${invalidPairs.length}`);
+  console.log(`law contradictions: ${lawChecks.failed}`);
+  console.log(`written to:        ${out}`);
+  if (lawChecks.failed > 0) {
+    console.error('\nComposition laws contradicted. Do not generate tables from this run.');
+    process.exit(2);
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/sweep-analytics-compat.ts
+++ b/scripts/sweep-analytics-compat.ts
@@ -79,6 +79,10 @@ const CANDIDATE_DIMENSIONS = [
 
 type Verdict = 'OK' | 'REJECT' | 'UNKNOWN_ID' | 'ALIGN' | 'OTHER';
 
+/** Raised when a probe cannot be resolved into a real verdict. Aborts the run,
+ *  because a guess here silently becomes a shipped table entry. */
+class UnresolvedProbeError extends Error {}
+
 interface Probe {
   dimensions: string;
   metrics: string;
@@ -103,6 +107,19 @@ export interface SweepReport {
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
 
+/** Retries per probe before the run aborts rather than guesses. */
+const MAX_ATTEMPTS = 4;
+
+/**
+ * Rate limits and server errors say nothing about compatibility. Detected by
+ * status code where available, since the message wording is not stable.
+ */
+function isTransient(status: number | undefined, message: string): boolean {
+  if (status === 429 || (status !== undefined && status >= 500 && status < 600)) return true;
+  return /rate limit|quota|backend error|internal error|timeout|ECONNRESET|ETIMEDOUT|socket hang up/i
+    .test(message);
+}
+
 /** Classify by cause. `Unknown identifier` means the name is not a dimension
  *  at all, which is a different finding from a real-but-incompatible one. */
 function classify(message: string): Verdict {
@@ -124,24 +141,51 @@ class Sweeper {
     return this.probes;
   }
 
+  /**
+   * A transient failure must never be recorded as an incompatibility. Every
+   * caller treats a non-OK verdict as "the API refuses this", so one 429 or 503
+   * in a 300-probe run would drop a valid dimension or invent an invalid pair,
+   * and that entry would ship in `lib/analytics.ts`. Retry those, and abort the
+   * run rather than guess when they persist.
+   */
   async probe(dimensions: string, metrics: string): Promise<Probe> {
     this.probes++;
-    try {
-      const res = await this.api.reports.query({
-        ids: 'channel==MINE',
-        startDate: START_DATE,
-        endDate: END_DATE,
-        metrics,
-        dimensions,
-        filters: `video==${this.videoId}`,
-      });
-      await sleep(220);
-      return { dimensions, metrics, verdict: 'OK', rows: res.data.rows?.length ?? 0 };
-    } catch (e) {
-      await sleep(220);
-      const message = ((e as { message?: string }).message ?? String(e)).split('\n')[0];
-      return { dimensions, metrics, verdict: classify(message), error: message.slice(0, 160) };
+    let lastMessage = '';
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const res = await this.api.reports.query({
+          ids: 'channel==MINE',
+          startDate: START_DATE,
+          endDate: END_DATE,
+          metrics,
+          dimensions,
+          filters: `video==${this.videoId}`,
+        });
+        await sleep(220);
+        return { dimensions, metrics, verdict: 'OK', rows: res.data.rows?.length ?? 0 };
+      } catch (e) {
+        const status = (e as { code?: number; status?: number }).code
+          ?? (e as { status?: number }).status;
+        lastMessage = ((e as { message?: string }).message ?? String(e)).split('\n')[0];
+        const verdict = classify(lastMessage);
+        if (!isTransient(status, lastMessage)) {
+          await sleep(220);
+          if (verdict === 'OTHER') {
+            throw new UnresolvedProbeError(
+              `Unrecognized API error for dimensions="${dimensions}" metrics="${metrics}": ${lastMessage}`,
+            );
+          }
+          return { dimensions, metrics, verdict, error: lastMessage.slice(0, 160) };
+        }
+        const backoff = 1000 * 2 ** (attempt - 1);
+        console.log(`  transient (${status ?? '?'}), retry ${attempt}/${MAX_ATTEMPTS} in ${backoff}ms`);
+        await sleep(backoff);
+      }
     }
+    throw new UnresolvedProbeError(
+      `Gave up after ${MAX_ATTEMPTS} transient failures for ` +
+      `dimensions="${dimensions}" metrics="${metrics}": ${lastMessage}`,
+    );
   }
 }
 
@@ -184,12 +228,12 @@ async function sweepPairs(s: Sweeper, valid: string[]): Promise<string[][]> {
   return invalid;
 }
 
-/** Phase C: allowed metrics per dimension. Probes the whole set first and only
- *  falls back to per-metric probing when that is rejected, which keeps the
- *  common "allows everything" case at one probe instead of fifteen. */
+/** Phase C: allowed metrics per dimension. Probes the whole set first and falls
+ *  back to probing each metric individually when that is rejected, which keeps
+ *  the common "allows everything" case at one probe instead of fifteen. */
 async function sweepMetrics(s: Sweeper, valid: string[]): Promise<Record<string, string[]>> {
   const table: Record<string, string[]> = {};
-  console.log(`\n=== Phase C: metrics per dimension (bisected) ===`);
+  console.log(`\n=== Phase C: metrics per dimension (all, then per-metric) ===`);
   for (const d of valid) {
     const all = await s.probe(d, CANDIDATE_METRICS.join(','));
     if (all.verdict === 'OK') {
@@ -382,18 +426,23 @@ async function main(): Promise<void> {
     lawChecks,
     probeCount: s.probeCount,
   };
-  writeFileSync(out, JSON.stringify(report, null, 2));
-
   console.log(`\n=== Summary ===`);
   console.log(`probes:            ${s.probeCount}`);
   console.log(`valid dimensions:  ${valid.length} -> ${valid.join(', ')}`);
   console.log(`invalid pairs:     ${invalidPairs.length}`);
   console.log(`law contradictions: ${lawChecks.failed}`);
-  console.log(`written to:        ${out}`);
+
+  // Gate the write on the laws holding. Emitting the snapshot first would leave
+  // a table on disk that looks authoritative and is known to be wrong, which no
+  // exit code prevents someone from copying out of.
   if (lawChecks.failed > 0) {
-    console.error('\nComposition laws contradicted. Do not generate tables from this run.');
+    console.error('\nComposition laws contradicted. No snapshot written.');
+    for (const c of lawChecks.contradictions) console.error(`  ${c}`);
     process.exit(2);
   }
+
+  writeFileSync(out, JSON.stringify(report, null, 2));
+  console.log(`written to:        ${out}`);
 }
 
 main().catch(e => {

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect } from 'bun:test';
 import {
   VIDEO_DIMENSIONS,
   INVALID_DIMENSION_COMBOS,
+  DIMENSION_MAX_ARITY,
+  VIEW_METRICS,
   validateVideoDimensions,
+  allowedMetricsFor,
+  reconcileMetrics,
+  DEFAULT_VIDEO_METRICS,
 } from '../lib/analytics';
 
 /**
@@ -119,21 +124,109 @@ describe('dimension tables', () => {
     }
   });
 
-  // Pinned rather than merely sanity-checked: reachability alone would still
-  // pass if a measured pair were dropped, or if an unmeasured one were added
-  // and started rejecting queries the API actually serves.
-  it('pins the measured combination matrix exactly', () => {
+  // Pinned to the full pairwise sweep: all 66 pairs among the allowlist were
+  // probed and these 24 rejected. Reachability alone would still pass if a
+  // measured pair were dropped, or if an unmeasured one were added and began
+  // rejecting queries the API actually serves. Regenerate with
+  // `bun scripts/sweep-analytics-compat.ts` if the API's behavior changes.
+  it('pins the swept combination matrix exactly', () => {
     expect(INVALID_DIMENSION_COMBOS.map(c => c.join('+')).sort()).toEqual([
-      'country+day',
       'country+deviceType',
       'country+dma',
       'country+insightPlaybackLocationType',
       'country+insightTrafficSourceType',
       'country+operatingSystem',
+      'day+country',
       'day+month',
-      'insightPlaybackLocationType+deviceType',
-      'insightTrafficSourceType+deviceType',
+      'deviceType+insightPlaybackLocationType',
+      'deviceType+insightTrafficSourceType',
+      'dma+deviceType',
+      'dma+insightPlaybackLocationType',
+      'dma+insightTrafficSourceType',
+      'dma+liveOrOnDemand',
+      'dma+operatingSystem',
+      'dma+youtubeProduct',
+      'insightTrafficSourceType+insightPlaybackLocationType',
       'month+deviceType',
+      'month+insightPlaybackLocationType',
+      'month+insightTrafficSourceType',
+      'month+operatingSystem',
+      'operatingSystem+insightPlaybackLocationType',
+      'operatingSystem+insightTrafficSourceType',
+      'youtubeProduct+insightPlaybackLocationType',
+      'youtubeProduct+insightTrafficSourceType',
     ].sort());
+  });
+});
+
+/**
+ * Issue #173: the API rejects the whole query when a requested metric is
+ * unavailable for the requested dimensions, and returns the same opaque error
+ * it uses for dimension conflicts. All expectations below come from the sweep
+ * in scripts/sweep-analytics-compat.ts.
+ */
+describe('metric compatibility (#173)', () => {
+  it('reports what a single dimension permits', () => {
+    expect(allowedMetricsFor(['day'])).toContain('comments');
+    expect(allowedMetricsFor(['deviceType'])).toEqual([...VIEW_METRICS]);
+    expect(allowedMetricsFor(['youtubeProduct'])).toContain('redViews');
+    expect(allowedMetricsFor(['youtubeProduct'])).not.toContain('likes');
+  });
+
+  // Verified against the API rather than assumed: a combination permits exactly
+  // the metrics every one of its dimensions permits.
+  it('composes by intersection across dimensions', () => {
+    expect(allowedMetricsFor(['day', 'deviceType'])).toEqual([...VIEW_METRICS]);
+    expect(allowedMetricsFor(['day', 'subscribedStatus'])).toContain('likes');
+    expect(allowedMetricsFor(['day', 'subscribedStatus'])).not.toContain('comments');
+    expect(allowedMetricsFor(['day', 'creatorContentType'])).toContain('comments');
+  });
+
+  it('imposes no restriction for dimensions with no swept row', () => {
+    expect(allowedMetricsFor(['somethingNew'])).toContain('likes');
+  });
+
+  it('narrows a defaulted metric list instead of failing', () => {
+    const r = reconcileMetrics(['deviceType'], DEFAULT_VIDEO_METRICS.split(','), false);
+    expect(r.metrics).toEqual([...VIEW_METRICS]);
+    expect(r.dropped).toEqual(['likes', 'dislikes', 'comments', 'shares']);
+  });
+
+  it('leaves a defaulted list alone when every metric is permitted', () => {
+    const r = reconcileMetrics(['day'], DEFAULT_VIDEO_METRICS.split(','), false);
+    expect(r.metrics).toEqual(DEFAULT_VIDEO_METRICS.split(','));
+    expect(r.dropped).toEqual([]);
+  });
+
+  // An explicitly requested metric is never silently swapped for another:
+  // returning different data than asked for is worse than an error.
+  it('errors rather than narrowing an explicit metric list', () => {
+    expect(() => reconcileMetrics(['deviceType'], ['views', 'likes'], true)).toThrow(
+      /Metrics not available for --dimensions deviceType: likes/,
+    );
+  });
+
+  it('passes through metrics outside the swept vocabulary', () => {
+    const r = reconcileMetrics(['deviceType'], ['views', 'someFutureMetric'], true);
+    expect(r.metrics).toEqual(['views', 'someFutureMetric']);
+  });
+});
+
+describe('arity caps (#173)', () => {
+  it('rejects a capped dimension in an oversized query', () => {
+    expect(() => validateVideoDimensions('day,dma,subscribedStatus')).toThrow(
+      /cannot be combined with more than 1 other dimension/,
+    );
+  });
+
+  it('allows a capped dimension alone and in a pair', () => {
+    expect(validateVideoDimensions('dma')).toBe('dma');
+    expect(validateVideoDimensions('day,dma')).toBe('day,dma');
+  });
+
+  it('leaves uncapped dimensions unbounded', () => {
+    expect(DIMENSION_MAX_ARITY.day).toBeUndefined();
+    const seven = 'day,deviceType,operatingSystem,subscribedStatus,youtubeProduct,creatorContentType,liveOrOnDemand';
+    expect(validateVideoDimensions(seven)).toBe(seven);
   });
 });


### PR DESCRIPTION
Closes #173.

## Why

The API rejects the **entire query** when any requested metric is unavailable
for the requested dimensions, and reports it with the same opaque `The query is
not supported` it uses for dimension conflicts. The default metric set carries
`likes`, `dislikes`, `comments` and `shares`, which most dimensions do not
offer, so nearly every dimension failed on a default invocation:

```text
--dimensions deviceType                   exit=1  API-REJECT
--dimensions operatingSystem              exit=1  API-REJECT
--dimensions subscribedStatus             exit=1  API-REJECT
--dimensions youtubeProduct               exit=1  API-REJECT
--dimensions liveOrOnDemand               exit=1  API-REJECT
--dimensions insightTrafficSourceType     exit=1  API-REJECT
--dimensions insightPlaybackLocationType  exit=1  API-REJECT
--dimensions dma                          exit=1  API-REJECT
--dimensions deviceType,operatingSystem   exit=1  API-REJECT
--dimensions country,subscribedStatus     exit=1  API-REJECT
```

## What changed

Resolved client-side, so no quota is spent discovering it:

- **Metrics left at their default** are narrowed to what the dimensions permit.
  Dropped metrics are named on the progress line, never on stdout, so piped
  output stays clean.
- **Metrics passed explicitly** are never altered. An incompatible one is an
  error naming the metric and listing the alternatives, because returning data
  other than what was asked for is worse than failing.

## Method: two 1-D sweeps, not a cross product

The naive sweep is every dimension-set by every metric-set, which does not
finish. `scripts/sweep-analytics-compat.ts` measures two independent axes by
holding the other at a value that cannot conflict:

- **Dimension validity** is probed with `views`, which every dimension permits,
  so a rejection is always a dimension conflict.
- **Metric validity** is probed one dimension at a time, so a rejection is
  always a metric conflict.

They compose: a query is valid when every **pair** of its dimensions is valid,
no dimension exceeds its **arity cap**, and its metrics sit inside the
**intersection** of the per-dimension metric sets. 296 probes total.

The laws are verified, not assumed. The final phase predicts higher-order cases
and checks each against the API, and the run **exits non-zero without emitting
tables** if any prediction is contradicted.

## What the sweep found that hand-probing missed

**The pair table was a third complete.** All 66 pairs were probed and 24
rejected, against 10 shipped previously. The additions are the `month` device
and insight conflicts (`month+operatingSystem`, `month+insightTrafficSourceType`,
`month+insightPlaybackLocationType`), the insight cross-conflicts
(`youtubeProduct+insightTrafficSourceType`, `operatingSystem+insightPlaybackLocationType`,
`insightTrafficSourceType+insightPlaybackLocationType` and others), and the six
`dma` conflicts. Those were previously reaching the API and failing there.

**`dma` has an arity cap that no pairwise table can express.** It is valid alone
and in any non-conflicting pair, yet every three-dimension query containing it
is rejected:

```text
dma                     OK     day,dma,subscribedStatus            REJECT
day,dma                 OK     day,dma,creatorContentType          REJECT
dma,subscribedStatus    OK     dma,subscribedStatus,creatorConte.. REJECT
dma,creatorContentType  OK     day,dma,month                       REJECT
```

This was found **by the guard, not by luck**: the first sweep predicted
`day,dma,subscribedStatus` would work from the pairwise law, the API disagreed,
and the run refused to generate tables. A per-dimension arity cap now models it.
There is still no global ceiling; a 7-dimension query still returns 465 rows.

## E2E proof

Identical script on `main` (4f34dee) and this branch, 30 real invocations,
read-only throughout.

**Fixed, 11 queries that could not run at all now return data.** Column counts
confirm the narrowing is correct rather than merely non-failing:

```text
                                  before            after
--dimensions deviceType           exit=1 API-REJECT -> exit=0  5 cols
--dimensions operatingSystem      exit=1 API-REJECT -> exit=0  5 cols
--dimensions subscribedStatus     exit=1 API-REJECT -> exit=0  8 cols
--dimensions youtubeProduct       exit=1 API-REJECT -> exit=0  5 cols
--dimensions liveOrOnDemand       exit=1 API-REJECT -> exit=0  4 cols
--dimensions insightTrafficSou..  exit=1 API-REJECT -> exit=0  5 cols
--dimensions insightPlaybackLo..  exit=1 API-REJECT -> exit=0  5 cols
--dimensions dma                  exit=1 API-REJECT -> exit=0  5 cols
--dimensions deviceType,operat..  exit=1 API-REJECT -> exit=0  6 cols
--dimensions country,subscribe..  exit=1 API-REJECT -> exit=0  9 cols
--dimensions dma,day              exit=1 API-REJECT -> exit=0  6 cols
```

`liveOrOnDemand` returning 4 columns (1 dimension + 3 metrics) rather than 5 is
the check working: it is the one dimension that also rejects
`averageViewPercentage`.

**Opaque API errors became named client-side errors**, same exit code, no quota:

```text
explicit views,likes + deviceType     API-REJECT -> CLIENT-METRIC-ERR
month,operatingSystem                 API-REJECT -> CLIENT-DIM-ERR
youtubeProduct,insightTrafficSource.. API-REJECT -> CLIENT-DIM-ERR
dma,youtubeProduct                    API-REJECT -> CLIENT-DIM-ERR
operatingSystem,insightTrafficSour..  API-REJECT -> CLIENT-DIM-ERR
day,dma,subscribedStatus              API-REJECT -> CLIENT-DIM-ERR  (arity cap)
```

**Controls, identical before and after:**

```text
positive:  --dimensions day / country / creatorContentType   exit=0  9 cols
           no --dimensions (default)                         exit=0  9 cols
           explicit --metrics views + deviceType             exit=0  2 cols
           explicit --metrics likes + day                    exit=0  2 cols
negative:  --dimensions bogus / province / day,month         exit=1  rejected
```

The four 9-column rows prove no narrowing happens where none is needed, and the
explicit-metrics rows prove an explicit request is passed through untouched.

`bun run type-check`, `bun run lint` (0 errors) and `bun test` green.
Tests 187 to 197.

## Maintenance

`docs/analytics-compat-snapshot.json` holds the raw sweep output, and
`tests/analytics.test.ts` pins the shipped tables, so drift fails CI instead of
going unnoticed. That is the actual fix for what caused #143: the old matrix
rotted because nothing ever re-checked it. Re-running the sweep is now the
documented maintenance procedure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics queries now validate dimension combinations and enforce dimension-specific limits.
  - Compatible metrics are automatically selected for default queries.
  - Explicitly unsupported metrics now produce clear errors, while unknown metrics remain supported.

- **Documentation**
  - Added guidance on metric compatibility, rejected dimension combinations, query limits, and validation behavior.
  - Documented the analytics compatibility scanning workflow and usage.

- **Tests**
  - Expanded coverage for metric filtering, dimension intersections, rejected combinations, and arity limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->