### PR TITLE
feat(#175): add engagedViews, measured against the live API post-cutoff

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -16,8 +16,9 @@ by column position or column count. Callers that pass `--metrics` explicitly
 are unaffected, as are those reading columns by name.
 
 **Why:** on 2026-08-24 YouTube began counting a view from the first frame with
-no minimum watch time. `engagedViews` carries the stricter previous definition
-and is the figure tied to monetization. The two diverge sharply on Shorts,
+no minimum watch time. `engagedViews` carries the stricter previous definition,
+which is the only way to keep one definition across the cutoff. The two diverge
+sharply on Shorts,
 measured over 2026-07-13..2026-08-23:
 
 | type | `views` | `engagedViews` |

--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -1,5 +1,47 @@
 # Breaking Changes
 
+## Unreleased
+
+**`get-video-analytics` default metrics gained `engagedViews`** (#175).
+
+The default set went from eight metrics to nine, with `engagedViews` inserted
+second, immediately after `views`:
+
+| Before | After |
+|---|---|
+| `views,estimatedMinutesWatched,...` | `views,engagedViews,estimatedMinutesWatched,...` |
+
+**Who is affected:** anything parsing default `--output json`, `csv` or `table`
+by column position or column count. Callers that pass `--metrics` explicitly
+are unaffected, as are those reading columns by name.
+
+**Why:** on 2026-08-24 YouTube began counting a view from the first frame with
+no minimum watch time. `engagedViews` carries the stricter previous definition
+and is the figure tied to monetization. The two diverge sharply on Shorts,
+measured over 2026-07-13..2026-08-23:
+
+| type | `views` | `engagedViews` |
+|---|---:|---:|
+| short | 197 | 8 |
+| short | 245 | 23 |
+| long-form | 548 | 548 |
+
+A default query on a Short reporting only `views` shows 197 where 8 is the
+engagement figure, so omitting it from the default was itself misleading.
+
+**To keep the old shape**, pass the previous set explicitly:
+
+```bash
+staqan-yt get-video-analytics --video-id ID \
+  --metrics views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares
+```
+
+Adding it costs nothing in compatibility: the live sweep measured
+`engagedViews` as permitted by all 13 valid dimensions, so unlike
+`likes`/`comments`/`shares` it is never dropped when `--dimensions` is used.
+
+---
+
 ## v2.1.0
 
 **`--tags` → `--replace`** in `update-video-tags`:

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -264,7 +264,7 @@ const TOOLS: Tool[] = [
         },
         metrics: {
           type: 'string',
-          description: 'Comma-separated list of metrics (default: views,engagedViews,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares). `views` counts every playback from the first frame; `engagedViews` applies the stricter pre-2026-08-24 definition and is the figure tied to monetization. On Shorts the two differ sharply (measured: 197 views against 8 engagedViews), so report the one the question calls for rather than assuming they agree. Both are accepted by every valid dimension.',
+          description: 'Comma-separated list of metrics (default: views,engagedViews,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares). `views` counts every playback from the first frame; `engagedViews` applies the stricter pre-2026-08-24 definition and is the only one consistent across that date. On Shorts the two differ sharply (measured: 197 views against 8 engagedViews), so report the one the question calls for rather than assuming they agree. Neither is a YouTube monetization figure: the Partner Programme uses its own separate metrics, so do not present either as earnings or eligibility. Both are accepted by every valid dimension.',
         },
         dimensions: {
           type: 'string',

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -264,7 +264,7 @@ const TOOLS: Tool[] = [
         },
         metrics: {
           type: 'string',
-          description: 'Comma-separated list of metrics (default: views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares)',
+          description: 'Comma-separated list of metrics (default: views,engagedViews,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares). `views` counts every playback from the first frame; `engagedViews` applies the stricter pre-2026-08-24 definition and is the figure tied to monetization. On Shorts the two differ sharply (measured: 197 views against 8 engagedViews), so report the one the question calls for rather than assuming they agree. Both are accepted by every valid dimension.',
         },
         dimensions: {
           type: 'string',

--- a/docs/analytics-compat-snapshot.json
+++ b/docs/analytics-compat-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-21T01:38:25.393Z",
+  "generatedAt": "2026-08-24T09:42:00.941Z",
   "videoId": "eQICyHf3hsY",
   "dateRange": {
     "startDate": "2026-06-01",
@@ -190,6 +190,7 @@
   "dimensionMetrics": {
     "video": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage",
@@ -207,6 +208,7 @@
     ],
     "day": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage",
@@ -224,6 +226,7 @@
     ],
     "month": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage",
@@ -241,6 +244,7 @@
     ],
     "country": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage",
@@ -258,24 +262,28 @@
     ],
     "dma": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage"
     ],
     "deviceType": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage"
     ],
     "operatingSystem": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage"
     ],
     "subscribedStatus": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage",
