### PR TITLE
fix(#182): stop the global-options fallback overwriting per-command flags

### DIFF
--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -295,6 +295,10 @@ _staqa_nyt_completion() {
       ;;
     --privacy)
       COMPREPLY=( \$(compgen -W "public private unlisted" -- "\${cur}") ); return ;;
+    --report)
+      # Mirrors the zsh _arguments spec for get-channel-analytics, which has
+      # always enumerated these; bash had no arm at all (#182).
+      COMPREPLY=( \$(compgen -W "demographics devices geography traffic-sources subscription-status" -- "\${cur}") ); return ;;
     --sort|-s)
       # Scoped to the command, like --type above: "top"/"new" are list-comments
       # values. get-channel-analytics --sort takes a field the query itself
@@ -410,8 +414,17 @@ _staqa_nyt_completion() {
       ;;
   esac
 
-  # Default completion for options
-  if [[ "\${cur}" == -* ]]; then
+  # Default completion for options (#182).
+  #
+  # Only fills in when nothing above matched. The per-command arms in the
+  # \`case\` above set COMPREPLY and fall through without returning, so an
+  # unconditional assignment here overwrote every one of them: since a flag
+  # name being completed always starts with "-", this branch always ran, and
+  # all 34 commands offered only the three global options.
+  #
+  # Guarding on emptiness rather than adding \`return\` to each arm keeps a
+  # future arm from reintroducing the bug by forgetting one.
+  if [[ "\${cur}" == -* && \${#COMPREPLY[@]} -eq 0 ]]; then
     COMPREPLY=( \$(compgen -W "\${global_options}" -- "\${cur}") )
   fi
 }

--- a/tests/completion.test.ts
+++ b/tests/completion.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression guard for #182: per-command flag lists must survive to COMPREPLY.
+ *
+ * The generated bash completion ends with a fallback that offers the three
+ * global options. The per-command arms above it set COMPREPLY and fall through
+ * without returning, so an unconditional fallback overwrote all of them: a flag
+ * name being completed always starts with "-", so the branch always ran, and
+ * every one of the 34 commands offered only --help/--output/--verbose.
+ *
+ * The bug is invisible in the cases exercised most often by hand, because the
+ * value-completion arms (--output, --video-id) return explicitly and were never
+ * affected. Only flag-NAME completion broke.
+ *
+ * These tests drive the real generated script through a real bash, because the
+ * defect is in shell control flow and nothing about it is observable from
+ * TypeScript. `_init_completion` comes from the bash-completion package, which
+ * is not present on every machine (notably macOS), so it is stubbed with the
+ * four variables the script actually reads.
+ */
+import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { getCompletionScript } from '../lib/completion';
+
+const SCRIPT = getCompletionScript('bash');
+
+/** Stub standing in for the bash-completion package's _init_completion. */
+const HARNESS = `
+_init_completion() {
+  words=( "\${COMP_WORDS[@]}" )
+  cword=$COMP_CWORD
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  prev="\${COMP_WORDS[COMP_CWORD-1]}"
+  return 0
+}
+`;
+
+/**
+ * Complete `line` and return the resulting COMPREPLY entries.
+ *
+ * `partial` distinguishes the two shapes bash passes in. A trailing space means
+ * a new, empty word is being completed (`--sort <TAB>`), so an empty element is
+ * appended. A partial word means the last token is itself the word being
+ * completed (`--s<TAB>`), so it is left alone. Getting this wrong silently
+ * tests the wrong branch.
+ */
+function complete(line: string, partial = false): string[] {
+  const words = line.split(' ');
+  const compWords = partial ? words : [...words, ''];
+  const script = [
+    HARNESS,
+    SCRIPT,
+    `COMP_WORDS=(${compWords.map(w => `'${w}'`).join(' ')})`,
+    `COMP_CWORD=${compWords.length - 1}`,
+    'COMPREPLY=()',
+    '_staqa_nyt_completion 2>/dev/null',
+    'printf "%s\\n" "${COMPREPLY[@]}"',
+  ].join('\n');
+
+  const res = spawnSync('bash', ['-c', script], { encoding: 'utf8' });
+  return res.stdout.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+describe('bash completion: per-command flags (#182)', () => {
+  it('offers a command\'s own flags, not just the global options', () => {
+    const reply = complete('staqan-yt get-channel-analytics --', true);
+    expect(reply).toContain('--report');
+    expect(reply).toContain('--dimensions');
+    expect(reply).toContain('--metrics');
+    expect(reply).toContain('--sort');
+    // The regression: these three were the ONLY entries returned.
+    expect(reply.length).toBeGreaterThan(3);
+  });
+
+  it('narrows on a partial flag name', () => {
+    const reply = complete('staqan-yt get-channel-analytics --s', true);
+    expect(reply.sort()).toEqual(['--sort', '--start-date']);
+  });
+
+  it('still falls back to global options for an unknown command', () => {
+    // Nothing in the case matches, so COMPREPLY is empty and the fallback runs.
+    const reply = complete('staqan-yt not-a-real-command --', true);
+    expect(reply.sort()).toEqual(['--help', '--output', '--verbose']);
+  });
+
+  it('keeps per-command flags distinct across commands', () => {
+    const tags = complete('staqan-yt update-video-tags --', true);
+    expect(tags).toContain('--replace');
+    expect(tags).toContain('--remove');
+    expect(tags).not.toContain('--dimensions');
+  });
+});
+
+describe('bash completion: flag values (#182)', () => {
+  it('enumerates --report, which bash previously never completed', () => {
+    const reply = complete('staqan-yt get-channel-analytics --report');
+    expect(reply.sort()).toEqual([
+      'demographics', 'devices', 'geography', 'subscription-status', 'traffic-sources',
+    ]);
+  });
+
+  it('leaves the returning value arms untouched', () => {
+    expect(complete('staqan-yt get-channel-analytics --output').sort())
+      .toEqual(['csv', 'json', 'pretty', 'table', 'text']);
+    expect(complete('staqan-yt put-caption --format').sort())
+      .toEqual(['raw', 'sbv', 'srt', 'ttml', 'vtt']);
+  });
+
+  it('scopes --sort values to list-comments (#179 follow-up)', () => {
+    expect(complete('staqan-yt list-comments --sort').sort()).toEqual(['new', 'top']);
+    expect(complete('staqan-yt list-comments -s').sort()).toEqual(['new', 'top']);
+    // get-channel-analytics --sort takes a field the query selects, which is
+    // not knowable here, so it must offer nothing rather than comment sorts.
+    expect(complete('staqan-yt get-channel-analytics --sort')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #182.

## The problem

The generated bash completion ends with a fallback offering the three global options:

```bash
  if [[ "${cur}" == -* ]]; then
    COMPREPLY=( $(compgen -W "${global_options}" -- "${cur}") )
  fi
```

Every per-command arm above it sets `COMPREPLY` and falls out of the `case` without returning. A flag name being completed always starts with `-`, so this branch always ran, and it overwrote all 34 commands' flag lists.

| input | before | after |
|---|---|---|
| `get-channel-analytics --<TAB>` | `--help --output --verbose` | full flag list |
| `get-channel-analytics --s<TAB>` | (nothing) | `--sort --start-date` |
| `update-video-tags --<TAB>` | `--help --output --verbose` | full flag list |

The defect was invisible by hand because the *value* arms (`--output`, `--video-id`, `--format`) return explicitly and were never affected. Only flag-**name** completion broke. zsh is unaffected: it uses `_arguments` with a per-command spec and never had the shared fallback.

## The change

**Guard the fallback on `COMPREPLY` being empty** rather than adding `return` to each of the 34 arms. A future arm cannot reintroduce the bug by forgetting one, which the per-arm fix invites.

**Add the missing `--report` value arm.** bash had none at all, so its five report types never completed there, even though the zsh spec has always enumerated them (issue item 3).

## Tests

Adds `tests/completion.test.ts`, the **first coverage of the completion scripts** in this repo (issue item 2). It drives the real generated script through a real `bash`, because the defect is in shell control flow and nothing about it is observable from TypeScript. `_init_completion` is stubbed with the four variables the script actually reads, since the bash-completion package is not present on macOS.

**Verified as a regression guard, not just a passing test.** Run against the pre-fix `lib/completion.ts` from `main`, 4 of the 7 fail with exactly the reported symptom:

```
error: expect(received).toContain(expected)
Expected to contain: "--replace"
Received: [ "--help", "--output", "--verbose" ]
```

The 3 that pass pre-fix are the deliberate controls: the returning value arms, and the genuine unknown-command fallback that must keep working.

Tests 206 -> 213. `type-check`, `lint`, `build` green; both generated scripts pass `bash -n` and `zsh -n`.

## Note on #165

#165 reports the `--privacy)` arm under `case "$prev"` as unreachable dead code, shadowed by the variadic pre-check. That is a separate defect in the same file and is **not** addressed here; this PR changes only what happens after the `case` completes, plus the one missing `--report` arm. Left for #165 so the two stay independently reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtPf8D4CPFzVEEtCz9X6Pp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added value suggestions for the `--report` option, including demographics, devices, geography, traffic sources, and subscription status.

* **Bug Fixes**
  * Command-specific Bash completion options are now preserved instead of being replaced by global options.
  * Improved filtering for partial flag names and command-specific values such as sorting options.

* **Tests**
  * Added regression coverage for command flags, option values, aliases, and fallback behavior in Bash completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->