### PR TITLE
fix(#178): flag ranges whose views predate the 2026-08-24 counting change

### DIFF
--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -71,6 +71,14 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     const { channelId, channelTitle, reportType, dateRange, columnHeaders, rows } = result;
     const { startDate, endDate } = dateRange;
 
+    // #178: human-facing formats only. json/csv/table are what scripts read,
+    // and a note they cannot parse is noise there; the same signal reaches
+    // those callers as `viewCountingNotice` in the MCP result. stderr, not
+    // stdout, so even here it never lands in a redirected file.
+    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
+      process.stderr.write(`${result.viewCountingNotice.message}\n`);
+    }
+
     if (rows.length === 0) {
       console.log('');
       console.log(chalk.yellow('No analytics data available for this channel and time period.'));

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -41,6 +41,14 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
 
     spinner.succeed(`Retrieved ${allRows.length} row(s) of analytics data`);
 
+    // #178: human-facing formats only, on stderr. See get-channel-analytics
+    // for the reasoning. This command is the more exposed of the two, since
+    // the default start date is the upload date, so every all-time query on a
+    // video published before the change reaches back past it.
+    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
+      process.stderr.write(`${result.viewCountingNotice.message}\n`);
+    }
+
     // Prepare aggregated data for structured formats
     const aggregated: { [key: string]: number } = {};
     columnHeaders.forEach((header, index) => {

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -678,11 +678,19 @@ async function handleToolCall(name: string, args: any) {
       });
 
       if (result.rows.length === 0) {
+        // The notice describes the requested date range, not the rows, so it
+        // still applies when nothing came back: a caller comparing this empty
+        // result against pre-cutoff archived data needs the same caveat. The
+        // CLI already emits its notice before its own empty-rows branch, and
+        // dropping it here was the one place the two surfaces disagreed.
+        const noData = 'No analytics data available for this channel and time period.';
         return {
           content: [
             {
               type: 'text',
-              text: 'No analytics data available for this channel and time period.',
+              text: result.viewCountingNotice
+                ? `${noData}\n\n${JSON.stringify({ viewCountingNotice: result.viewCountingNotice }, null, 2)}`
+                : noData,
             },
           ],
         };

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -207,7 +207,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_channel_analytics',
-    description: 'Get channel-level analytics reports from YouTube Analytics API (demographics, devices, geography, traffic sources, subscription status, etc.). When the result carries `viewCountingNotice`, the requested range reaches back before the 2026-08-24 view-counting change, so `views` in these rows is not measured consistently across the range (or against later data); report that caveat rather than presenting a total as comparable. `engagedViews` keeps the stricter pre-change definition throughout.',
+    description: 'Get channel-level analytics reports from YouTube Analytics API (demographics, devices, geography, traffic sources, subscription status, etc.). When the result carries `viewCountingNotice`, the requested range reaches back before the 2026-08-24 view-counting change, so the metrics named in its `affectedMetrics` (`views` and/or `redViews`) are not measured consistently across the range (or against later data); report that caveat rather than presenting a total as comparable. `engagedViews` keeps the stricter pre-change definition throughout.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -246,7 +246,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_video_analytics',
-    description: 'Get video performance analytics including views, watch time, average view duration, likes, comments, and more. When the result carries `viewCountingNotice`, the requested range reaches back before the 2026-08-24 view-counting change, so `views` in these rows is not measured consistently across the range (or against later data); report that caveat rather than presenting a total as comparable. Note the default start date is the video\'s upload date, so all-time queries on older videos always reach back past the change.',
+    description: 'Get video performance analytics including views, watch time, average view duration, likes, comments, and more. When the result carries `viewCountingNotice`, the requested range reaches back before the 2026-08-24 view-counting change, so the metrics named in its `affectedMetrics` (`views` and/or `redViews`) are not measured consistently across the range (or against later data); report that caveat rather than presenting a total as comparable. `engagedViews` keeps the stricter pre-change definition throughout. Note the default start date is the video\'s upload date, so all-time queries on older videos always reach back past the change.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -207,7 +207,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_channel_analytics',
-    description: 'Get channel-level analytics reports from YouTube Analytics API (demographics, devices, geography, traffic sources, subscription status, etc.)',
+    description: 'Get channel-level analytics reports from YouTube Analytics API (demographics, devices, geography, traffic sources, subscription status, etc.). When the result carries `viewCountingNotice`, the requested range reaches back before the 2026-08-24 view-counting change, so `views` in these rows is not measured consistently across the range (or against later data); report that caveat rather than presenting a total as comparable. `engagedViews` keeps the stricter pre-change definition throughout.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -246,7 +246,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_video_analytics',
-    description: 'Get video performance analytics including views, watch time, average view duration, likes, comments, and more',
+    description: 'Get video performance analytics including views, watch time, average view duration, likes, comments, and more. When the result carries `viewCountingNotice`, the requested range reaches back before the 2026-08-24 view-counting change, so `views` in these rows is not measured consistently across the range (or against later data); report that caveat rather than presenting a total as comparable. Note the default start date is the video\'s upload date, so all-time queries on older videos always reach back past the change.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -4,6 +4,56 @@ Commands for retrieving YouTube Analytics data and performance metrics.
 
 > **Important:** These commands require the `https://www.googleapis.com/auth/yt-analytics.readonly` OAuth scope. Re-authenticate if needed: `staqan-yt auth`
 
+## The 2026-08-24 view-counting change
+
+On **2026-08-24** YouTube aligned view counting across formats: a view is
+counted from the first frame of playback, with no minimum watch time. Dates
+from that day onward are measured that way, earlier dates are not. The stricter
+previous definition survives as **`engagedViews`**, which is also the metric
+tied to monetization and YPP eligibility.
+
+What this means in practice:
+
+- **`views` is not one series.** A range that starts before 2026-08-24 and ends
+  on or after it carries both definitions in the same column, so a total across
+  it mixes them.
+- **Older data is not comparable to newer data.** A range lying entirely before
+  the change is internally consistent, but its `views` cannot be compared
+  against `views` pulled for later dates.
+- **`engagedViews` is consistent across the boundary.** Use it when you need
+  one definition throughout, or when comparing against anything archived
+  before the change.
+- `redViews` is affected the same way as `views`.
+
+`get-video-analytics` and `get-channel-analytics` print a note on stderr when
+the requested range reaches back before the change, naming the dates affected.
+It appears for `--output pretty` and `--output text` only, so `json`, `csv` and
+`table` stay clean for piping. Ranges lying entirely on or after 2026-08-24 get
+no note, because nothing about them is ambiguous.
+
+```console
+$ staqan-yt get-channel-analytics --dimensions day --metrics views \
+    --start-date 2026-08-01 --end-date 2026-09-05
+Note: views changes definition inside this date range. 2026-08-01 to
+2026-08-23 is counted under the previous definition; 2026-08-24 onward counts
+every playback from the first frame. Totals across the whole range mix the two.
+engagedViews keeps the stricter definition throughout.
+https://support.google.com/youtube/answer/2991785
+```
+
+MCP callers get the same signal as a `viewCountingNotice` object on the result,
+carrying `changeDate`, `affectedMetrics`, `affectedRange` and `spansChange`, so
+the date does not have to be hardcoded downstream.
+
+Note that `views` and `engagedViews` were already returning different totals
+for the same range before 2026-08-24, so the change date is not a clean
+before/after split between the two metrics. The note states only which dates
+were measured under which definition.
+
+**Reference:** [How YouTube counts views](https://support.google.com/youtube/answer/2991785)
+
+---
+
 ## get-video-analytics
 
 Get video performance analytics (views, watch time, CTR, etc.).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,6 +139,44 @@ staqan-yt auth
 
 ## API Issues
 
+### Views jumped suddenly, or two runs disagree
+
+**Symptom:** View counts rose sharply with no matching change in traffic, or a
+total you stored earlier no longer matches what the CLI returns for the same
+date range. You may also see a note on stderr mentioning 2026-08-24.
+
+**Cause:** On **2026-08-24** YouTube changed how views are counted. From that
+date a view is counted from the first frame of playback, with no minimum watch
+time. Earlier dates use the previous, stricter definition. The field name did
+not change, so nothing in the numbers themselves marks the boundary.
+
+This is not a bug and not a data correction. The two numbers answer different
+questions.
+
+**Solution:** use `engagedViews`, which keeps the stricter definition on both
+sides of the date and is the metric tied to monetization:
+
+```bash
+# One consistent definition across the whole range
+staqan-yt get-channel-analytics --dimensions day --metrics engagedViews \
+  --start-date 2026-08-01 --end-date 2026-09-05
+
+# Both, to see the difference for yourself
+staqan-yt get-channel-analytics --dimensions day --metrics views,engagedViews \
+  --start-date 2026-08-01 --end-date 2026-09-05 --sort -engagedViews
+```
+
+Note that `views` and `engagedViews` already differed for the same range before
+2026-08-24, so the change date is not a clean before/after split between them.
+
+The Data API's `statistics.viewCount` (`get-video`, `get-channel`) uses the new
+definition and has no `engagedViews` equivalent; the previous definition is only
+reachable through the Analytics and Reporting APIs.
+
+**Reference:** [How YouTube counts views](https://support.google.com/youtube/answer/2991785)
+
+---
+
 ### "API quota exceeded"
 
 **Symptom:**

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -265,6 +265,8 @@ export interface VideoAnalyticsResult {
   metrics: string;
   columnHeaders: { name?: string | null }[];
   rows: unknown[][];
+  /** Set when the range reaches before the view-counting change (#178). */
+  viewCountingNotice?: ViewCountingNotice;
 }
 
 export const DEFAULT_VIDEO_METRICS =
@@ -363,6 +365,7 @@ export async function fetchVideoAnalytics(params: VideoAnalyticsParams): Promise
     metrics,
     columnHeaders,
     rows: allRows,
+    viewCountingNotice: viewCountingNoticeFor(startDate, endDate, metrics),
   };
 }
 
@@ -617,6 +620,91 @@ async function lookupChannel(youtube: youtube_v3.Youtube, channel: string): Prom
 }
 
 /**
+ * The date YouTube aligned view counting across formats: a view counts from
+ * the first frame of playback, with no minimum watch time (#178). Dates from
+ * here onward are measured that way; earlier dates are not.
+ */
+export const VIEW_COUNTING_CHANGE_DATE = '2026-08-24';
+
+/** Last date measured under the previous, stricter definition. */
+const LAST_PRE_CHANGE_DATE = '2026-08-23';
+
+export const VIEW_COUNTING_CHANGE_URL = 'https://support.google.com/youtube/answer/2991785';
+
+/** Metrics whose meaning depends on which side of the change a date falls. */
+const VIEW_COUNTING_AFFECTED_METRICS = ['views', 'redViews'] as const;
+
+export interface ViewCountingNotice {
+  /** The change date, so callers do not hardcode it. */
+  changeDate: string;
+  /** Metrics in this query whose definition the change moved. */
+  affectedMetrics: string[];
+  /** The part of the requested range measured under the old definition. */
+  affectedRange: { startDate: string; endDate: string };
+  /** True when the range covers both definitions; false when entirely before. */
+  spansChange: boolean;
+  /** Human-readable text; the CLI prints this verbatim. */
+  message: string;
+  learnMoreUrl: string;
+}
+
+/**
+ * Build the view-counting notice for a resolved query, or undefined when the
+ * query is unaffected (#178).
+ *
+ * Two independent conditions have to hold, and both are about whether the
+ * numbers actually returned can be misread:
+ *
+ * 1. The query selects a metric the change moved. `engagedViews` keeps the
+ *    stricter definition on both sides of the date, so a query selecting only
+ *    it is consistent end to end and gets nothing.
+ * 2. The range reaches back before the change. A range starting on or after
+ *    it is measured one way throughout, so there is nothing to warn about.
+ *
+ * Deliberately not limited to ranges that *straddle* the date. A range lying
+ * entirely before it is internally consistent but is not comparable to data
+ * pulled for later dates, which is the same trap one step removed, so it gets
+ * a notice worded for that case instead.
+ */
+export function viewCountingNoticeFor(
+  startDate: string,
+  endDate: string,
+  metrics: string,
+): ViewCountingNotice | undefined {
+  const selected = splitFields(metrics);
+  const affectedMetrics = VIEW_COUNTING_AFFECTED_METRICS.filter(m => selected.includes(m));
+  if (affectedMetrics.length === 0) return undefined;
+
+  // ISO dates compare correctly as strings; no parsing needed.
+  if (startDate >= VIEW_COUNTING_CHANGE_DATE) return undefined;
+
+  const spansChange = endDate >= VIEW_COUNTING_CHANGE_DATE;
+  const affectedEnd = spansChange ? LAST_PRE_CHANGE_DATE : endDate;
+  const names = affectedMetrics.join(', ');
+
+  const message = spansChange
+    ? `Note: ${names} changes definition inside this date range. ` +
+      `${startDate} to ${affectedEnd} is counted under the previous definition; ` +
+      `${VIEW_COUNTING_CHANGE_DATE} onward counts every playback from the first frame. ` +
+      `Totals across the whole range mix the two. ` +
+      `engagedViews keeps the stricter definition throughout. ${VIEW_COUNTING_CHANGE_URL}`
+    : `Note: ${names} for ${startDate} to ${affectedEnd} is counted under the definition ` +
+      `used before ${VIEW_COUNTING_CHANGE_DATE}, so it is not comparable to ${names} for ` +
+      `dates from ${VIEW_COUNTING_CHANGE_DATE} onward, which counts every playback from ` +
+      `the first frame. engagedViews keeps the stricter definition throughout. ` +
+      `${VIEW_COUNTING_CHANGE_URL}`;
+
+  return {
+    changeDate: VIEW_COUNTING_CHANGE_DATE,
+    affectedMetrics: [...affectedMetrics],
+    affectedRange: { startDate, endDate: affectedEnd },
+    spansChange,
+    message,
+    learnMoreUrl: VIEW_COUNTING_CHANGE_URL,
+  };
+}
+
+/**
  * Metrics a custom query is ranked by when the caller does not say, in
  * preference order (#179).
  *
@@ -706,6 +794,8 @@ export interface ChannelAnalyticsResult {
   dateRange: { startDate: string; endDate: string };
   columnHeaders: { name?: string | null }[];
   rows: unknown[][];
+  /** Set when the range reaches before the view-counting change (#178). */
+  viewCountingNotice?: ViewCountingNotice;
 }
 
 /**
@@ -794,6 +884,7 @@ export async function fetchChannelAnalytics(params: ChannelAnalyticsParams): Pro
     dateRange: { startDate, endDate },
     columnHeaders: response.data.columnHeaders || [],
     rows: response.data.rows || [],
+    viewCountingNotice: viewCountingNoticeFor(startDate, endDate, metrics),
   };
 }
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -631,7 +631,16 @@ const LAST_PRE_CHANGE_DATE = '2026-08-23';
 
 export const VIEW_COUNTING_CHANGE_URL = 'https://support.google.com/youtube/answer/2991785';
 
-/** Metrics whose meaning depends on which side of the change a date falls. */
+/**
+ * Metrics whose meaning depends on which side of the change a date falls.
+ *
+ * `views` is affected by definition. `redViews` is included because it counts
+ * the same playback event, restricted to Premium members, so a change to what
+ * counts as a view necessarily moves it too. That is an inference from the
+ * announcement rather than a separately documented statement about `redViews`,
+ * and it is the conservative direction: a notice on a series that turned out
+ * to be stable is a smaller error than silence on one that moved.
+ */
 const VIEW_COUNTING_AFFECTED_METRICS = ['views', 'redViews'] as const;
 
 export interface ViewCountingNotice {

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -11,6 +11,9 @@ import {
   resolveCustomSort,
   SORTABLE_METRIC_PREFERENCE,
   CHANNEL_REPORT_TYPES,
+  viewCountingNoticeFor,
+  VIEW_COUNTING_CHANGE_DATE,
+  VIEW_COUNTING_CHANGE_URL,
 } from '../lib/analytics';
 
 /**
@@ -301,5 +304,81 @@ describe('custom query sort (#179)', () => {
     expect([...SORTABLE_METRIC_PREFERENCE]).toEqual([
       'views', 'engagedViews', 'estimatedMinutesWatched',
     ]);
+  });
+});
+
+/**
+ * The notice fires on the range, not on a guess about the data (#178).
+ *
+ * Live measurement on 2026-08-21, before the change: `views` and
+ * `engagedViews` already differed for the same range (channel STAQAN, country
+ * JP, 2026-05-01..2026-08-19: 1404 vs 802). So the notice deliberately does
+ * NOT claim the two series are equal before the cutoff and diverge after it.
+ * It states only what the date arithmetic supports: which dates were measured
+ * under which definition.
+ */
+describe('view-counting change notice (#178)', () => {
+  const AFTER = '2026-08-24';
+  const BEFORE_END = '2026-08-23';
+
+  it('stays silent for a range entirely on or after the change', () => {
+    expect(viewCountingNoticeFor(AFTER, '2026-09-30', 'views')).toBeUndefined();
+    expect(viewCountingNoticeFor('2026-09-01', '2026-09-30', 'views')).toBeUndefined();
+  });
+
+  it('fires on the first day that reaches back before the change', () => {
+    // Boundary: a start one day earlier is affected, the change date itself is not.
+    expect(viewCountingNoticeFor(BEFORE_END, '2026-09-30', 'views')).toBeDefined();
+    expect(viewCountingNoticeFor(AFTER, '2026-09-30', 'views')).toBeUndefined();
+  });
+
+  it('reports a straddling range as mixing two definitions', () => {
+    const n = viewCountingNoticeFor('2026-08-01', '2026-09-05', 'views');
+    expect(n?.spansChange).toBe(true);
+    // The affected slice ends the day before the change, not at the range end.
+    expect(n?.affectedRange).toEqual({ startDate: '2026-08-01', endDate: BEFORE_END });
+    expect(n?.message).toContain('mix the two');
+  });
+
+  it('reports a fully pre-change range as not comparable to later data', () => {
+    const n = viewCountingNoticeFor('2026-05-01', '2026-08-19', 'views');
+    expect(n?.spansChange).toBe(false);
+    // Nothing is truncated here: the whole requested range is affected.
+    expect(n?.affectedRange).toEqual({ startDate: '2026-05-01', endDate: '2026-08-19' });
+    expect(n?.message).toContain('not comparable');
+    expect(n?.message).not.toContain('mix the two');
+  });
+
+  it('only fires for metrics the change actually moved', () => {
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'views')).toBeDefined();
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'redViews')).toBeDefined();
+    // engagedViews keeps the stricter definition on both sides, so a query
+    // selecting only it is consistent end to end.
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'engagedViews')).toBeUndefined();
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'likes,shares')).toBeUndefined();
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'viewerPercentage')).toBeUndefined();
+  });
+
+  it('names every affected metric it found', () => {
+    const n = viewCountingNoticeFor('2026-05-01', '2026-09-05', 'views,engagedViews,redViews');
+    expect(n?.affectedMetrics).toEqual(['views', 'redViews']);
+    expect(n?.affectedMetrics).not.toContain('engagedViews');
+  });
+
+  it('does not match a metric that merely contains an affected name', () => {
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'redViewsPercentage')).toBeUndefined();
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'estimatedRedMinutesWatched')).toBeUndefined();
+  });
+
+  it('carries the date and the reference URL so callers need not hardcode them', () => {
+    const n = viewCountingNoticeFor('2026-05-01', '2026-09-05', 'views');
+    expect(n?.changeDate).toBe(VIEW_COUNTING_CHANGE_DATE);
+    expect(n?.learnMoreUrl).toBe(VIEW_COUNTING_CHANGE_URL);
+    expect(n?.message).toContain(VIEW_COUNTING_CHANGE_URL);
+    expect(n?.message).toContain('2026-08-24');
+  });
+
+  it('tolerates whitespace in the metric list', () => {
+    expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', ' views , likes ')).toBeDefined();
   });
 });

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -365,6 +365,15 @@ describe('view-counting change notice (#178)', () => {
     expect(n?.affectedMetrics).not.toContain('engagedViews');
   });
 
