### PR TITLE
docs: record that get-channel-analytics --dimensions video cannot work

### DIFF
--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -450,6 +450,33 @@ staqan-yt get-channel-analytics @yourchannel \
   --metrics estimatedMinutesWatched
 ```
 
+#### `--dimensions video` is not supported here
+
+A per-video breakdown is a top-N report, and the Analytics API requires
+`maxResults` for it. This command does not send one, so
+`--dimensions video` is rejected with the opaque `The query is not supported`
+**for every metric set**, including `--metrics views`. Measured 2026-08-24:
+
+| query | result |
+|---|---|
+| `dimensions=video` + metrics, no sort | rejected |
+| `+ sort=-engagedViews` | rejected |
+| `+ sort=-engagedViews` **+ `maxResults`** | accepted |
+| `+ sort=engagedViews` (ascending) + `maxResults` | rejected |
+
+That report also accepts **descending sort only**, so it would need more than a
+passthrough flag to support properly.
+
+For per-video numbers, use `get-video-analytics` on each video ID:
+
+```bash
+staqan-yt list-videos @yourchannel --limit 20 --output json | jq -r '.[].id' | \
+  while read id; do
+    staqan-yt get-video-analytics --video-id "$id" \
+      --metrics views,engagedViews --output csv | tail -1
+  done
+```
+
 #### Row order
 
 The Analytics API only sorts by a field the query itself selects, so a custom

--- a/docs/dimension-compatibility.md
+++ b/docs/dimension-compatibility.md
@@ -238,6 +238,7 @@ staqan-yt get-video-analytics --video-id VIDEO_ID --dimensions day
 | `Invalid --dimensions value: "x"` | Not in the allowlist. | Check the supported list above. |
 | `Invalid --dimensions combination: a + b` | Known-bad pair, refused locally. | Split into separate queries. |
 | `The query is not supported` | Usually the metric set, not the dimensions. | Retry with `--metrics views`. |
+| `The query is not supported` from `get-channel-analytics --dimensions video` | Not the metrics. That report needs `maxResults`, which the command does not send, so no metric set works. | Use `get-video-analytics` per video. See [analytics.md](commands/analytics.md#--dimensions-video-is-not-supported-here). |
 | `does not align to chosen date dimension` | `month` with dates that are not the 1st. | Use first-of-month for both dates. |
 | `Unknown identifier (x)` | Not a real dimension. | Check spelling against the supported list. |
 


### PR DESCRIPTION
Docs only, no source changes.

## Why

`docs/dimension-compatibility.md` told anyone hitting `The query is not supported` to retry with `--metrics views`. For `get-channel-analytics --dimensions video` that advice is **wrong**, and costs the reader time: the failure is not the metric set, and no metric set fixes it.

A per-video breakdown is a top-N report and the API requires `maxResults` for it. `fetchChannelAnalytics` never sends one, so the query is rejected every time.

## Measured 2026-08-24

| query | result |
|---|---|
| `dimensions=video` + metrics, no sort | rejected |
| `+ sort=-engagedViews` | rejected |
| `+ sort=-engagedViews` **+ `maxResults`** | accepted |
| `+ sort=engagedViews` (ascending) + `maxResults` | rejected |

The report also accepts **descending sort only**, so supporting it properly needs more than passing a limit through. That is why this documents the limitation rather than quietly adding a flag: the right fix is a design decision, not a one-liner.

## Verified before committing

```
--dimensions video --metrics views   -> exit 1   (claim still holds)

documented per-video workaround:
  -COxZI7L-IA,548,548     (long-form)
  BpesXOddpVc,197,8       (Short)
  qC_vD4tPNqA,245,23      (Short)
```

## How this surfaced

While writing a doc recipe for #176 I drafted `--dimensions video --metrics views,engagedViews --sort engagedViews`, then ran it before publishing. It failed. The flag passes the CLI's own dimension validation and fails only at the API, so nothing short of running it would have caught this.

That is also the argument for documenting it rather than leaving it: the local validation gives no hint, and the API error points at the wrong cause.

## Scope

Deliberately does not add `--limit` to `get-channel-analytics`. That is a feature decision (which sort orders to expose, what default limit, how it interacts with the `--sort` work from #179) and belongs in its own issue if wanted.

`type-check`, `lint`, 229 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtPf8D4CPFzVEEtCz9X6Pp