### PR TITLE
fix(#179): rank custom analytics queries by any selected view metric

### DIFF
--- a/bin/staqan-yt.ts
+++ b/bin/staqan-yt.ts
@@ -488,6 +488,7 @@ program
   .option('--end-date <date>', 'End date (YYYY-MM-DD), defaults to today')
   .option('--dimensions <dims>', 'Custom dimensions (comma-separated, requires --metrics)')
   .option('--metrics <metrics>', 'Custom metrics (comma-separated, requires --dimensions)')
+  .option('--sort <field>', 'Sort custom query by a selected field, "-field" for descending (not valid with --report)')
   .option('--output <format>', 'Output format: json, table, text, pretty, csv')
   .option('-v, --verbose', 'Enable verbose output with debug information')
   .action(withHelpWrapper('get-channel-analytics', getChannelAnalyticsCommand));

--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -31,6 +31,7 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
         report: options.report,
         dimensions: options.dimensions,
         metrics: options.metrics,
+        sort: options.sort,
         onProgress: (message) => { spinner.text = message; },
       });
     } catch (analyticsErr) {

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -228,6 +228,10 @@ const TOOLS: Tool[] = [
           type: 'string',
           description: 'Custom metrics (comma-separated, requires dimensions)',
         },
+        sort: {
+          type: 'string',
+          description: 'Sort a custom query by one of its selected dimensions or metrics, "-field" for descending. Not valid with report. Defaults to the first of views, engagedViews, estimatedMinutesWatched present in metrics; a query selecting none of those is returned in the API\'s own order unless sort is given.',
+        },
         startDate: {
           type: 'string',
           description: 'Start date in YYYY-MM-DD format (defaults to 30 days ago)',
@@ -670,6 +674,7 @@ async function handleToolCall(name: string, args: any) {
         report: args.report,
         dimensions: args.dimensions,
         metrics: args.metrics,
+        sort: args.sort,
       });
 
       if (result.rows.length === 0) {

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -299,6 +299,7 @@ staqan-yt get-channel-analytics [channelHandle]
 - `--end-date <date>` - End date (YYYY-MM-DD), defaults to today
 - `--dimensions <dims>` - Custom dimensions (comma-separated, requires `--metrics`)
 - `--metrics <metrics>` - Custom metrics (comma-separated, requires `--dimensions`)
+- `--sort <field>` - Sort a custom query by one of the fields it selects; prefix with `-` for descending. Not valid with `--report`
 - `--output <format>` - Output format: json, table, text, pretty, csv (default: pretty)
 - `-v, --verbose` - Enable verbose output with debug information
 - `-h, --help` - Show help
@@ -368,6 +369,40 @@ staqan-yt get-channel-analytics @yourchannel \
   --dimensions country \
   --metrics estimatedMinutesWatched
 ```
+
+#### Row order
+
+The Analytics API only sorts by a field the query itself selects, so a custom
+query is ranked by the first of these its `--metrics` contains:
+
+1. `views`
+2. `engagedViews`
+3. `estimatedMinutesWatched`
+
+descending. A query selecting none of them (`--metrics likes,shares`) comes
+back in whatever order the API returns unless you pass `--sort`.
+
+`--sort` overrides that choice and accepts any dimension or metric the query
+selects, `-field` for descending:
+
+```bash
+# Rank countries by engaged views, not by the post-2026-08-24 views count
+staqan-yt get-channel-analytics @yourchannel \
+  --dimensions country \
+  --metrics views,engagedViews \
+  --sort -engagedViews
+
+# Chronological instead of ranked
+staqan-yt get-channel-analytics @yourchannel \
+  --dimensions day \
+  --metrics views \
+  --sort day
+```
+
+Naming a field the query does not select fails before the request is sent, and
+the error lists what is available. Predefined `--report` types carry their own
+sort order, so combining them with `--sort` is rejected rather than silently
+ignored.
 
 ---
 

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -386,7 +386,7 @@ back in whatever order the API returns unless you pass `--sort`.
 selects, `-field` for descending:
 
 ```bash
-# Rank countries by engaged views, not by the post-2026-08-24 views count
+# Rank countries by engaged views rather than by views
 staqan-yt get-channel-analytics @yourchannel \
   --dimensions country \
   --metrics views,engagedViews \
@@ -403,6 +403,12 @@ Naming a field the query does not select fails before the request is sent, and
 the error lists what is available. Predefined `--report` types carry their own
 sort order, so combining them with `--sort` is rejected rather than silently
 ignored.
+
+`engagedViews` is accepted by the Analytics API today and is the metric that
+keeps the stricter view definition once YouTube's view-counting change takes
+effect on 2026-08-24. Which of the two belongs on the ranking axis is a
+question about the analysis, not about the date, which is why `--sort` exists
+rather than a rule that switches on its own.
 
 ---
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -547,6 +547,13 @@ export async function fetchVideoRetention(params: { videoId: string }): Promise<
  * accepts for ageGroup/gender reports (live-verified 2026-07-17: the old
  * views,estimatedMinutesWatched pair was rejected with "not supported",
  * so the report type never worked on either surface).
+ *
+ * These metric sets deliberately do NOT carry engagedViews (#179). Each
+ * report is a fixed output shape that existing consumers parse by column, so
+ * widening one silently changes their input. engagedViews is reachable today
+ * through a custom --dimensions/--metrics query, and whether it is accepted
+ * for each of these dimensions has not been swept the way #173 swept the
+ * rest, so adding it here would ship an unverified claim. Revisit under #175.
  */
 export const CHANNEL_REPORT_TYPES: Record<string, { dimensions: string; metrics: string; sort: string }> = {
   demographics: {
@@ -609,6 +616,67 @@ async function lookupChannel(youtube: youtube_v3.Youtube, channel: string): Prom
   };
 }
 
+/**
+ * Metrics a custom query is ranked by when the caller does not say, in
+ * preference order (#179).
+ *
+ * `views` stays first so every query that sorted before this existed sorts
+ * identically after it. `engagedViews` follows: it carries the pre-2026-08-24
+ * view semantics, so a caller selecting it is asking the same question
+ * `views` used to answer, and it is the figure tied to monetization.
+ * `estimatedMinutesWatched` is the fallback for metric sets that select no
+ * view metric at all.
+ */
+export const SORTABLE_METRIC_PREFERENCE = ['views', 'engagedViews', 'estimatedMinutesWatched'] as const;
+
+/** Split a comma-separated API field list into trimmed, non-empty entries. */
+function splitFields(raw: string): string[] {
+  return raw.split(',').map(f => f.trim()).filter(Boolean);
+}
+
+/**
+ * Resolve the sort field for a custom dimensions+metrics query (#179).
+ *
+ * The API rejects a sort field absent from the query's own metrics and
+ * dimensions, so the axis can only be chosen from what the caller selected.
+ * The previous rule looked for the literal string `views` and fell through to
+ * no sort at all otherwise, which left every other metric set in whatever
+ * order the API happened to return (live-verified 2026-08-21: `--dimensions
+ * day --metrics engagedViews` came back in raw date order, so a top-days
+ * query was silently unranked).
+ *
+ * `explicit` is the caller's `--sort`. It is validated against the selected
+ * fields, so an unsortable axis is named here rather than surfacing as the
+ * API's opaque 400, but it is never second-guessed. Returns undefined only
+ * when nothing rankable was selected and the caller named no axis, which is
+ * the one case where the API's own row order stands.
+ */
+export function resolveCustomSort(
+  dimensions: string,
+  metrics: string,
+  explicit?: string,
+): string | undefined {
+  const metricList = splitFields(metrics);
+
+  if (explicit !== undefined) {
+    const field = explicit.replace(/^-/, '').trim();
+    if (field.length === 0) {
+      throw new Error('--sort cannot be empty');
+    }
+    const selectable = [...splitFields(dimensions), ...metricList];
+    if (!selectable.includes(field)) {
+      throw new Error(
+        `Invalid --sort value: "${field}". The Analytics API only sorts by a field the ` +
+        `query itself selects. Available: ${selectable.join(', ')}.`,
+      );
+    }
+    return explicit.trim();
+  }
+
+  const preferred = SORTABLE_METRIC_PREFERENCE.find(m => metricList.includes(m));
+  return preferred ? `-${preferred}` : undefined;
+}
+
 export interface ChannelAnalyticsParams {
   /** Channel handle (@name) or ID (callers run requireChannel first). */
   channel: string;
@@ -622,6 +690,11 @@ export interface ChannelAnalyticsParams {
   dimensions?: string;
   /** Custom metrics; requires dimensions. */
   metrics?: string;
+  /**
+   * Explicit sort field for a custom query, `-field` for descending. Only
+   * valid alongside dimensions/metrics: predefined reports carry their own.
+   */
+  sort?: string;
   /** Progress hook — commands wire this to the spinner; MCP omits it. */
   onProgress?: (message: string) => void;
 }
@@ -648,6 +721,13 @@ export async function fetchChannelAnalytics(params: ChannelAnalyticsParams): Pro
     throw new Error('Cannot combine --report with --dimensions or --metrics. Use one or the other.');
   }
 
+  // Same reasoning as the check above: a predefined report already fixes its
+  // own sort, so honoring --sort here would mean silently redefining the
+  // report, and ignoring it would mean silently discarding the flag.
+  if (params.report !== undefined && params.sort !== undefined) {
+    throw new Error('Cannot combine --report with --sort. Predefined reports carry their own sort order.');
+  }
+
   let dimensions: string;
   let metrics: string;
   let reportName: string;
@@ -665,9 +745,7 @@ export async function fetchChannelAnalytics(params: ChannelAnalyticsParams): Pro
   } else if (params.dimensions && params.metrics) {
     dimensions = params.dimensions;
     metrics = params.metrics;
-    // The API rejects a sort field that isn't in metrics/dimensions, so only
-    // sort custom queries that actually select views.
-    sort = params.metrics.split(',').map(m => m.trim()).includes('views') ? '-views' : undefined;
+    sort = resolveCustomSort(dimensions, metrics, params.sort);
     reportName = 'custom';
   } else {
     throw new Error(

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -129,7 +129,7 @@ export function getCommandOptions(command: string): string[] {
     'get-search-terms': ['--limit', '-l', ...outputOptions, ...verboseOption],
     'get-traffic-sources': [...outputOptions, ...verboseOption],
     'get-video-retention': [...outputOptions, ...verboseOption],
-    'get-channel-analytics': ['--report', '--start-date', '--end-date', '--dimensions', '--metrics', ...outputOptions, ...verboseOption],
+    'get-channel-analytics': ['--report', '--start-date', '--end-date', '--dimensions', '--metrics', '--sort', ...outputOptions, ...verboseOption],
     'get-channel-search-terms': ['--channel', '--limit', '-l', '--content-type', '--start-date', '--end-date', ...outputOptions, ...verboseOption],
     'list-comments': ['--limit', '-l', '--sort', '-s', ...outputOptions, ...verboseOption],
     'get-video-tags': [...outputOptions, ...verboseOption],
@@ -327,7 +327,7 @@ _staqa_nyt_completion() {
       COMPREPLY=( \$(compgen -W "--video-id --start-date --end-date --metrics --dimensions --output --verbose" -- "\${cur}") )
       ;;
     get-channel-analytics)
-      COMPREPLY=( \$(compgen -W "--channel --report --start-date --end-date --dimensions --metrics --output --verbose" -- "\${cur}") )
+      COMPREPLY=( \$(compgen -W "--channel --report --start-date --end-date --dimensions --metrics --sort --output --verbose" -- "\${cur}") )
       ;;
     get-search-terms|get-traffic-sources|get-video-retention|get-video-tags|list-captions)
       COMPREPLY=( \$(compgen -W "--video-id --output --verbose" -- "\${cur}") )

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -296,7 +296,15 @@ _staqa_nyt_completion() {
     --privacy)
       COMPREPLY=( \$(compgen -W "public private unlisted" -- "\${cur}") ); return ;;
     --sort|-s)
-      COMPREPLY=( \$(compgen -W "top new" -- "\${cur}") ); return ;;
+      # Scoped to the command, like --type above: "top"/"new" are list-comments
+      # values. get-channel-analytics --sort takes a field the query itself
+      # selects, which is only knowable from the --dimensions/--metrics typed
+      # so far, so its values stay unenumerated rather than wrong.
+      case "$cmd" in
+        list-comments)
+          COMPREPLY=( \$(compgen -W "top new" -- "\${cur}") ); return ;;
+      esac
+      ;;
     --format)
       COMPREPLY=( \$(compgen -W "raw srt vtt sbv ttml" -- "\${cur}") ); return ;;
     --dimensions)
