### PR TITLE
fix: emit the view-counting notice for the fixed-metric reports

### DIFF
--- a/commands/get-channel-analytics.ts
+++ b/commands/get-channel-analytics.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { debug, formatNumber, initCommand, withSpinner, validateDateOption, validateDateRange, runOrExit, writeStdout } from '../lib/utils';
 import { requireChannel, getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
-import { fetchChannelAnalytics, ChannelAnalyticsResult } from '../lib/analytics';
+import { fetchChannelAnalytics, ChannelAnalyticsResult, emitViewCountingNotice } from '../lib/analytics';
 import { ChannelAnalyticsOptions } from '../types';
 
 async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Promise<void> {
@@ -75,9 +75,7 @@ async function getChannelAnalyticsCommand(options: ChannelAnalyticsOptions): Pro
     // and a note they cannot parse is noise there; the same signal reaches
     // those callers as `viewCountingNotice` in the MCP result. stderr, not
     // stdout, so even here it never lands in a redirected file.
-    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
-      process.stderr.write(`${result.viewCountingNotice.message}\n`);
-    }
+    emitViewCountingNotice(result.viewCountingNotice, outputFormat);
 
     if (rows.length === 0) {
       console.log('');

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -7,6 +7,7 @@ import {
   validateContentType,
   ALL_TIME_START_DATE,
   CHANNEL_SEARCH_TERMS_MAX_VIDEOS,
+  emitViewCountingNotice,
 } from '../lib/analytics';
 import { ChannelSearchTermsOptions } from '../types';
 
@@ -55,9 +56,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     // get-channel-analytics: json/csv/table are what scripts read and a note
     // they cannot parse is noise there. MCP callers read `viewCountingNotice`
     // off the result instead.
-    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
-      process.stderr.write(`${result.viewCountingNotice.message}\n`);
-    }
+    emitViewCountingNotice(result.viewCountingNotice, outputFormat);
     const { channelId, channelTitle, videosAnalyzed, columnHeaders, rows } = result;
     const { startDate, endDate } = result.dateRange;
     const isLifetime = startDate === ALL_TIME_START_DATE;

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -44,6 +44,20 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
+    // #178 view-counting caveat. These reports send a fixed `views` metric
+    // set the caller cannot widen, so unlike the custom-query commands there
+    // is no way to ask for `engagedViews` instead and sidestep the ambiguity.
+    // Whether they should also return `engagedViews` is #185; that decision
+    // changes the output shape, while this note does not, so it is not
+    // blocked on it.
+    //
+    // Human-facing formats only, on stderr, matching get-video-analytics and
+    // get-channel-analytics: json/csv/table are what scripts read and a note
+    // they cannot parse is noise there. MCP callers read `viewCountingNotice`
+    // off the result instead.
+    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
+      process.stderr.write(`${result.viewCountingNotice.message}\n`);
+    }
     const { channelId, channelTitle, videosAnalyzed, columnHeaders, rows } = result;
     const { startDate, endDate } = result.dateRange;
     const isLifetime = startDate === ALL_TIME_START_DATE;

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -33,6 +33,20 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
+    // #178 view-counting caveat. These reports send a fixed `views` metric
+    // set the caller cannot widen, so unlike the custom-query commands there
+    // is no way to ask for `engagedViews` instead and sidestep the ambiguity.
+    // Whether they should also return `engagedViews` is #185; that decision
+    // changes the output shape, while this note does not, so it is not
+    // blocked on it.
+    //
+    // Human-facing formats only, on stderr, matching get-video-analytics and
+    // get-channel-analytics: json/csv/table are what scripts read and a note
+    // they cannot parse is noise there. MCP callers read `viewCountingNotice`
+    // off the result instead.
+    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
+      process.stderr.write(`${result.viewCountingNotice.message}\n`);
+    }
     const searchTermsData = rows.map((row, index) => ({
       rank: index + 1,
       searchTerm: row[0] as string,

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { parseVideoId, parsePositiveInt, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, daysAgoYmd, runOrExit, writeStdout } from '../lib/utils';
-import { fetchSearchTerms } from '../lib/analytics';
+import { fetchSearchTerms, emitViewCountingNotice } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { SearchTermsOptions } from '../types';
@@ -44,9 +44,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     // get-channel-analytics: json/csv/table are what scripts read and a note
     // they cannot parse is noise there. MCP callers read `viewCountingNotice`
     // off the result instead.
-    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
-      process.stderr.write(`${result.viewCountingNotice.message}\n`);
-    }
+    emitViewCountingNotice(result.viewCountingNotice, outputFormat);
     const searchTermsData = rows.map((row, index) => ({
       rank: index + 1,
       searchTerm: row[0] as string,

--- a/commands/get-traffic-sources.ts
+++ b/commands/get-traffic-sources.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { parseVideoId, debug, formatNumber, convertToCSV, initCommand, withSpinner, toLocalYmd, daysAgoYmd, writeStdout } from '../lib/utils';
-import { fetchTrafficSources } from '../lib/analytics';
+import { fetchTrafficSources, emitViewCountingNotice } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable, formatCsv } from '../lib/formatters';
 import { TrafficSourcesOptions } from '../types';
@@ -43,9 +43,7 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
     // get-channel-analytics: json/csv/table are what scripts read and a note
     // they cannot parse is noise there. MCP callers read `viewCountingNotice`
     // off the result instead.
-    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
-      process.stderr.write(`${result.viewCountingNotice.message}\n`);
-    }
+    emitViewCountingNotice(result.viewCountingNotice, outputFormat);
 
     // Traffic source labels
     const sourceLabels: { [key: string]: string } = {

--- a/commands/get-traffic-sources.ts
+++ b/commands/get-traffic-sources.ts
@@ -32,6 +32,20 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
+    // #178 view-counting caveat. These reports send a fixed `views` metric
+    // set the caller cannot widen, so unlike the custom-query commands there
+    // is no way to ask for `engagedViews` instead and sidestep the ambiguity.
+    // Whether they should also return `engagedViews` is #185; that decision
+    // changes the output shape, while this note does not, so it is not
+    // blocked on it.
+    //
+    // Human-facing formats only, on stderr, matching get-video-analytics and
+    // get-channel-analytics: json/csv/table are what scripts read and a note
+    // they cannot parse is noise there. MCP callers read `viewCountingNotice`
+    // off the result instead.
+    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
+      process.stderr.write(`${result.viewCountingNotice.message}\n`);
+    }
 
     // Traffic source labels
     const sourceLabels: { [key: string]: string } = {

--- a/commands/get-video-analytics.ts
+++ b/commands/get-video-analytics.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { parseVideoId, debug, formatNumber, convertToCSV, initCommand, withSpinner, validateDateOption, validateDateRange, runOrExit, writeStdout } from '../lib/utils';
-import { fetchVideoAnalytics } from '../lib/analytics';
+import { fetchVideoAnalytics, emitViewCountingNotice } from '../lib/analytics';
 import { getOutputFormat } from '../lib/config';
 import { formatJson, formatTable } from '../lib/formatters';
 import { AnalyticsOptions } from '../types';
@@ -45,9 +45,7 @@ async function getVideoAnalyticsCommand(options: AnalyticsOptions): Promise<void
     // for the reasoning. This command is the more exposed of the two, since
     // the default start date is the upload date, so every all-time query on a
     // video published before the change reaches back past it.
-    if (result.viewCountingNotice && (outputFormat === 'pretty' || outputFormat === 'text')) {
-      process.stderr.write(`${result.viewCountingNotice.message}\n`);
-    }
+    emitViewCountingNotice(result.viewCountingNotice, outputFormat);
 
     // Prepare aggregated data for structured formats
     const aggregated: { [key: string]: number } = {};

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -763,6 +763,41 @@ export function viewCountingNoticeFor(
 }
 
 /**
+ * Output formats the notice is written for. `json`, `csv` and `table` are what
+ * scripts parse, and a prose note they cannot read is noise there.
+ */
+const NOTICE_OUTPUT_FORMATS = new Set(['pretty', 'text']);
+
+/**
+ * Write a view-counting notice for the human-facing output formats, and
+ * report whether it was written.
+ *
+ * Extracted because five commands had reimplemented the same two conditions
+ * (`get-video-analytics`, `get-channel-analytics`, `get-traffic-sources`,
+ * `get-search-terms`, `get-channel-search-terms`). Five copies of a rule about
+ * which stream carries what is five chances for one of them to drift onto
+ * stdout and corrupt a piped result.
+ *
+ * `get-report-data` deliberately does NOT use this: it prints its notice for
+ * every format, alongside its unconditional Incomplete Data warning. That is a
+ * different rule, so it stays a separate call rather than a flag here.
+ *
+ * `stream` exists so tests can assert both the content and the routing without
+ * capturing the real process streams. It defaults to stderr, never stdout,
+ * because stdout carries the machine-readable output.
+ */
+export function emitViewCountingNotice(
+  notice: ViewCountingNotice | undefined,
+  outputFormat: string,
+  stream: { write(chunk: string): unknown } = process.stderr,
+): boolean {
+  if (!notice) return false;
+  if (!NOTICE_OUTPUT_FORMATS.has(outputFormat)) return false;
+  stream.write(`${notice.message}\n`);
+  return true;
+}
+
+/**
  * The same notice for a bulk Reporting API result, keyed on the report's CSV
  * columns instead of an Analytics metric list (#177).
  *

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -411,6 +411,12 @@ export interface VideoReportResult {
   dateRange: { startDate: string; endDate: string };
   columnHeaders: { name?: string | null }[];
   rows: unknown[][];
+  /**
+   * Set when the range reaches back before the 2026-08-24 view-counting
+   * change. These reports send a fixed `views` metric set, so the caveat
+   * applies to every row they return.
+   */
+  viewCountingNotice?: ViewCountingNotice;
 }
 
 /**
@@ -487,6 +493,7 @@ export async function fetchTrafficSources(params: {
     dateRange: { startDate: params.startDate, endDate: params.endDate },
     columnHeaders: response.data.columnHeaders || [],
     rows: response.data.rows || [],
+    viewCountingNotice: viewCountingNoticeFor(params.startDate, params.endDate, 'views'),
   };
 }
 
@@ -525,6 +532,7 @@ export async function fetchSearchTerms(params: {
     dateRange: { startDate: params.startDate, endDate: params.endDate },
     columnHeaders: response.data.columnHeaders || [],
     rows: response.data.rows || [],
+    viewCountingNotice: viewCountingNoticeFor(params.startDate, params.endDate, 'views'),
   };
 }
 
@@ -1034,6 +1042,12 @@ export interface ChannelSearchTermsResult {
   dateRange: { startDate: string; endDate: string };
   columnHeaders: { name?: string | null }[];
   rows: unknown[][];
+  /**
+   * Set when the range reaches back before the 2026-08-24 view-counting
+   * change. `SEARCH_TERMS_METRICS` always sends `views`, so the caveat
+   * applies to every row this returns.
+   */
+  viewCountingNotice?: ViewCountingNotice;
 }
 
 // Metrics for insightTrafficSourceDetail with insightTrafficSourceType==YT_SEARCH.
@@ -1128,5 +1142,6 @@ export async function fetchChannelSearchTerms(params: ChannelSearchTermsParams):
     dateRange: { startDate, endDate },
     columnHeaders: response.data.columnHeaders || [],
     rows: response.data.rows || [],
+    viewCountingNotice: viewCountingNoticeFor(startDate, endDate, SEARCH_TERMS_METRICS),
   };
 }

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -395,6 +395,44 @@ describe('view-counting change notice (#178)', () => {
 });
 
 /**
+ * The fixed-shape reports send metric sets the caller cannot override, so the
+ * notice has to be derived from what each one hardcodes rather than from a
+ * user-supplied `--metrics` (#185's sites, but not #185's decision).
+ *
+ * `get-traffic-sources` is the sharpest case: it exposes no date flags at all
+ * and hardcodes a rolling 30-day window, so for the first 30 days after
+ * 2026-08-24 its one and only behaviour straddles the change.
+ */
+describe('view-counting notice for fixed-metric reports', () => {
+  it('fires for the traffic-source and per-video search-term metric set', () => {
+    // Both send exactly `views`.
+    expect(viewCountingNoticeFor('2026-07-26', '2026-08-25', 'views')).toBeDefined();
+  });
+
+  it('fires for the channel search-terms metric set', () => {
+    // SEARCH_TERMS_METRICS is 'views,estimatedMinutesWatched'; only the first
+    // is affected, and the note must not claim the watch-time metric moved.
+    const n = viewCountingNoticeFor('2026-05-01', '2026-09-05', 'views,estimatedMinutesWatched');
+    expect(n?.affectedMetrics).toEqual(['views']);
+    expect(n?.message).not.toContain('estimatedMinutesWatched');
+  });
+
+  it('reports a rolling window that straddles the change as mixing definitions', () => {
+    // A 30-day window ending after the change, which is what
+    // get-traffic-sources produces unattended.
+    const n = viewCountingNoticeFor('2026-07-26', '2026-08-25', 'views');
+    expect(n?.spansChange).toBe(true);
+    expect(n?.affectedRange).toEqual({ startDate: '2026-07-26', endDate: '2026-08-23' });
+    expect(n?.message).toContain('mix the two');
+  });
+
+  it('goes quiet once the rolling window clears the change date', () => {
+    // 30 days after the change these commands stop warning on their own.
+    expect(viewCountingNoticeFor('2026-09-24', '2026-10-24', 'views')).toBeUndefined();
+  });
+});
+
+/**
  * engagedViews support (#175), from the live sweep on 2026-08-24 (the day the
  * view-counting change took effect, which is the first day the metric could be
  * measured post-cutoff). Snapshot: docs/analytics-compat-snapshot.json.

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -14,6 +14,7 @@ import {
   SORTABLE_METRIC_PREFERENCE,
   CHANNEL_REPORT_TYPES,
   viewCountingNoticeFor,
+  emitViewCountingNotice,
   viewCountingNoticeForColumns,
   VIEW_COUNTING_CHANGE_DATE,
   VIEW_COUNTING_CHANGE_URL,
@@ -481,6 +482,81 @@ describe('view-counting change notice for report columns (#177)', () => {
  * and hardcodes a rolling 30-day window, so for the first 30 days after
  * 2026-08-24 its one and only behaviour straddles the change.
  */