+  it('names only redViews for a redViews-only query', () => {
+    // The message must not talk about `views` when the query never selected
+    // it, which is what a hardcoded metric name in the wording would do.
+    const n = viewCountingNoticeFor('2026-05-01', '2026-09-05', 'redViews');
+    expect(n?.affectedMetrics).toEqual(['redViews']);
+    expect(n?.message).toContain('redViews');
+    expect(n?.message).not.toMatch(/(^|[^d])\bviews\b/);
+  });
+
   it('does not match a metric that merely contains an affected name', () => {
     expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'redViewsPercentage')).toBeUndefined();
     expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', 'estimatedRedMinutesWatched')).toBeUndefined();


### PR DESCRIPTION
Closes #178.

## The problem

On **2026-08-24** YouTube began counting a view from the first frame of playback, with no minimum watch time. The field name did not change, so a `views` column spanning that date carries two definitions with nothing marking the boundary, and a total across it mixes them.

## When the notice fires

Two conditions, both required, so the notice appears exactly when the returned numbers can be misread:

| condition | fires |
|---|---|
| range reaches back before 2026-08-24 | yes |
| range starts on or after 2026-08-24 | **no** |
| selects `views` or `redViews` | yes |
| selects only `engagedViews` | **no**, it keeps the stricter definition on both sides |
| selects neither (`likes,shares`) | **no** |