@@ -847,6 +855,7 @@ ${commandList}
         '--end-date[End date (YYYY-MM-DD)]:date:' \\
         '--dimensions[Custom dimensions (comma-separated)]:dims:' \\
         '--metrics[Custom metrics (comma-separated)]:metrics:' \\
+        '--sort[Sort by a selected field, -field for descending]:field:' \\
         '--output[Output format]:format:(json table text pretty csv)' \\
         '--verbose[Enable verbose output]'
       ;;

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -8,6 +8,9 @@ import {
   allowedMetricsFor,
   reconcileMetrics,
   DEFAULT_VIDEO_METRICS,
+  resolveCustomSort,
+  SORTABLE_METRIC_PREFERENCE,
+  CHANNEL_REPORT_TYPES,
 } from '../lib/analytics';
 
 /**
@@ -228,5 +231,75 @@ describe('arity caps (#173)', () => {
     expect(DIMENSION_MAX_ARITY.day).toBeUndefined();
     const seven = 'day,deviceType,operatingSystem,subscribedStatus,youtubeProduct,creatorContentType,liveOrOnDemand';
     expect(validateVideoDimensions(seven)).toBe(seven);
+  });
+});
+
+/**
+ * The unsorted-output failure was measured against the live Analytics API on
+ * 2026-08-21: `--dimensions day --metrics views` came back ranked by views,
+ * while `--dimensions day --metrics engagedViews` over the identical range
+ * came back in raw date order.
+ */
+describe('custom query sort (#179)', () => {
+  it('keeps -views for any metric set selecting views', () => {
+    expect(resolveCustomSort('country', 'views')).toBe('-views');
+    expect(resolveCustomSort('country', 'views,estimatedMinutesWatched')).toBe('-views');
+    // The pre-#179 rule already produced this; widening the preference list
+    // must not move an existing query's ranking axis.
+    expect(resolveCustomSort('country', 'views,engagedViews')).toBe('-views');
+  });
+
+  it('ranks a view metric the old literal check missed', () => {
+    expect(resolveCustomSort('day', 'engagedViews')).toBe('-engagedViews');
+    expect(resolveCustomSort('day', 'engagedViews,estimatedMinutesWatched')).toBe('-engagedViews');
+    expect(resolveCustomSort('day', 'estimatedMinutesWatched')).toBe('-estimatedMinutesWatched');
+  });
+
+  it('does not match a metric that merely contains a sortable name', () => {
+    expect(resolveCustomSort('day', 'redViews')).toBeUndefined();
+    expect(resolveCustomSort('day', 'estimatedRedMinutesWatched')).toBeUndefined();
+  });
+
+  it('tolerates whitespace and empty entries in the metric list', () => {
+    expect(resolveCustomSort('country', ' views , likes ')).toBe('-views');
+    expect(resolveCustomSort('country', 'engagedViews,,')).toBe('-engagedViews');
+  });
+
+  it('leaves a query selecting nothing rankable to the API order', () => {
+    expect(resolveCustomSort('ageGroup,gender', 'viewerPercentage')).toBeUndefined();
+    expect(resolveCustomSort('country', 'likes,shares')).toBeUndefined();
+  });
+
+  it('honors an explicit sort over the preference order', () => {
+    expect(resolveCustomSort('country', 'views,likes', 'likes')).toBe('likes');
+    expect(resolveCustomSort('country', 'views,likes', '-likes')).toBe('-likes');
+    // A dimension is a valid sort field too.
+    expect(resolveCustomSort('day', 'views', 'day')).toBe('day');
+  });
+
+  it('rejects an explicit sort the query does not select', () => {
+    expect(() => resolveCustomSort('country', 'views', 'likes')).toThrow(
+      /Invalid --sort value: "likes"/,
+    );
+    // The message names what is actually available, per the #173 convention.
+    expect(() => resolveCustomSort('country', 'views', '-shares')).toThrow(
+      /Available: country, views/,
+    );
+    expect(() => resolveCustomSort('country', 'views', '-')).toThrow(/--sort cannot be empty/);
+  });
+
+  it('keeps engagedViews out of the predefined reports (#179 item 3)', () => {
+    for (const [name, config] of Object.entries(CHANNEL_REPORT_TYPES)) {
+      expect(config.metrics, `${name} metrics`).not.toContain('engagedViews');
+      // Each predefined report carries its own sort, so it never reaches
+      // resolveCustomSort and is unaffected by the preference order.
+      expect(config.sort, `${name} sort`).toBeTruthy();
+    }
+  });
+
+  it('lists the preference order most-specific first', () => {
+    expect([...SORTABLE_METRIC_PREFERENCE]).toEqual([
+      'views', 'engagedViews', 'estimatedMinutesWatched',
+    ]);
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -375,6 +375,7 @@ export interface ChannelAnalyticsOptions extends ChannelOption, OutputOption, Ve
   endDate?: string;
   dimensions?: string;
   metrics?: string;
+  sort?: string;
 }
 
 // Channel search terms command options


### PR DESCRIPTION
Closes #179.

## The problem

`fetchChannelAnalytics` picked the sort field for a custom query by testing the requested metrics for the literal string `views`:

```ts
sort = params.metrics.split(',').map(m => m.trim()).includes('views') ? '-views' : undefined;
```

Any metric set that did not contain exactly `views` fell through to no sort at all, and the API's own row order stood. A top-N query silently stopped being a ranking.

This is not a future problem. `engagedViews` is **already accepted by the live API** ahead of the 2026-08-24 view-counting change, so the failure reproduces today.

## Live measurement (2026-08-21, `--dimensions day`, range 2026-08-05..2026-08-19)

| `--metrics` | row order returned |
|---|---|
| `views` | ranked: 56, 55, 54, 34, 32, ... |
| `engagedViews` | **raw date order**: 08-05, 08-06, 08-07, ... |
| `estimatedMinutesWatched` | **raw date order** |

`views` and `engagedViews` already diverge in historical data, well before the cutoff. Country `JP` over 2026-05-01..2026-08-19: **1404 views, 802 engaged views**. Engaged views is the figure that keeps the pre-change semantics and the one tied to monetization, so the metric most worth ranking was the one losing its ranking.

## The change

**Preference order instead of a literal check.** A custom query is ranked by the first of `views`, `engagedViews`, `estimatedMinutesWatched` present in the selected metrics, descending. `views` stays first, so no query that sorted before this change moves. Extracted into a pure exported `resolveCustomSort`, which makes the selection testable without a live call (issue item 4).

**A `--sort` flag**, because the preference order cannot resolve intent when both view metrics are selected: `--metrics views,engagedViews` ranks by `-views`, and a caller who wants the engaged figure ranked previously had no way to say so. It accepts any dimension or metric the query selects, `-field` for descending, and is validated client-side so an unsortable axis is named here rather than surfacing as the API's opaque 400.

**`--report` + `--sort` is rejected**, matching the existing #70 check. A predefined report fixes its own sort, so honoring the flag would silently redefine the report and ignoring it would silently discard the flag.

**Predefined report metric sets deliberately keep no `engagedViews`** (issue item 3). Each is a fixed output shape parsed by column, and whether `engagedViews` is accepted for each of those dimensions has not been swept the way #173 swept the rest, so adding it would ship an unverified claim. The reasoning is recorded at `CHANNEL_REPORT_TYPES` and the work left to #175.

## E2E proof

Baseline captured from the released binary before the change; identical commands re-run against `bun dist/bin/staqan-yt.js` after.

**Regression control.** `--metrics views` over the same range is **byte-identical** to main (`diff` clean). The metric that already sorted did not move.

**Fix.** `engagedViews` and `estimatedMinutesWatched` now come back ranked descending, and the row *set* is unchanged, only reordered (`diff` of both sorted, clean) so nothing was dropped or filtered.

**Report path.** `--report geography` output unchanged.

**Negative controls**, all exit 1 with a message naming the problem:

| command | message |
|---|---|
| `--dimensions country --metrics views --sort likes` | `Invalid --sort value: "likes". ... Available: country, views.` |
| `--report geography --sort -views` | `Cannot combine --report with --sort. ...` |
| `--dimensions country --metrics views --sort -` | `--sort cannot be empty` |
| `--report geography --metrics views` | `Cannot combine --report with --dimensions or --metrics.` (#70, still rejected) |

**Positive controls.** `--sort day` returns chronological order; `--sort -likes` overrides the `views` default and is accepted by the API.

Tests 197 -> 206. `type-check`, `lint`, `build`, `bun test` all green.

## Note for #178

The measurement above weakens a premise in #178, which proposes warning that a range spanning 2026-08-24 mixes old- and new-logic views. In Analytics, `views` and `engagedViews` already differ across all of July and early August 2026, so there may be no clean discontinuity at that date on this API surface. Worth confirming against post-cutoff data before shipping a warning that asserts one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtPf8D4CPFzVEEtCz9X6Pp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sorting for custom channel analytics queries.
  * Supports ascending and descending sorting using the selected dimensions and metrics.
  * Analytics results now use a sensible default metric order when no sort field is specified.
  * Added sorting support to the analytics tool and shell completion.

* **Bug Fixes**
  * Added validation for unsupported sort fields and incompatible predefined reports.

* **Documentation**
  * Documented sorting syntax, defaults, validation, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->