@@ -290,6 +298,7 @@
     ],
     "youtubeProduct": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage",
@@ -298,6 +307,7 @@
     ],
     "liveOrOnDemand": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "redViews",
@@ -305,6 +315,7 @@
     ],
     "creatorContentType": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage",
@@ -320,12 +331,14 @@
     ],
     "insightTrafficSourceType": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage"
     ],
     "insightPlaybackLocationType": [
       "views",
+      "engagedViews",
       "estimatedMinutesWatched",
       "averageViewDuration",
       "averageViewPercentage"
@@ -337,5 +350,5 @@
     "failed": 0,
     "contradictions": []
   },
-  "probeCount": 296
+  "probeCount": 305
 }

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -112,8 +112,9 @@ staqan-yt get-video-analytics --video-id dQw4w9WgXcQ --output json
 
 ### Default Metrics
 
-If no `--metrics` specified, fetches these eight (`DEFAULT_VIDEO_METRICS` in `lib/analytics.ts`):
-- `views` - Total views
+If no `--metrics` specified, fetches these nine (`DEFAULT_VIDEO_METRICS` in `lib/analytics.ts`):
+- `views` - Every playback, counted from the first frame
+- `engagedViews` - Views under the stricter pre-2026-08-24 definition
 - `estimatedMinutesWatched` - Total watch time
 - `averageViewDuration` - Average view duration (seconds)
 - `averageViewPercentage` - Average share of the video watched