**Deliberately not limited to ranges that straddle the date.** A range lying entirely before it is internally consistent but is not comparable to later data, which is the same trap one step removed. It gets a notice worded for that case:

```
# straddling
Note: views changes definition inside this date range. 2026-08-20 to 2026-08-23
is counted under the previous definition; 2026-08-24 onward counts every playback
from the first frame. Totals across the whole range mix the two. engagedViews
keeps the stricter definition throughout. https://support.google.com/youtube/answer/2991785

# entirely before
Note: views for 2026-08-01 to 2026-08-19 is counted under the definition used
before 2026-08-24, so it is not comparable to views for dates from 2026-08-24
onward, which counts every playback from the first frame. ...
```

The notice names **the dates affected**, not just the range: a straddling query reports the pre-change slice ending `2026-08-23`, not the range end.

## Where it appears

**stderr, for `--output pretty` and `text` only.** `json`, `csv` and `table` are what scripts read, and a note they cannot parse is noise there. stderr rather than stdout means even the human formats never put it in a redirected file.

**MCP callers get the same signal structurally**, as `viewCountingNotice` on the result (issue item 3), carrying `changeDate`, `affectedMetrics`, `affectedRange` and `spansChange` so the date is not hardcoded downstream. Verified against the live API:

```json
{ "changeDate": "2026-08-24", "affectedMetrics": ["views"],
  "affectedRange": { "startDate": "2026-08-20", "endDate": "2026-08-23" },
  "spansChange": true, "message": "...", "learnMoreUrl": "..." }
```