+/**
+ * Which stream carries the notice, and for which output formats (#178, #190).
+ *
+ * This is the rule five commands had each reimplemented inline before it was
+ * extracted: get-video-analytics, get-channel-analytics, get-traffic-sources,
+ * get-search-terms and get-channel-search-terms. Five copies of a decision
+ * about stream routing is five chances for one to drift onto stdout, which
+ * would corrupt any piped result rather than merely annoy the reader.
+ *
+ * A fake stream is injected so both the content and the routing are asserted
+ * without touching the real process streams.
+ */
+describe('emitViewCountingNotice routing', () => {
+  const notice = viewCountingNoticeFor('2026-05-01', '2026-09-05', 'views')!;
+  const sink = () => {
+    const written: string[] = [];
+    return { written, write(c: string) { written.push(c); return true; } };
+  };
+
+  it('writes for the human-facing formats', () => {
+    for (const fmt of ['pretty', 'text']) {
+      const s = sink();
+      expect(emitViewCountingNotice(notice, fmt, s)).toBe(true);
+      expect(s.written).toHaveLength(1);
+      expect(s.written[0]).toBe(`${notice.message}\n`);
+    }
+  });
+
+  it('writes nothing for the machine-readable formats', () => {
+    // These are what scripts parse. A prose note they cannot read is noise,
+    // and on stdout it would be corruption.
+    for (const fmt of ['json', 'csv', 'table']) {
+      const s = sink();
+      expect(emitViewCountingNotice(notice, fmt, s)).toBe(false);
+      expect(s.written).toEqual([]);
+    }
+  });
+
+  it('writes nothing when there is no notice', () => {
+    // The undefined case is the common one: any range starting on or after
+    // the change date produces no notice at all.
+    const s = sink();
+    expect(emitViewCountingNotice(undefined, 'pretty', s)).toBe(false);
+    expect(s.written).toEqual([]);
+  });
+
+  it('does not treat an unknown format as human-facing', () => {
+    // Fails closed: a format added later stays out of stdout's way until
+    // someone opts it in deliberately.
+    const s = sink();
+    expect(emitViewCountingNotice(notice, 'yaml', s)).toBe(false);
+    expect(s.written).toEqual([]);
+  });
+
+  it('defaults to stderr, never stdout', () => {
+    // The default argument is the actual routing decision, so pin it.
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const origOut = process.stdout.write;
+    const origErr = process.stderr.write;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stdout as any).write = (c: string) => { stdout.push(String(c)); return true; };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as any).write = (c: string) => { stderr.push(String(c)); return true; };
+    try {
+      emitViewCountingNotice(notice, 'pretty');
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    }
+    expect(stderr.join('')).toContain(notice.message);
+    expect(stdout).toEqual([]);
+  });
+});
+
 describe('view-counting notice for fixed-metric reports', () => {
   it('fires for the traffic-source and per-video search-term metric set', () => {
     // Both send exactly `views`.


### PR DESCRIPTION
Three commands return `views` over a date range and say nothing about the 2026-08-24 view-counting change, while `get-video-analytics` and `get-channel-analytics` have warned since #178.

| command | metrics sent | notice before | after |
|---|---|---|---|
| `get-traffic-sources` | `views` | no | yes |
| `get-search-terms` | `views` | no | yes |
| `get-channel-search-terms` | `views,estimatedMinutesWatched` | no | yes |

## Why this one is not theoretical

`get-traffic-sources` exposes **no date flags at all**. It hardcodes a rolling 30-day window, so for the first 30 days after the change its one and only behaviour straddles it. Run on 2026-08-25 against `main`:

```
Date Range: 2026-07-26 to 2026-08-25          (change date: 2026-08-24)
```

Two counting definitions in one `views` column, sorted by `-views`, with no caveat. No unusual invocation required to reach it.

These three also have less room to work around the ambiguity than the custom-query commands do: each sends a fixed metric set the caller cannot widen, so there is no `--metrics engagedViews` escape.

## Relationship to #185

#185 asks whether these reports should also **return** `engagedViews`. That is an output-shape decision across five commands, it interacts with the `sort: '-views'` axis, and it is unresolved.

This PR does not touch it. The notice goes to stderr and changes no output shape, so it is not blocked on that decision and does not pre-empt it. It just stops the commands being silent while the decision waits.

## Convention followed

Matches the two commands that already warn: stderr, `--output pretty` and `--output text` only, so `json`/`csv`/`table` stay clean for piping. MCP callers read `viewCountingNotice` off the result.

This is deliberately the opposite choice from the one in #189, where the notice is unconditional. That command's sibling Incomplete Data warning is already unconditional, so gating there would have left the weaker caveat more visible; these three have no such sibling and follow their own surface's precedent.

## E2E proof

`get-traffic-sources`, identical invocation, live API, main (`4473778`) vs branch:

| | main | branch |
|---|---|---|
| exit code | 0 | 0 |
| `--output text` stdout sha256 | `eea9de23f6141657` | `eea9de23f6141657` |
| `--output json` stdout sha256 | `5bb54c049c3851f9` | `5bb54c049c3851f9` |
| notice on stderr, `text` | **0** | **1** |
| notice on stderr, `json` | 0 | **0** (correctly gated) |

stdout byte-identical in both formats, so no data regression.

```
Note: views changes definition inside this date range. 2026-07-26 to 2026-08-23 is
counted under the previous definition; 2026-08-24 onward counts every playback from
the first frame. Totals across the whole range mix the two. engagedViews keeps the
stricter definition throughout.
```

`get-channel-search-terms` over `2026-05-01` to `2026-08-21` likewise went from 0 notices to 1, and correctly names only `views`, not `estimatedMinutesWatched`.

Tests 229 -> 233, including a case pinning that the rolling window goes quiet again once it clears the change date. Type-check and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added view-counting notices to traffic-source, search-term, channel search-term, and per-video reports when metric definitions may affect results.
  * Notices account for reporting date ranges, mixed metric definitions, and rolling-window changes.

* **Bug Fixes**
  * Human-readable `pretty` and `text` output now displays notices on stderr without disrupting report data.
  * JSON and CSV output remain unchanged, while MCP results continue exposing the notice as metadata.

* **Tests**
  * Added coverage for affected metrics, boundary dates, mixed definitions, and automatic notice removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->