@@ -122,18 +123,41 @@ If no `--metrics` specified, fetches these eight (`DEFAULT_VIDEO_METRICS` in `li
 - `comments` - Total comments
 - `shares` - Total shares
 
-The last four are unavailable for most dimensions, so pass `--metrics views` when using `--dimensions`. See [Dimension Compatibility Guide](../dimension-compatibility.md#metrics-decide-more-than-dimensions-do).
+`likes`, `dislikes`, `comments` and `shares` are unavailable for most
+dimensions and get dropped automatically when you pass `--dimensions`.
+`views` and `engagedViews` are permitted by every valid dimension, so neither
+is ever dropped. See [Dimension Compatibility Guide](../dimension-compatibility.md#metrics-decide-more-than-dimensions-do).
 
 ### Available Metrics
 
 Common metrics:
-- `views` - Total views
+- `views` - Every playback, counted from the first frame
+- `engagedViews` - Views under the stricter pre-2026-08-24 definition; the figure tied to monetization
 - `estimatedMinutesWatched` - Total watch time (minutes)
 - `averageViewDuration` - Average view duration (seconds)
 - `subscribersGained` / `subscribersLost` - Subscriber changes
 - `likes` / `dislikes` - Likes/dislikes
 - `shares` - Number of shares
 - `annotationClicks` - Annotation clicks
+
+#### views vs engagedViews
+
+The gap is not cosmetic, and it is concentrated in Shorts. Measured on one
+channel over 2026-07-13..2026-08-23:
+
+| video | type | `views` | `engagedViews` |
+|---|---|---:|---:|
+| a Short | short | 197 | **8** |
+| a Short | short | 245 | **23** |
+| a Short | short | 196 | **13** |
+| long-form | regular | 548 | 548 |
+
+Long-form is identical because a long-form view already counted from the
+start. The 2026-08-24 alignment removed a minimum-watch-time rule that only
+ever applied to Shorts, so that is where the two diverge.
+
+Read `views` for reach and `engagedViews` for engagement and monetization.
+Both are accepted by every valid dimension.
 
 Full list: [YouTube Analytics Metrics](https://developers.google.com/youtube/analytics/v3/dimsmets/mets)
 

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -9,8 +9,13 @@ Commands for retrieving YouTube Analytics data and performance metrics.
 On **2026-08-24** YouTube aligned view counting across formats: a view is
 counted from the first frame of playback, with no minimum watch time. Dates
 from that day onward are measured that way, earlier dates are not. The stricter
-previous definition survives as **`engagedViews`**, which is also the metric
-tied to monetization and YPP eligibility.
+previous definition survives as **`engagedViews`**.
+
+YouTube's monetization programme uses its own separate metrics (engaged Shorts
+views and engaged watch hours for earnings, qualified views and qualified watch
+hours for YPP eligibility). Those are not the same thing as this Analytics
+metric, so do not read `engagedViews` as a payout or eligibility figure. See
+[How YouTube counts views](https://support.google.com/youtube/answer/2991785).
 
 What this means in practice:
 
@@ -132,7 +137,7 @@ is ever dropped. See [Dimension Compatibility Guide](../dimension-compatibility.
 
 Common metrics:
 - `views` - Every playback, counted from the first frame
-- `engagedViews` - Views under the stricter pre-2026-08-24 definition; the figure tied to monetization
+- `engagedViews` - Views under the stricter pre-2026-08-24 definition
 - `estimatedMinutesWatched` - Total watch time (minutes)
 - `averageViewDuration` - Average view duration (seconds)
 - `subscribersGained` / `subscribersLost` - Subscriber changes
@@ -156,8 +161,9 @@ Long-form is identical because a long-form view already counted from the
 start. The 2026-08-24 alignment removed a minimum-watch-time rule that only
 ever applied to Shorts, so that is where the two diverge.
 
-Read `views` for reach and `engagedViews` for engagement and monetization.
-Both are accepted by every valid dimension.
+Read `views` for reach and `engagedViews` for engagement. Both are accepted by
+every valid dimension. Neither is YouTube's monetization metric; see the note
+at the top of this page.
 
 Full list: [YouTube Analytics Metrics](https://developers.google.com/youtube/analytics/v3/dimsmets/mets)
 
@@ -186,7 +192,7 @@ Supported dimensions for video-level queries:
 
 Combine multiple dimensions with commas (e.g. `--dimensions day,deviceType`). The CLI rejects unknown dimensions and known-bad combinations (e.g. `country + day`) with a clear error before any API call.
 
-**Most dimensions need `--metrics` narrowed.** The default metric set includes `likes`, `dislikes`, `comments` and `shares`, which the API only offers for a few dimensions, so `--dimensions deviceType` fails until you pass something like `--metrics views`. This is the most common cause of `The query is not supported`.
+**Most dimensions permit only some of the default metrics.** `likes`, `dislikes`, `comments` and `shares` are offered for only a few dimensions. When you pass `--dimensions` without `--metrics`, the CLI drops the unsupported defaults automatically and reports which ones on stderr, so `--dimensions deviceType` runs and returns the five view and watch-time columns (`views`, `engagedViews`, `estimatedMinutesWatched`, `averageViewDuration`, `averageViewPercentage`). An **explicit** `--metrics` list is never narrowed: naming an unavailable metric is an error rather than a silent substitution, and that is the most common cause of `The query is not supported`.
 
 **→ See [Dimension Compatibility Guide](../dimension-compatibility.md)** for the measured dimension/metric matrix, the rejected combinations, and the `month` date rule.
 

--- a/docs/dimension-compatibility.md
+++ b/docs/dimension-compatibility.md
@@ -17,11 +17,11 @@ do](#metrics-decide-more-than-dimensions-do).
 
 ## Metrics decide more than dimensions do
 
-`get-video-analytics` sends eight metrics by default:
+`get-video-analytics` sends nine metrics by default:
 
 ```text
-views, estimatedMinutesWatched, averageViewDuration, averageViewPercentage,
-likes, dislikes, comments, shares
+views, engagedViews, estimatedMinutesWatched, averageViewDuration,
+averageViewPercentage, likes, dislikes, comments, shares
 ```
 
 The four engagement metrics (`likes`, `dislikes`, `comments`, `shares`) are only
@@ -29,27 +29,31 @@ available for a few dimensions. The API rejects the **entire query** when any
 requested metric is unavailable for the requested dimensions, using the same
 opaque "query is not supported" it uses for dimension conflicts.
 
-Which of the eight default metrics each dimension permits:
+`engagedViews` (added 2026-08-24, #175) is in the same compatibility class as
+`views`: every dimension below permits both, so neither is ever the reason a
+query is rejected.
 
-| dimension | views | minutes | avgDur | avgPct | likes | dislikes | comments | shares |
-|---|---|---|---|---|---|---|---|---|
-| `video` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `day` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `month` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `country` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `creatorContentType` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `subscribedStatus` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| `dma` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `deviceType` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `operatingSystem` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `youtubeProduct` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `insightTrafficSourceType` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `insightPlaybackLocationType` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `liveOrOnDemand` | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+Which of the nine default metrics each dimension permits:
+
+| dimension | views | engaged | minutes | avgDur | avgPct | likes | dislikes | comments | shares |
+|---|---|---|---|---|---|---|---|---|---|
+| `video` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `day` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `month` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `country` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `creatorContentType` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `subscribedStatus` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
+| `dma` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `deviceType` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `operatingSystem` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `youtubeProduct` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `insightTrafficSourceType` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `insightPlaybackLocationType` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| `liveOrOnDemand` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 For a multi-dimension query the permitted set is the **intersection** of the
-rows above. That is a measured law, not an assumption: `day` permits all eight,
-`deviceType` permits four, and `day,deviceType` permits exactly those four.
+rows above. That is a measured law, not an assumption: `day` permits all nine,
+`deviceType` permits five, and `day,deviceType` permits exactly those five.
 
 ### What the CLI does about it
 

--- a/docs/dimension-compatibility.md
+++ b/docs/dimension-compatibility.md
@@ -65,8 +65,10 @@ rows above. That is a measured law, not an assumption: `day` permits all nine,
   because quietly returning different data than you asked for is worse than
   failing.
 
-So `--dimensions deviceType` now works and returns the four view and watch-time
-columns. To choose the columns yourself, pass them:
+So `--dimensions deviceType` now works and returns the five view and watch-time
+columns: `views`, `engagedViews`, `estimatedMinutesWatched`,
+`averageViewDuration` and `averageViewPercentage`. To choose the columns
+yourself, pass them:
 
 ```bash
 staqan-yt get-video-analytics --video-id VIDEO_ID \

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -154,7 +154,7 @@ This is not a bug and not a data correction. The two numbers answer different
 questions.
 
 **Solution:** use `engagedViews`, which keeps the stricter definition on both
-sides of the date and is the metric tied to monetization:
+sides of the date and is therefore the only view metric comparable across it:
 
 ```bash
 # One consistent definition across the whole range

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -753,7 +753,7 @@ export function viewCountingNoticeFor(
  * `views` stays first so every query that sorted before this existed sorts
  * identically after it. `engagedViews` follows: it carries the pre-2026-08-24
  * view semantics, so a caller selecting it is asking the same question
- * `views` used to answer, and it is the figure tied to monetization.
+ * `views` used to answer.
  * `estimatedMinutesWatched` is the fallback for metric sets that select no
  * view metric at all.
  */

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -19,15 +19,24 @@ import { chunkDateRange, debug, parseChannelHandle, parseDuration, toLocalYmd, v
  * nothing about it.
  */
 export const ALL_SWEPT_METRICS: readonly string[] = [
-  'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
-  'likes', 'dislikes', 'comments', 'shares', 'subscribersGained', 'subscribersLost',
-  'videosAddedToPlaylists', 'redViews', 'estimatedRedMinutesWatched',
-  'annotationClickThroughRate', 'cardClickRate',
+  'views', 'engagedViews', 'estimatedMinutesWatched', 'averageViewDuration',
+  'averageViewPercentage', 'likes', 'dislikes', 'comments', 'shares',
+  'subscribersGained', 'subscribersLost', 'videosAddedToPlaylists', 'redViews',
+  'estimatedRedMinutesWatched', 'annotationClickThroughRate', 'cardClickRate',
 ];
 
-/** The four view and watch-time metrics every valid dimension permits. */
+/**
+ * The five view and watch-time metrics every valid dimension permits.
+ *
+ * `engagedViews` was added from the 2026-08-24 sweep (#175) and sits in exactly
+ * the same compatibility class as `views`: measured against all 13 valid
+ * dimensions, every one accepts it, including the five restrictive dimensions
+ * that permit nothing else beyond this set. Its availability was measured
+ * rather than inferred from `views`, since the earlier sweep predated it.
+ */
 export const VIEW_METRICS: readonly string[] = [
-  'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
+  'views', 'engagedViews', 'estimatedMinutesWatched', 'averageViewDuration',
+  'averageViewPercentage',
 ];
 
 /**
@@ -125,22 +134,23 @@ export const DIMENSION_METRICS: Readonly<Record<string, readonly string[]>> = {
   deviceType: VIEW_METRICS,
   operatingSystem: VIEW_METRICS,
   subscribedStatus: [
-    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
-    'likes', 'dislikes', 'shares', 'videosAddedToPlaylists', 'redViews',
-    'estimatedRedMinutesWatched', 'annotationClickThroughRate', 'cardClickRate',
+    'views', 'engagedViews', 'estimatedMinutesWatched', 'averageViewDuration',
+    'averageViewPercentage', 'likes', 'dislikes', 'shares', 'videosAddedToPlaylists',
+    'redViews', 'estimatedRedMinutesWatched', 'annotationClickThroughRate', 'cardClickRate',
   ],
   youtubeProduct: [
-    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
-    'redViews', 'estimatedRedMinutesWatched',
+    'views', 'engagedViews', 'estimatedMinutesWatched', 'averageViewDuration',
+    'averageViewPercentage', 'redViews', 'estimatedRedMinutesWatched',
   ],
   liveOrOnDemand: [
-    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'redViews',
-    'estimatedRedMinutesWatched',
+    'views', 'engagedViews', 'estimatedMinutesWatched', 'averageViewDuration',
+    'redViews', 'estimatedRedMinutesWatched',
   ],
   creatorContentType: [
-    'views', 'estimatedMinutesWatched', 'averageViewDuration', 'averageViewPercentage',
-    'likes', 'dislikes', 'comments', 'shares', 'subscribersGained', 'subscribersLost',
-    'redViews', 'estimatedRedMinutesWatched', 'cardClickRate',
+    'views', 'engagedViews', 'estimatedMinutesWatched', 'averageViewDuration',
+    'averageViewPercentage', 'likes', 'dislikes', 'comments', 'shares',
+    'subscribersGained', 'subscribersLost', 'redViews', 'estimatedRedMinutesWatched',
+    'cardClickRate',
   ],
   insightTrafficSourceType: VIEW_METRICS,
   insightPlaybackLocationType: VIEW_METRICS,
@@ -269,8 +279,28 @@ export interface VideoAnalyticsResult {
   viewCountingNotice?: ViewCountingNotice;
 }
 
+/**
+ * Default columns for a video analytics query.
+ *
+ * `engagedViews` sits second, next to `views`, because on Shorts the two answer
+ * very different questions and reading only the first is misleading. Measured
+ * on this channel over 2026-07-13..2026-08-23:
+ *
+ *   BpesXOddpVc (short)     197 views     8 engagedViews
+ *   qC_vD4tPNqA (short)     245 views    23 engagedViews
+ *   -COxZI7L-IA (long-form) 548 views   548 engagedViews
+ *
+ * Long-form is unchanged because a long-form view already counted from the
+ * start; the 2026-08-24 alignment removed the minimum-watch-time rule that
+ * only ever applied to Shorts. So the default set has to carry both, or a
+ * Shorts creator reads 197 where 8 is the engagement figure.
+ *
+ * Widening this set costs nothing in compatibility: the #175 sweep measured
+ * `engagedViews` as permitted by all 13 valid dimensions, so unlike the
+ * metrics #173 has to drop, it never narrows a query.
+ */
 export const DEFAULT_VIDEO_METRICS =
-  'views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares';
+  'views,engagedViews,estimatedMinutesWatched,averageViewDuration,averageViewPercentage,likes,dislikes,comments,shares';
 
 /**
  * Fetch analytics for one video: resolves the date range from the upload
@@ -551,12 +581,15 @@ export async function fetchVideoRetention(params: { videoId: string }): Promise<
  * views,estimatedMinutesWatched pair was rejected with "not supported",
  * so the report type never worked on either surface).
  *
- * These metric sets deliberately do NOT carry engagedViews (#179). Each
- * report is a fixed output shape that existing consumers parse by column, so
- * widening one silently changes their input. engagedViews is reachable today
- * through a custom --dimensions/--metrics query, and whether it is accepted
- * for each of these dimensions has not been swept the way #173 swept the
- * rest, so adding it here would ship an unverified claim. Revisit under #175.
+ * These metric sets deliberately do NOT carry engagedViews. The original
+ * reason (#179) was that its compatibility here was unmeasured; the #175 sweep
+ * has since measured it, and every dimension these reports use does accept it.
+ *
+ * They stay as they are for the remaining reason only: each is a fixed output
+ * shape that existing consumers parse by column, and widening five reports at
+ * once is a separate decision from widening the video-analytics default, which
+ * #175 covers. engagedViews is reachable here through a custom
+ * --dimensions/--metrics query with --sort. Tracked in #185.
  */
 export const CHANNEL_REPORT_TYPES: Record<string, { dimensions: string; metrics: string; sort: string }> = {
   demographics: {

--- a/scripts/sweep-analytics-compat.ts
+++ b/scripts/sweep-analytics-compat.ts
@@ -45,6 +45,11 @@ const CARRIER_METRIC = 'views';
 /** Probed one at a time against a single dimension. */
 const CANDIDATE_METRICS = [
   'views',
+  // Added for #175. Carries the pre-2026-08-24 view definition, so its
+  // per-dimension availability had to be measured rather than assumed to
+  // match `views`: the previous sweep probed `views` only and its conclusions
+  // do not automatically transfer to a metric the API gained later.
+  'engagedViews',
   'estimatedMinutesWatched',
   'averageViewDuration',
   'averageViewPercentage',

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -4,6 +4,8 @@ import {
   INVALID_DIMENSION_COMBOS,
   DIMENSION_MAX_ARITY,
   VIEW_METRICS,
+  ALL_SWEPT_METRICS,
+  DIMENSION_METRICS,
   validateVideoDimensions,
   allowedMetricsFor,
   reconcileMetrics,
@@ -389,5 +391,67 @@ describe('view-counting change notice (#178)', () => {
 
   it('tolerates whitespace in the metric list', () => {
     expect(viewCountingNoticeFor('2026-05-01', '2026-09-05', ' views , likes ')).toBeDefined();
+  });
+});
+
+/**
+ * engagedViews support (#175), from the live sweep on 2026-08-24 (the day the
+ * view-counting change took effect, which is the first day the metric could be
+ * measured post-cutoff). Snapshot: docs/analytics-compat-snapshot.json.
+ *
+ * The measured behavior that motivated widening the default set, same channel,
+ * 2026-07-13..2026-08-23:
+ *
+ *   BpesXOddpVc (short)     197 views     8 engagedViews
+ *   qC_vD4tPNqA (short)     245 views    23 engagedViews
+ *   -COxZI7L-IA (long-form) 548 views   548 engagedViews
+ *
+ * Long-form is unchanged because the minimum-watch-time rule the alignment
+ * removed only ever applied to Shorts.
+ */
+describe('engagedViews (#175)', () => {
+  it('is permitted by every dimension the sweep validated', () => {
+    // The point of widening the default: unlike likes/comments/shares, this
+    // metric never narrows a query, so it costs nothing in compatibility.
+    for (const d of Object.keys(DIMENSION_METRICS)) {
+      expect(allowedMetricsFor([d]), `dimension ${d}`).toContain('engagedViews');
+    }
+  });
+
+  it('sits in the same compatibility class as views', () => {
+    // Measured, not assumed: any dimension permitting views permits
+    // engagedViews and vice versa. A future sweep that breaks this parity
+    // should fail here rather than silently produce an asymmetric table.
+    for (const d of Object.keys(DIMENSION_METRICS)) {
+      const allowed = allowedMetricsFor([d]);
+      expect(allowed.includes('views'), `dimension ${d}`).toBe(allowed.includes('engagedViews'));
+    }
+  });
+
+  it('is carried by the swept vocabulary and the universal view set', () => {
+    expect(ALL_SWEPT_METRICS).toContain('engagedViews');
+    expect(VIEW_METRICS).toContain('engagedViews');
+  });
+
+  it('is in the default metric set, right after views', () => {
+    const defaults = DEFAULT_VIDEO_METRICS.split(',');
+    expect(defaults).toContain('engagedViews');
+    expect(defaults.indexOf('engagedViews')).toBe(defaults.indexOf('views') + 1);
+  });
+
+  it('survives reconciliation for every dimension, including restrictive ones', () => {
+    // The concern #175 raised about widening the default was that it would add
+    // failure modes. It does not: the metric is never dropped, anywhere.
+    for (const d of Object.keys(DIMENSION_METRICS)) {
+      const r = reconcileMetrics([d], DEFAULT_VIDEO_METRICS.split(','), false);
+      expect(r.metrics, `dimension ${d}`).toContain('engagedViews');
+      expect(r.dropped, `dimension ${d}`).not.toContain('engagedViews');
+    }
+  });
+
+  it('does not change which other metrics get dropped', () => {
+    // Widening the default must not disturb the existing narrowing behavior.
+    const r = reconcileMetrics(['deviceType'], DEFAULT_VIDEO_METRICS.split(','), false);
+    expect(r.dropped).toEqual(['likes', 'dislikes', 'comments', 'shares']);
   });
 });


### PR DESCRIPTION
Closes #175.

## Why it needed measuring, not assuming

#175 item 1 says to verify against the live API after 2026-08-24, because `engagedViews` postdates the #173 sweep and that sweep's conclusions do not transfer. Ran on the cutoff date, the first day it could be measured post-change.

Added `engagedViews` to the sweep's candidate list and re-ran:

```
305 probes, 0 composition-law contradictions
engagedViews permitted by ALL 13 valid dimensions
```

The snapshot delta is clean: `validDimensions`, `invalidPairs` and `arityCaps` are **byte-identical** to the previous run, and the only change is `+engagedViews` on every dimension row. So it sits in the same compatibility class as `views`, including the five restrictive dimensions that permit nothing else, and joins `VIEW_METRICS`.

## It also demonstrably works

API acceptance is not the same as returning meaningful data, so measured over 2026-07-13..2026-08-23:

| video | type | `views` | `engagedViews` |
|---|---|---:|---:|
| BpesXOddpVc | short | 197 | **8** |
| qC_vD4tPNqA | short | 245 | **23** |
| 1zqV4DUboCY | short | 196 | **13** |
| -COxZI7L-IA | long-form | 548 | 548 |

Long-form is identical because a long-form view already counted from the start; the alignment removed a minimum-watch-time rule that only ever applied to Shorts. **That asymmetry is the argument for the default set.** A default query on a Short reported 197 where 8 is the engagement figure, so leaving it out was itself misleading.

## The default-set decision (#175 item 2)

#175 flagged widening the default as costly, citing #173: the default set already fails for most `--dimensions` values. **The sweep removes that objection specifically for this metric.** Unlike `likes`/`dislikes`/`comments`/`shares`, `engagedViews` is permitted everywhere, so it is never dropped and never narrows a query.

Verified end to end, `--dimensions deviceType`:

```
before:  deviceType,views,estimatedMinutesWatched,averageViewDuration,averageViewPercentage
         Note: dropped likes, dislikes, comments, shares ...

after:   deviceType,views,engagedViews,estimatedMinutesWatched,averageViewDuration,averageViewPercentage
         Note: dropped likes, dislikes, comments, shares ...   <- unchanged
```

Same four dropped, nothing else, plus the new column.

## E2E proof

Default query on a Short, main `7e7d674` before vs branch after:

```
before: video,views,estimatedMinutesWatched,...          -> 197, (no engagement figure)
after:  video,views,engagedViews,estimatedMinutesWatched,... -> 197, 8
```

9 columns to 10; every other column's value identical.

## Breaking-ish, and recorded

The added column changes default `json`/`csv`/`table` shape for callers parsing by position or column count. Recorded in `BREAKING-CHANGES.md` with the reasoning, the measurements, and the escape hatch (pass the previous eight explicitly). Callers reading by name, or passing `--metrics`, are unaffected.

## Docs (#175 items 3, 4, 5)

- `docs/dimension-compatibility.md`: matrix regenerated to nine columns and **verified cell-by-cell against the snapshot programmatically**, not by hand. Stale "all eight / permits four" counts corrected.
- `docs/commands/analytics.md`: metric added to both lists, plus a `views` vs `engagedViews` section carrying the Shorts table.
- `commands/mcp.ts`: metric schema description names both, states which answers which question, and gives the Shorts figures so an agent caller does not assume they agree.

## One correction carried forward

The `CHANNEL_REPORT_TYPES` comment (from #179) said `engagedViews` compatibility there was unswept. It is now swept, and those dimensions **do** accept it. Rather than leave a stale claim, the comment now states the remaining reason (fixed output shapes, five commands, a separate decision from this one) and the open question is tracked in **#185** with the measurements.

Tests 223 -> 229, including a guard that `views` and `engagedViews` stay in the same compatibility class so a future sweep breaking that parity fails loudly. `type-check`, `lint`, `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtPf8D4CPFzVEEtCz9X6Pp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `engagedViews` as the second default metric for video analytics.
  * Made `engagedViews` available across supported analytics dimensions.
  * Clarified differences between `views` and `engagedViews`, including Shorts counting behavior.

* **Breaking Changes**
  * Default JSON, CSV, and table outputs now include an additional metric.
  * Consumers requiring the previous output shape must provide an explicit metric list.

* **Documentation**
  * Updated analytics guides, compatibility references, and tool descriptions with metric availability and definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->