### PR TITLE
docs(#176): caveat the Data API viewCount cutoff, and fix the jq recipes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -173,9 +173,24 @@ cat video_ids.txt | \
 ### Find Underperforming Videos
 
 ```bash
-# Get videos with low views
-staqan-yt list-videos @mychannel --limit 100 --output json | \
-  jq '.[] | select(.viewCount | tonumber < 1000) | {title, viewCount}'
+# Get videos with low views.
+# Counts come from get-videos, not list-videos: list-videos returns no
+# statistics at all. Pass the IDs you want, or collect them from list-videos.
+staqan-yt get-videos --video-ids ID1 ID2 ID3 --output json | \
+  jq '.[] | select(.statistics.viewCount < 1000) | {title, views: .statistics.viewCount}'
+```
+
+Since 2026-08-24 `viewCount` counts every playback from the first frame, which
+inflates Shorts relative to a threshold chosen before that date. To judge a
+video by engagement instead, pull `engagedViews`, which keeps the stricter
+definition:
+
+```bash
+staqan-yt get-video-analytics --video-id VIDEO_ID \
+  --metrics views,engagedViews --output csv
+
+# video,views,engagedViews
+# BpesXOddpVc,197,8      <- a Short: 197 reached, 8 engaged
 ```
 
 ### Archive Thumbnail CTR Data

--- a/docs/commands/channel-operations.md
+++ b/docs/commands/channel-operations.md
@@ -227,8 +227,11 @@ staqan-yt list-videos @yourchannel --limit 20 --output table
 
 ```bash
 # Export video stats for analysis
-staqan-yt list-videos @yourchannel --output json | \
-  jq '.[] | {title, viewCount: .viewCount | tonumber, likeCount: .likeCount | tonumber}' | \
+# Counts come from get-videos: list-videos returns no statistics.
+# Collect the IDs first, then fetch them in one batch.
+staqan-yt list-videos @yourchannel --output json | jq -r '.[].id' | \
+  xargs staqan-yt get-videos --output json --video-ids | \
+  jq '.[] | {title, viewCount: .statistics.viewCount, likeCount: .statistics.likeCount}' | \
   jq -s 'sort_by(.viewCount) | reverse'
 ```
 

--- a/docs/commands/channel-operations.md
+++ b/docs/commands/channel-operations.md
@@ -2,6 +2,14 @@
 
 Commands for working with YouTube channels and their content.
 
+> **`viewCount` (shown as `Total Views`) changed meaning on 2026-08-24.** From
+> that date the Data API counts a view from the first frame of playback, with
+> no minimum watch time. A channel total spanning the cutoff is therefore a sum
+> over two different definitions, and comparing today's total against one
+> stored earlier measures the methodology change as well as the channel. The
+> previous definition survives only as `engagedViews` in the Analytics API.
+> See [The 2026-08-24 view-counting change](analytics.md#the-2026-08-24-view-counting-change).
+
 ## get-channel
 
 Get detailed metadata for a YouTube channel.

--- a/docs/commands/channel-operations.md
+++ b/docs/commands/channel-operations.md
@@ -2,7 +2,7 @@
 
 Commands for working with YouTube channels and their content.
 
-> **`viewCount` (shown as `Total Views`) changed meaning on 2026-08-24.** From
+> **`statistics.viewCount` (shown as `Total Views`) changed meaning on 2026-08-24.** From
 > that date the Data API counts a view from the first frame of playback, with
 > no minimum watch time. A channel total spanning the cutoff is therefore a sum
 > over two different definitions, and comparing today's total against one
@@ -52,12 +52,16 @@ staqan-yt get-channel @mkbhd --output json
 - `id` - Channel ID
 - `title` - Channel name
 - `handle` - Channel handle (@username)
+- `customUrl` - Custom channel URL
 - `description` - Channel description
+- `country` - Channel country code
 - `publishedAt` - Channel creation date
-- `thumbnail` - Channel thumbnail URL
-- `subscriberCount` - Subscriber count
-- `videoCount` - Total video count
-- `viewCount` - Total lifetime view count
+- `brandingSettings` - Channel branding (banner, keywords, etc.)
+- `topicDetails` - Topic categories
+- `statistics` - Object containing `subscriberCount`, `videoCount`, `viewCount`, `hiddenSubscriberCount`
+
+The counts are **nested under `statistics`**, so the jq path for the lifetime
+total is `.statistics.viewCount`, not `.viewCount`.
 
 ### Related Commands
 
@@ -117,14 +121,15 @@ staqan-yt list-videos @yourchannel --output json > videos.json
 - `id` - Video ID
 - `title` - Video title
 - `description` - Video description (truncated)
-- `channelId` - Channel ID
-- `channelTitle` - Channel name
 - `publishedAt` - Publication date
-- `thumbnail` - Thumbnail URL
-- `viewCount` - View count
-- `likeCount` - Like count
-- `commentCount` - Comment count
-- `duration` - Video duration (ISO 8601)
+- `thumbnail` - Thumbnail URL (default quality)
+- `videoType` - `short` or `regular`
+- `privacyStatus` - `public`, `unlisted` or `private`
+
+**No statistics.** `list-videos` does not return view, like or comment counts.
+It is a listing call; fetching counts for every video would cost an extra
+`videos.list` request per page. Pass the IDs to `get-videos --video-ids` when
+you need counts.
 
 ### Filtering by Video Type
 

--- a/docs/commands/video-discovery.md
+++ b/docs/commands/video-discovery.md
@@ -60,15 +60,18 @@ staqan-yt get-video --video-id dQw4w9WgXcQ --output table
 - `id` - Video ID
 - `title` - Video title
 - `description` - Video description
-- `channelId` - Channel ID
 - `channelTitle` - Channel name
 - `publishedAt` - Publication date
-- `thumbnail` - Thumbnail URL (default quality)
-- `viewCount` - View count
-- `likeCount` - Like count
-- `commentCount` - Comment count
+- `thumbnails` - Object keyed by size: `default`, `medium`, `high`, `standard`, `maxres`
+- `videoType` - `short` or `regular`
+- `privacyStatus` - `public`, `unlisted` or `private`
+- `categoryId` - YouTube category ID
 - `duration` - Video duration (ISO 8601)
 - `tags` - Video tags
+- `statistics` - Object containing `viewCount`, `likeCount`, `commentCount` (numbers)
+
+The counts are **nested under `statistics`**, not top level, so the jq path is
+`.[].statistics.viewCount`. The result is an array even for a single video.
 
 ### Related Commands
 
@@ -179,6 +182,9 @@ staqan-yt search-videos --query "Python" --output csv > results.csv
 - `channelTitle` - Channel name
 - `publishedAt` - Publication date
 - `thumbnail` - Thumbnail URL
+- `videoType` - `short` or `regular`
+
+No statistics here either; `search-videos` returns metadata only.
 
 ### Search Behavior
 

--- a/docs/commands/video-discovery.md
+++ b/docs/commands/video-discovery.md
@@ -232,8 +232,10 @@ staqan-yt search-videos --query "keyword" --output json | \
 
 ```bash
 # List and sort by view count
-staqan-yt list-videos @yourchannel --limit 50 --output json | \
-  jq 'sort_by(.viewCount | tonumber) | reverse | .[0:10]'
+# list-videos has no statistics, so pull the counts with get-videos first.
+staqan-yt list-videos @yourchannel --limit 50 --output json | jq -r '.[].id' | \
+  xargs staqan-yt get-videos --output json --video-ids | \
+  jq 'sort_by(.statistics.viewCount) | reverse | .[0:10] | .[] | {title, views: .statistics.viewCount}'
 ```
 
 ## Tips

--- a/docs/commands/video-discovery.md
+++ b/docs/commands/video-discovery.md
@@ -2,6 +2,15 @@
 
 Commands for finding and retrieving video information.
 
+> **`viewCount` changed meaning on 2026-08-24.** From that date the Data API
+> counts a view from the first frame of playback, with no minimum watch time.
+> The field name and type did not change, so nothing in the payload marks the
+> boundary. A `viewCount` you stored before the cutoff and one you fetch now
+> answer different questions, and the difference is large on Shorts. The
+> previous definition is not available from the Data API at all: it survives
+> only as `engagedViews` in the Analytics API.
+> See [The 2026-08-24 view-counting change](analytics.md#the-2026-08-24-view-counting-change).
+
 ## get-video
 
 Get detailed metadata for a single video.

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -2,7 +2,8 @@
 
 All staqan-yt-cli commands support multiple output formats via the `--output` flag.
 
-> **`viewCount` is not comparable across 2026-08-24.** The Data API changed
+> **`viewCount` from before 2026-08-24 is not comparable with `viewCount` from
+> on or after it.** The Data API changed
 > what counts as a view on that date (first frame, no minimum watch time). The
 > field name, type and position are unchanged, so a payload gives no signal
 > either way. Recipes below that **aggregate or compare** it are affected;
@@ -343,8 +344,8 @@ Need to process data programmatically?
 ### Combining Formats
 
 ```bash
-# Get JSON, convert to CSV
-staqan-yt list-videos @yourchannel --output json | \
+# Get JSON, convert to CSV (get-videos, since list-videos carries no statistics)
+staqan-yt get-videos --video-ids ID1 ID2 --output json | \
   jq -r '.[] | [.id, .title, .statistics.viewCount] | @csv' > videos.csv
 
 # Get CSV, process with awk

--- a/docs/output-formats.md
+++ b/docs/output-formats.md
@@ -2,6 +2,22 @@
 
 All staqan-yt-cli commands support multiple output formats via the `--output` flag.
 
+> **`viewCount` is not comparable across 2026-08-24.** The Data API changed
+> what counts as a view on that date (first frame, no minimum watch time). The
+> field name, type and position are unchanged, so a payload gives no signal
+> either way. Recipes below that **aggregate or compare** it are affected;
+> recipes that just display it are not. The field is `statistics.viewCount` in
+> `json` and the `views` column in `csv`/`table`, and only `get-video`,
+> `get-videos` and `get-channel` return it at all.
+>
+> There is deliberately no methodology marker in the payload. Post-cutoff it
+> would be a constant carrying no information, and a fetch timestamp would make
+> every payload differ from every other, breaking the diff and checksum
+> workflows this page recommends. Use the fetch date you already control, or
+> query `engagedViews` through the Analytics API for a series with one
+> definition throughout. See
+> [The 2026-08-24 view-counting change](commands/analytics.md#the-2026-08-24-view-counting-change).
+
 ## Global Options
 
 ### Quiet Mode (`-q, --quiet`)
@@ -101,29 +117,37 @@ staqan-yt get-video dQw4w9WgXcQ
 - Nested objects and arrays
 - Easy to parse with `jq`
 
-**Example:**
+**Example** (`get-video`; counts are numbers, and live under `statistics`):
 ```json
 [
   {
     "id": "dQw4w9WgXcQ",
     "title": "Never Gonna Give You Up",
-    "viewCount": "1400000000"
+    "statistics": {
+      "viewCount": 1400000000,
+      "likeCount": 18000000,
+      "commentCount": 2400000
+    }
   }
 ]
 ```
 
+Note `list-videos` carries **no** statistics at all: it returns `id`, `title`,
+`description`, `publishedAt`, `thumbnail`, `videoType` and `privacyStatus`. Use
+`get-videos --video-ids` when you need counts for several videos.
+
 **Common Usage:**
 ```bash
-# Pipe to jq for filtering
-staqan-yt --quiet list-videos @yourchannel --output json | \
-  jq '.[] | select(.viewCount | tonumber > 1000000)'
+# Pipe to jq for filtering (get-videos, not list-videos: it has the counts)
+staqan-yt --quiet get-videos --video-ids ID1 ID2 --output json | \
+  jq '.[] | select(.statistics.viewCount > 1000000)'
 
 # Save to file
-staqan-yt --quiet get-video VIDEO_ID --output json > video.json
+staqan-yt --quiet get-video --video-id VIDEO_ID --output json > video.json
 
-# Parse with scripts
-data=$(staqan-yt --quiet get-video VIDEO_ID --output json)
-title=$(echo "$data" | jq -r '.title')
+# Parse with scripts (top-level result is an array)
+data=$(staqan-yt --quiet get-video --video-id VIDEO_ID --output json)
+title=$(echo "$data" | jq -r '.[0].title')
 ```
 
 ---
@@ -140,22 +164,25 @@ title=$(echo "$data" | jq -r '.title')
 - Doubles internal quotes for proper escaping
 - Handles nested objects by JSON-encoding them
 
-**Example:**
+**Example** (`get-videos`; the view column is named `views`):
 ```csv
-id,title,viewCount,publishedAt
-dQw4w9WgXcQ,"Never Gonna Give You Up",1400000000,2009-10-25T06:57:33Z
+id,title,channel,published,duration,views,likes,comments,type
+dQw4w9WgXcQ,"Never Gonna Give You Up",RickAstleyVEVO,2009-10-25T06:57:33Z,PT3M33S,1400000000,18000000,2400000,regular
 ```
+
+`list-videos --output csv` is a lighter shape with **no counts**:
+`id,title,published,privacy,type`.
 
 **Common Usage:**
 ```bash
-# Export to Excel
-staqan-yt list-videos @yourchannel --output csv > videos.csv
+# Export to Excel (get-videos carries the counts; list-videos does not)
+staqan-yt get-videos --video-ids ID1 ID2 --output csv > videos.csv
 
 # Open in Excel (macOS)
 open videos.csv
 
 # Process with csvkit
-csvsort --columns viewCount videos.csv > sorted.csv
+csvsort --columns views videos.csv > sorted.csv
 
 # Load into pandas (Python)
 python -c "import pandas as pd; df = pd.read_csv('videos.csv')"
@@ -212,9 +239,9 @@ staqan-yt get-video-analytics VIDEO_ID --output table
 - Raw data output
 - Easy to parse with Unix tools
 
-**Example:**
+**Example** (`list-videos`: id, title, date, privacy, type; no counts):
 ```text
-dQw4w9WgXcQ	Never Gonna Give You Up	1400000000
+dQw4w9WgXcQ	Never Gonna Give You Up	Oct 25, 2009	public	regular
 ```
 
 **Common Usage:**
@@ -318,7 +345,7 @@ Need to process data programmatically?
 ```bash
 # Get JSON, convert to CSV
 staqan-yt list-videos @yourchannel --output json | \
-  jq -r '.[] | [.id, .title, .viewCount] | @csv' > videos.csv
+  jq -r '.[] | [.id, .title, .statistics.viewCount] | @csv' > videos.csv
 
 # Get CSV, process with awk
 staqan-yt get-video-analytics VIDEO_ID --output csv | \
@@ -334,12 +361,15 @@ staqan-yt list-videos @yourchannel --output table | \
 
 ```bash
 # Create custom report
-staqan-yt list-videos @yourchannel --output json | \
-  jq -r '.[] | "\(.title)\t\(.viewCount) views\t\(.likeCount) likes"'
+staqan-yt get-videos --video-ids ID1 ID2 --output json | \
+  jq -r '.[] | "\(.title)\t\(.statistics.viewCount) views\t\(.statistics.likeCount) likes"'
 
 # Calculate totals
-staqan-yt list-videos @yourchannel --output json | \
-  jq '[.[].viewCount | tonumber] | add'
+# Sums views under whichever definition applied when each video accrued them.
+# Fine as a snapshot of now; not comparable to a total stored before
+# 2026-08-24. For a consistent series use engagedViews via get-video-analytics.
+staqan-yt get-videos --video-ids ID1 ID2 --output json | \
+  jq '[.[].statistics.viewCount] | add'
 
 # Format for presentation
 staqan-yt get-channel-analytics @yourchannel --output json | \


### PR DESCRIPTION
Closes #176. Docs only, no source changes.

## The caveat (#176 item 1)

`statistics.viewCount` switched to the new view-counting logic on 2026-08-24. The field name and type did not change, so a payload spanning the cutoff gives a consumer no signal that it now answers a different question, and the previous definition is **not reachable through the Data API at all** (only as `engagedViews` via Analytics).

Added where the field is surfaced:

- **`video-discovery.md`** (`get-video`, `get-videos`)
- **`channel-operations.md`**, where the same number is labelled `Total Views`. Worth calling out separately: that one is a *lifetime* total, so it necessarily sums across both definitions rather than merely risking it.
- **`output-formats.md`**, scoped to the recipes that aggregate or compare rather than merely display.

## No payload marker (#176 item 2) — decided against

The issue floated `viewCountMethodology` or `_fetchedAt`. Declining both:

- `viewCountMethodology` would be a **constant** post-cutoff, carrying nothing a doc line does not, and it cannot retroactively mark data already archived.
- `_fetchedAt` would make **every payload differ from every other**, breaking the diff and checksum workflows `output-formats.md` itself recommends, and which this repo's own E2E merge gate depends on.

The reasoning is written into the docs rather than left implicit, so it does not get re-proposed later. No `BREAKING-CHANGES.md` entry is needed, since output shape is unchanged.

## The jq cross-check (#176 item 3) found something bigger

The issue asks to cross-check the recipes for historical-comparison advice. They turned out to be **wrong on their own terms**, pre-existing and unrelated to the date:

| documented | actual |
|---|---|
| `list-videos ... jq '.[].viewCount'` (4 recipes) | `list-videos` returns **no statistics at all** |
| top-level `.viewCount` | nested at `.statistics.viewCount` |
| `.viewCount \| tonumber`, sample `"1400000000"` | it is already a **number** |
| `csvsort --columns viewCount` | the CSV column is named **`views`** |
| csv sample `id,title,viewCount,publishedAt` | `id,title,channel,published,duration,views,likes,comments,type` |
| text sample `id\ttitle\t1400000000` | `id\ttitle\tdate\tprivacy\ttype` |

So `csvsort --columns viewCount` could never have worked, and the four `list-videos` recipes returned `null` for every row.

**Every rewritten recipe was run against the live CLI before committing**, not reasoned about:

```
get-videos --video-ids ... | jq 'select(.statistics.viewCount > N)'   -> {"id":"BpesXOddpVc","v":197}
jq -r '.[0].title'  (result is an array)                             -> ok
jq '[.[].statistics.viewCount] | add'                                -> 197
jq -r '.[] | [.id,.title,.statistics.viewCount] | @csv'              -> ok
csvsort --columns views                                              -> column exists
get-video-analytics --metrics views,engagedViews                     -> 197, 8
```

Samples now show the headers the commands actually print, and the caveat names where the field lives per format (`statistics.viewCount` in json, `views` column in csv/table) so the mapping is not guesswork.

## One recipe I wrote, tested, and had to replace

I first documented `get-channel-analytics --dimensions video --metrics views,engagedViews --sort engagedViews`. It fails. Probing the API directly:

| query | result |
|---|---|
| `dimensions=video` + metrics, no sort | rejected |
| `+ sort=-engagedViews` | rejected |
| `+ sort=-engagedViews` **+ maxResults** | **OK** |
| `+ sort=engagedViews` (ascending) + maxResults | rejected |

So that report requires `maxResults` and permits descending sort only. `fetchChannelAnalytics` never sends `maxResults`, which means **`get-channel-analytics --dimensions video` cannot work today** regardless of metrics. Replaced with a verified `get-video-analytics` recipe; the missing-`--limit` gap is left unfiled pending your call on whether it is worth a separate issue.

## Relationship to #186

Independent. This branch is off `main` and touches no source, so it does not depend on the `engagedViews` default-metrics change in #186 and will not conflict with it. The recipes here pass `--metrics` explicitly, so they work on `main` today either way.

`type-check`, `lint`, `build`, 223 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtPf8D4CPFzVEEtCz9X6Pp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for YouTube’s August 24, 2026 `viewCount` methodology change and mixed historical totals.
  * Recommended Analytics `engagedViews` for evaluating engagement under the former definition.
  * Clarified which commands provide statistics and how to retrieve video statistics before filtering, sorting, or analyzing performance.
  * Revised command examples and JSON, CSV, and text output documentation to reflect nested statistics fields and updated column names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->