The CLI's own json payload is **unchanged**, keeping the output shape stable for existing consumers.

## A correction to the issue's premise

#178 proposes warning that a spanning range mixes old- and new-logic views, implying the two metrics agree before the change and diverge after it. **They do not.** Live measurement on 2026-08-21, before the cutoff: channel STAQAN, country `JP`, 2026-05-01..2026-08-19 gave **1404 views against 802 engagedViews** for the same range.

So this notice states only what the date arithmetic supports, which is *which dates were measured under which definition*. It makes no claim about the relationship between the two metrics. The docs say the same explicitly, so the cutoff is not read as a clean split between them.

## E2E proof (live API)

| case | result |
|---|---|
| `--output pretty` / `text`, spanning range | notice on stderr, stdout untouched |
| `--output json` / `csv` / `table`, same range | **silent on both streams** |
| range `2026-08-24..2026-08-24` | silent |
| `--metrics engagedViews`, range reaching back | silent |
| `--metrics likes`, range reaching back | silent |
| range fully before the change | notice, "not comparable" wording |
| `get-video-analytics` all-time (upload 2023-11-02) | notice, `2023-11-02 to 2026-08-23` |

json still parses and exits 0.

## Docs

- `docs/commands/analytics.md`: a section on the change up front, what it means for each case, and the worked example.
- `docs/troubleshooting.md`: filed under **"Views jumped suddenly, or two runs disagree"** (issue item 4 asks for the heading someone will actually search), including that the Data API's `viewCount` has no `engagedViews` equivalent.

## Scope

Analytics surfaces only. The Reporting API's merged-cache problem is a schema mismatch (pre-cutoff CSVs have no `engaged_views` column at all) and belongs to **#177**, which tracks it. `views` in `CHANNEL_REPORT_TYPES` is untouched, per the reasoning recorded in #181.

Tests: 43 in `analytics.test.ts`, covering the 2026-08-23/24 boundary in both directions and metrics that merely contain an affected name (`redViewsPercentage`). `type-check`, `lint`, `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtPf8D4CPFzVEEtCz9X6Pp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notices for analytics covering YouTube’s view-counting change on August 24, 2026.
  * Notices identify affected metrics and date ranges, with a link to learn more.
  * Human-readable CLI output displays notices on stderr, keeping structured output unchanged.
  * Analytics results now include view-counting details for integrations such as MCP.

* **Documentation**
  * Added guidance on mixed historical date ranges, affected metrics, and comparing results consistently.
  * Added troubleshooting information and updated analytics tool descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->