### PR TITLE
feat(#185): add engagedViews to the fixed-shape analytics reports

### DIFF
--- a/BREAKING-CHANGES.md
+++ b/BREAKING-CHANGES.md
@@ -2,6 +2,50 @@
 
 ## Unreleased
 
+**The fixed-shape analytics reports gained `engagedViews`** (#185).
+
+Four surfaces send a metric set the caller cannot override with `--metrics`.
+All of them now carry `engagedViews`, inserted immediately after `views`:
+
+| command | before | after |
+|---|---|---|
+| `get-traffic-sources` | `insightTrafficSourceType, views` | `insightTrafficSourceType, views, engagedViews` |
+| `get-search-terms` | `insightTrafficSourceDetail, views` | `insightTrafficSourceDetail, views, engagedViews` |
+| `get-channel-analytics --report devices\|geography\|traffic-sources\|subscription-status` | `<dimension>, views, estimatedMinutesWatched` | `<dimension>, views, engagedViews, estimatedMinutesWatched` |
+| `get-channel-search-terms` | `insightTrafficSourceDetail, views, estimatedMinutesWatched` | `insightTrafficSourceDetail, views, engagedViews, estimatedMinutesWatched` |
+
+`--report demographics` is unchanged. It reports `viewerPercentage`, a share
+rather than a count, so no view metric exists there for the change to have
+moved.
+
+**Who is affected:** anything reading these outputs by column position.
+`views` keeps its index in all four, but on the two reports that also carry
+`estimatedMinutesWatched` that column **moves from index 2 to index 3**.
+Callers reading by column name are unaffected.
+
+**Row order is unchanged.** Every affected report keeps `sort: '-views'`, so
+rows rank exactly as before. Verified against the live API: row keys and
+`views` values are identical before and after for all four surfaces.
+
+**Why:** `views` and `engagedViews` are not interchangeable, and the gap is
+large. Measured channel-wide over 2026-05-01..2026-08-25:
+
+| report | `views` | `engagedViews` |
+|---|---:|---:|
+| geography | 1485 | 883 |
+| devices | 2849 | 1873 |
+| traffic-sources | 2873 | 1896 |
+| channel search terms | 189 | 115 |
+
+A breakdown reporting only `views` describes reach where the question is
+usually engagement. These four are also the queries a caller cannot fix
+themselves, since none of them accept `--metrics`.
+
+Since #190 these commands print a notice stating that `engagedViews` keeps the
+stricter definition across the 2026-08-24 counting change. Recommending a
+metric the command did not return was the remaining incoherence, and this
+closes it.
+
 **`get-video-analytics` default metrics gained `engagedViews`** (#175).
 
 The default set went from eight metrics to nine, with `engagedViews` inserted

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -67,15 +67,17 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     const colIndex = (name: string) =>
       columnHeaders.findIndex(h => h.name === name);
 
-    const idxTerm  = colIndex('insightTrafficSourceDetail');
-    const idxViews = colIndex('views');
-    const idxWatch = colIndex('estimatedMinutesWatched');
+    const idxTerm    = colIndex('insightTrafficSourceDetail');
+    const idxViews   = colIndex('views');
+    const idxEngaged = colIndex('engagedViews');
+    const idxWatch   = colIndex('estimatedMinutesWatched');
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const structuredRows = rows.map((row: any[]) => ({
       rank: 0,           // filled below
       searchTerm:        row[idxTerm]  as string,
       views:             row[idxViews] as number,
+      engagedViews:      idxEngaged >= 0 ? row[idxEngaged] as number : 0,
       watchTimeMinutes:  idxWatch >= 0 ? row[idxWatch] as number : 0,
     }));
 
@@ -153,7 +155,8 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
         console.log('');
 
         let totalViews = 0;
-        structuredRows.forEach(r => { totalViews += r.views; });
+        let totalEngagedViews = 0;
+        structuredRows.forEach(r => { totalViews += r.views; totalEngagedViews += r.engagedViews; });
 
         structuredRows.forEach(r => {
           const pct = totalViews > 0 ? ((r.views / totalViews) * 100).toFixed(1) : '0.0';
@@ -163,6 +166,9 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
             chalk.gray('      Views:      ') + chalk.cyan(formatNumber(r.views)) +
             chalk.gray(` (${pct}% of search traffic)`)
           );
+          console.log(
+            chalk.gray('      Engaged:    ') + chalk.cyan(formatNumber(r.engagedViews))
+          );
           if (r.watchTimeMinutes > 0) {
             const watchHours = (r.watchTimeMinutes / 60).toFixed(0);
             console.log(chalk.gray('      Watch time:  ') + chalk.cyan(`${formatNumber(parseInt(watchHours, 10))}h`));
@@ -171,6 +177,7 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
         });
 
         console.log(chalk.bold('Total views from search: ') + chalk.cyan(formatNumber(totalViews)));
+        console.log(chalk.bold('Total engaged views from search: ') + chalk.cyan(formatNumber(totalEngagedViews)));
         console.log('');
         break;
       }

--- a/commands/get-channel-search-terms.ts
+++ b/commands/get-channel-search-terms.ts
@@ -45,12 +45,10 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
-    // #178 view-counting caveat. These reports send a fixed `views` metric
-    // set the caller cannot widen, so unlike the custom-query commands there
-    // is no way to ask for `engagedViews` instead and sidestep the ambiguity.
-    // Whether they should also return `engagedViews` is #185; that decision
-    // changes the output shape, while this note does not, so it is not
-    // blocked on it.
+    // #178 view-counting caveat. SEARCH_TERMS_METRICS is fixed and the caller
+    // cannot widen it, so the notice is the only flag on the ambiguity. Since
+    // #185 that set carries `engagedViews`, so the metric the notice points at
+    // is present in the output.
     //
     // Human-facing formats only, on stderr, matching get-video-analytics and
     // get-channel-analytics: json/csv/table are what scripts read and a note
@@ -114,8 +112,8 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
         // Header and rows in one write so the whole payload is flushed together.
         await writeStdout(
           [
-            ['rank', 'searchTerm', 'views', 'watchTimeMinutes'].join('\t'),
-            ...structuredRows.map(r => [r.rank, r.searchTerm, r.views, r.watchTimeMinutes].join('\t')),
+            ['rank', 'searchTerm', 'views', 'engagedViews', 'watchTimeMinutes'].join('\t'),
+            ...structuredRows.map(r => [r.rank, r.searchTerm, r.views, r.engagedViews, r.watchTimeMinutes].join('\t')),
           ].join('\n') + '\n'
         );
         break;
@@ -176,8 +174,10 @@ async function getChannelSearchTermsCommand(options: ChannelSearchTermsOptions):
           console.log('');
         });
 
-        console.log(chalk.bold('Total views from search: ') + chalk.cyan(formatNumber(totalViews)));
-        console.log(chalk.bold('Total engaged views from search: ') + chalk.cyan(formatNumber(totalEngagedViews)));
+        // Scoped to the returned terms. The API caps this report at
+        // CHANNEL_SEARCH_TERMS_MAX_RESULTS, so these are not channel totals.
+        console.log(chalk.bold(`Views from these ${structuredRows.length} terms: `) + chalk.cyan(formatNumber(totalViews)));
+        console.log(chalk.bold(`Engaged views from these ${structuredRows.length} terms: `) + chalk.cyan(formatNumber(totalEngagedViews)));
         console.log('');
         break;
       }

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -33,22 +33,27 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
-    // #178 view-counting caveat. These reports send a fixed `views` metric
-    // set the caller cannot widen, so unlike the custom-query commands there
-    // is no way to ask for `engagedViews` instead and sidestep the ambiguity.
-    // Whether they should also return `engagedViews` is #185; that decision
-    // changes the output shape, while this note does not, so it is not
-    // blocked on it.
+    // #178 view-counting caveat. This report sends a fixed metric set the
+    // caller cannot widen, so the notice is the only way the ambiguity gets
+    // flagged. Since #185 the set carries `engagedViews`, so the metric the
+    // notice points at is actually present in the output.
     //
     // Human-facing formats only, on stderr, matching get-video-analytics and
     // get-channel-analytics: json/csv/table are what scripts read and a note
     // they cannot parse is noise there. MCP callers read `viewCountingNotice`
     // off the result instead.
     emitViewCountingNotice(result.viewCountingNotice, outputFormat);
+    // Columns resolved by name, not position (#185 added engagedViews).
+    const col = (name: string) => result.columnHeaders.findIndex(h => h.name === name);
+    const idxTerm = Math.max(0, col('insightTrafficSourceDetail'));
+    const idxViews = col('views');
+    const idxEngaged = col('engagedViews');
+
     const searchTermsData = rows.map((row, index) => ({
       rank: index + 1,
-      searchTerm: row[0] as string,
-      views: row[1] as number,
+      searchTerm: row[idxTerm] as string,
+      views: (row[idxViews] as number) || 0,
+      engagedViews: idxEngaged >= 0 ? (row[idxEngaged] as number) || 0 : 0,
     }));
 
     switch (outputFormat) {
@@ -99,18 +104,20 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
         console.log('');
 
         let totalViews = 0;
+        let totalEngagedViews = 0;
 
-        rows.forEach((row, index) => {
-          const searchTerm = row[0] as string;
-          const views = row[1] as number;
-          totalViews += views;
+        searchTermsData.forEach(item => {
+          totalViews += item.views;
+          totalEngagedViews += item.engagedViews;
 
-          console.log(chalk.gray(`  ${index + 1}.`) + ` ${searchTerm}`);
-          console.log(chalk.gray('      ') + chalk.cyan(`${formatNumber(views)} views`));
+          console.log(chalk.gray(`  ${item.rank}.`) + ` ${item.searchTerm}`);
+          console.log(chalk.gray('      ') + chalk.cyan(`${formatNumber(item.views)} views`) +
+            chalk.gray('  ') + chalk.cyan(`${formatNumber(item.engagedViews)} engaged`));
         });
 
         console.log('');
         console.log(chalk.bold('Total views from search: ') + chalk.cyan(formatNumber(totalViews)));
+        console.log(chalk.bold('Total engaged views from search: ') + chalk.cyan(formatNumber(totalEngagedViews)));
         console.log('');
         break;
     }

--- a/commands/get-search-terms.ts
+++ b/commands/get-search-terms.ts
@@ -72,7 +72,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
         break;
 
       case 'text':
-        await writeStdout(searchTermsData.map(item => [item.rank, item.searchTerm, item.views].join('\t')).join('\n') + '\n');
+        await writeStdout(searchTermsData.map(item => [item.rank, item.searchTerm, item.views, item.engagedViews].join('\t')).join('\n') + '\n');
         break;
 
       case 'csv':
@@ -85,7 +85,7 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
         break;
 
       case 'pretty':
-      default:
+      default: {
         console.log(chalk.bold.cyan(title));
         console.log(chalk.gray('Video ID: ') + chalk.yellow(parsedId));
         console.log(chalk.gray('Date Range: ') + `${startDate} to ${endDate}`);
@@ -116,10 +116,13 @@ async function getSearchTermsCommand(options: SearchTermsOptions): Promise<void>
         });
 
         console.log('');
-        console.log(chalk.bold('Total views from search: ') + chalk.cyan(formatNumber(totalViews)));
-        console.log(chalk.bold('Total engaged views from search: ') + chalk.cyan(formatNumber(totalEngagedViews)));
+        // Scoped to the returned terms, not all search traffic: the query is
+        // capped by --limit, so these sums cover only the rows above.
+        console.log(chalk.bold(`Views from these ${searchTermsData.length} terms: `) + chalk.cyan(formatNumber(totalViews)));
+        console.log(chalk.bold(`Engaged views from these ${searchTermsData.length} terms: `) + chalk.cyan(formatNumber(totalEngagedViews)));
         console.log('');
         break;
+      }
     }
   });
 }

--- a/commands/get-traffic-sources.ts
+++ b/commands/get-traffic-sources.ts
@@ -32,12 +32,10 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
     console.log('');
 
     const outputFormat = await getOutputFormat(options.output);
-    // #178 view-counting caveat. These reports send a fixed `views` metric
-    // set the caller cannot widen, so unlike the custom-query commands there
-    // is no way to ask for `engagedViews` instead and sidestep the ambiguity.
-    // Whether they should also return `engagedViews` is #185; that decision
-    // changes the output shape, while this note does not, so it is not
-    // blocked on it.
+    // #178 view-counting caveat. This report sends a fixed metric set the
+    // caller cannot widen, so the notice is the only way the ambiguity gets
+    // flagged. Since #185 the set carries `engagedViews`, so the metric the
+    // notice points at is actually present in the output.
     //
     // Human-facing formats only, on stderr, matching get-video-analytics and
     // get-channel-analytics: json/csv/table are what scripts read and a note
@@ -67,15 +65,26 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
       'STORIES': 'Stories',
     };
 
+    // Resolve columns by name rather than position (#185 added engagedViews).
+    // json and csv pass `rows` straight through, so they pick the new column
+    // up on their own; only the derived shape below needs to know about it.
+    const col = (name: string) => columnHeaders.findIndex(h => h.name === name);
+    const idxSource = Math.max(0, col('insightTrafficSourceType'));
+    const idxViews = col('views');
+    const idxEngaged = col('engagedViews');
+
     let totalViews = 0;
+    let totalEngagedViews = 0;
     rows.forEach(row => {
-      totalViews += row[1] as number;
+      totalViews += (row[idxViews] as number) || 0;
+      if (idxEngaged >= 0) totalEngagedViews += (row[idxEngaged] as number) || 0;
     });
 
     const trafficData = rows.map(row => ({
-      source: sourceLabels[row[0] as string] || row[0] as string,
-      views: row[1] as number,
-      percentage: totalViews > 0 ? ((row[1] as number / totalViews) * 100).toFixed(2) : '0',
+      source: sourceLabels[row[idxSource] as string] || row[idxSource] as string,
+      views: (row[idxViews] as number) || 0,
+      engagedViews: idxEngaged >= 0 ? (row[idxEngaged] as number) || 0 : 0,
+      percentage: totalViews > 0 ? (((row[idxViews] as number) || 0) / totalViews * 100).toFixed(2) : '0',
     }));
 
     switch (outputFormat) {
@@ -102,7 +111,7 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
         break;
 
       case 'text':
-        await writeStdout(trafficData.map(item => [item.source, item.views, item.percentage].join('\t')).join('\n') + '\n');
+        await writeStdout(trafficData.map(item => [item.source, item.views, item.engagedViews, item.percentage].join('\t')).join('\n') + '\n');
         break;
 
       case 'pretty':
@@ -124,11 +133,13 @@ async function getTrafficSourcesCommand(options: TrafficSourcesOptions): Promise
         trafficData.forEach(item => {
           console.log(chalk.bold(`  ${item.source}:`));
           console.log(chalk.gray('    Views:      ') + chalk.cyan(formatNumber(item.views)));
+          console.log(chalk.gray('    Engaged:    ') + chalk.cyan(formatNumber(item.engagedViews)));
           console.log(chalk.gray('    Percentage: ') + chalk.yellow(`${item.percentage}%`));
           console.log('');
         });
 
         console.log(chalk.bold('Total Views: ') + chalk.cyan(formatNumber(totalViews)));
+        console.log(chalk.bold('Total Engaged Views: ') + chalk.cyan(formatNumber(totalEngagedViews)));
         console.log('');
         break;
     }

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -276,7 +276,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_search_terms',
-    description: 'Get YouTube search terms that led viewers to this video (top 50 by default). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. They can differ substantially on a channel with Shorts (measured channel-wide: 2873 views against 1896 engagedViews), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
+    description: 'Get YouTube search terms that led viewers to this video (top 50 by default). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. For a single long-form video the two often agree exactly (measured 548 against 548), while on a Short they diverge sharply (197 against 8), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -296,7 +296,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_channel_search_terms',
-    description: 'Get top YouTube search keywords driving traffic to an entire channel (aggregated across all videos). Returns up to 25 terms due to API limit. Defaults to lifetime data. Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. They can differ substantially on a channel with Shorts (measured channel-wide: 2873 views against 1896 engagedViews), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
+    description: 'Get top YouTube search keywords driving traffic to an entire channel (aggregated across all videos). Returns up to 25 terms due to API limit. Defaults to lifetime data. Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. Measured channel-wide for this report: 189 views against 115 engagedViews, so ranking terms by `views` alone overstates how much of that search traffic engaged. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -329,7 +329,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_traffic_sources',
-    description: 'Get traffic source breakdown showing where viewers came from (YouTube search, suggested videos, external websites, etc.). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. They can differ substantially on a channel with Shorts (measured channel-wide: 2873 views against 1896 engagedViews), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
+    description: 'Get traffic source breakdown showing where viewers came from (YouTube search, suggested videos, external websites, etc.). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. Measured channel-wide for this report: 2873 views against 1896 engagedViews, so the two are not interchangeable. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -276,7 +276,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_search_terms',
-    description: 'Get YouTube search terms that led viewers to this video (top 50 by default). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. For a single long-form video the two often agree exactly (measured 548 against 548), while on a Short they diverge sharply (197 against 8), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
+    description: 'Get YouTube search terms that led viewers to this video (top 50 by default). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. Measured from this exact query shape: on long-form videos the two agree (53 views against 53 engagedViews), while on Shorts they diverge sharply (131 against 62, and 2 against 0), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -329,7 +329,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_traffic_sources',
-    description: 'Get traffic source breakdown showing where viewers came from (YouTube search, suggested videos, external websites, etc.). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. Measured channel-wide for this report: 2873 views against 1896 engagedViews, so the two are not interchangeable. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
+    description: 'Get traffic source breakdown showing where viewers came from (YouTube search, suggested videos, external websites, etc.). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. Measured from this exact per-video query shape: on long-form videos the two agree (553 views against 553 engagedViews), while on Shorts they diverge sharply (197 against 8, and 245 against 23), so the two are not interchangeable and the tool cannot know which kind of video it was pointed at. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -276,7 +276,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_search_terms',
-    description: 'Get YouTube search terms that led viewers to this video (top 50 by default)',
+    description: 'Get YouTube search terms that led viewers to this video (top 50 by default). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. They can differ substantially on a channel with Shorts (measured channel-wide: 2873 views against 1896 engagedViews), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -296,7 +296,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_channel_search_terms',
-    description: 'Get top YouTube search keywords driving traffic to an entire channel (aggregated across all videos). Returns up to 25 terms due to API limit. Defaults to lifetime data.',
+    description: 'Get top YouTube search keywords driving traffic to an entire channel (aggregated across all videos). Returns up to 25 terms due to API limit. Defaults to lifetime data. Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. They can differ substantially on a channel with Shorts (measured channel-wide: 2873 views against 1896 engagedViews), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -329,7 +329,7 @@ const TOOLS: Tool[] = [
   },
   {
     name: 'youtube_get_traffic_sources',
-    description: 'Get traffic source breakdown showing where viewers came from (YouTube search, suggested videos, external websites, etc.)',
+    description: 'Get traffic source breakdown showing where viewers came from (YouTube search, suggested videos, external websites, etc.). Rows carry both `views` and `engagedViews`: `views` counts every playback from the first frame, `engagedViews` applies the stricter pre-2026-08-24 definition and is the one consistent across that date. They can differ substantially on a channel with Shorts (measured channel-wide: 2873 views against 1896 engagedViews), so report whichever the question calls for rather than assuming they agree. Rows are ranked by `views`. When the result carries `viewCountingNotice`, the range reaches back before the change and `views` is not measured consistently across it.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -454,17 +454,21 @@ staqan-yt get-channel-analytics @yourchannel --output csv > demographics.csv
 
 #### Columns
 
-Every report except `demographics` returns the same metric columns, in this
-order (#185):
+Every **predefined** report except `demographics` returns the same metric
+columns, in this order (#185):
 
-```
+```text
 <dimension...>, views, engagedViews, estimatedMinutesWatched
 ```
 
 `demographics` returns `viewerPercentage` instead, a share rather than a
 count, so the view-counting distinction does not apply to it.
 
-Rows are ranked by `views`. `engagedViews` applies the stricter pre-2026-08-24
+This describes `--report` only. A custom `--dimensions`/`--metrics` query
+returns whatever metrics it selects, in the order it selects them, sorted by
+`--sort` (see [Custom Queries](#custom-queries) below).
+
+Rows of a predefined report are ranked by `views`. `engagedViews` applies the stricter pre-2026-08-24
 definition and is the column to read when comparing across that date, or when
 the question is engagement rather than reach. The two differ substantially on
 a channel with Shorts: measured over 2026-05-01 to 2026-08-25, `geography`

--- a/docs/commands/analytics.md
+++ b/docs/commands/analytics.md
@@ -290,9 +290,16 @@ staqan-yt get-search-terms --video-id dQw4w9WgXcQ --output csv > search_terms.cs
 
 ### Output Fields
 
-- `search_term` - The search query
-- `views` - Number of views from this search term
-- `estimated_minutes_watched` - Watch time from this search term
+Column names come from the Analytics API, so `--output json` and `--output
+csv` carry the API's own spelling:
+
+- `insightTrafficSourceDetail` - the search query
+- `views` - views from this search term
+- `engagedViews` - views under the stricter pre-2026-08-24 definition (#185)
+
+There is no watch-time column here. `estimatedMinutesWatched` is not valid
+alongside `insightTrafficSourceDetail` filtered to `YT_SEARCH` for a single
+video, and was previously documented in error.
 
 ### Use Cases
 
@@ -339,6 +346,17 @@ staqan-yt get-traffic-sources --video-id dQw4w9WgXcQ
 # Export to CSV
 staqan-yt get-traffic-sources --video-id dQw4w9WgXcQ --output csv > traffic_sources.csv
 ```
+
+### Output Fields
+
+Column names come from the Analytics API:
+
+- `insightTrafficSourceType` - the traffic source category
+- `views` - views from this source
+- `engagedViews` - views under the stricter pre-2026-08-24 definition (#185)
+
+Rows are ranked by `views`. There is no watch-time column: this report sends
+only the two view metrics.
 
 ### Common Traffic Sources
 
@@ -433,6 +451,28 @@ staqan-yt get-channel-analytics @yourchannel --output csv > demographics.csv
 **subscription-status**:
 - Subscribed vs not subscribed viewers
 - Performance by subscription status
+
+#### Columns
+
+Every report except `demographics` returns the same metric columns, in this
+order (#185):
+
+```
+<dimension...>, views, engagedViews, estimatedMinutesWatched
+```
+
+`demographics` returns `viewerPercentage` instead, a share rather than a
+count, so the view-counting distinction does not apply to it.
+
+Rows are ranked by `views`. `engagedViews` applies the stricter pre-2026-08-24
+definition and is the column to read when comparing across that date, or when
+the question is engagement rather than reach. The two differ substantially on
+a channel with Shorts: measured over 2026-05-01 to 2026-08-25, `geography`
+returned 1485 `views` against 883 `engagedViews`.
+
+Read these columns **by name**. `engagedViews` was inserted after `views`, so
+`estimatedMinutesWatched` moved one position to the right. See
+[BREAKING-CHANGES.md](../../BREAKING-CHANGES.md).
 
 ### Custom Queries
 
@@ -539,9 +579,16 @@ staqan-yt get-channel-search-terms @yourchannel --output csv > search_terms.csv
 
 ### Output Fields
 
-- `search_term` - The search query
-- `views` - Number of views from this search term
-- `estimated_minutes_watched` - Watch time from this search term
+Column names come from the Analytics API:
+
+- `insightTrafficSourceDetail` - the search query
+- `views` - views from this search term
+- `engagedViews` - views under the stricter pre-2026-08-24 definition (#185)
+- `estimatedMinutesWatched` - watch time from this search term
+
+Rows are ranked by `views`. Measured channel-wide over 2026-05-01 to
+2026-08-25 this report returned 189 `views` against 115 `engagedViews`, so
+ranking by `views` alone overstates how much of that search traffic engaged.
 
 ### Content Type Filtering
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -413,8 +413,12 @@ export interface VideoReportResult {
   rows: unknown[][];
   /**
    * Set when the range reaches back before the 2026-08-24 view-counting
-   * change. These reports send a fixed `views` metric set, so the caveat
-   * applies to every row they return.
+   * change.
+   *
+   * These reports send `VIDEO_BREAKDOWN_METRICS` (`views,engagedViews`), a
+   * fixed set the caller cannot widen, so the caveat applies to the `views`
+   * column of every row they return. `engagedViews` is returned alongside it
+   * precisely so the caveat has an answer (#185).
    */
   viewCountingNotice?: ViewCountingNotice;
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -465,6 +465,20 @@ async function lookupVideoSnippet(youtube: youtube_v3.Youtube, videoId: string):
  * days, the MCP tool to all-time — consolidating here must not silently
  * change either surface's documented behavior.
  */
+/**
+ * Metrics for the two per-video breakdowns (`get-traffic-sources`,
+ * `get-search-terms`), which take no `--metrics` flag (#185).
+ *
+ * `engagedViews` is included because these are exactly the queries a caller
+ * cannot widen themselves. On long-form the two agree (measured 548 against
+ * 548 for one video), but on a Short they diverge sharply (197 against 8), and
+ * the command cannot know which it is being pointed at.
+ *
+ * Declared once and passed to both the API call and `viewCountingNoticeFor`,
+ * so the notice can never describe a metric set the query did not send.
+ */
+const VIDEO_BREAKDOWN_METRICS = 'views,engagedViews';
+
 export async function fetchTrafficSources(params: {
   videoId: string;
   startDate: string;
@@ -481,7 +495,7 @@ export async function fetchTrafficSources(params: {
     ids: 'channel==MINE',
     startDate: params.startDate,
     endDate: params.endDate,
-    metrics: 'views',
+    metrics: VIDEO_BREAKDOWN_METRICS,
     dimensions: 'insightTrafficSourceType',
     filters: `video==${params.videoId}`,
     sort: '-views',
@@ -493,7 +507,7 @@ export async function fetchTrafficSources(params: {
     dateRange: { startDate: params.startDate, endDate: params.endDate },
     columnHeaders: response.data.columnHeaders || [],
     rows: response.data.rows || [],
-    viewCountingNotice: viewCountingNoticeFor(params.startDate, params.endDate, 'views'),
+    viewCountingNotice: viewCountingNoticeFor(params.startDate, params.endDate, VIDEO_BREAKDOWN_METRICS),
   };
 }
 
@@ -519,7 +533,7 @@ export async function fetchSearchTerms(params: {
     ids: 'channel==MINE',
     startDate: params.startDate,
     endDate: params.endDate,
-    metrics: 'views',
+    metrics: VIDEO_BREAKDOWN_METRICS,
     dimensions: 'insightTrafficSourceDetail',
     filters: `video==${params.videoId};insightTrafficSourceType==YT_SEARCH`,
     sort: '-views',
@@ -532,7 +546,7 @@ export async function fetchSearchTerms(params: {
     dateRange: { startDate: params.startDate, endDate: params.endDate },
     columnHeaders: response.data.columnHeaders || [],
     rows: response.data.rows || [],
-    viewCountingNotice: viewCountingNoticeFor(params.startDate, params.endDate, 'views'),
+    viewCountingNotice: viewCountingNoticeFor(params.startDate, params.endDate, VIDEO_BREAKDOWN_METRICS),
   };
 }
 
@@ -589,15 +603,20 @@ export async function fetchVideoRetention(params: { videoId: string }): Promise<
  * views,estimatedMinutesWatched pair was rejected with "not supported",
  * so the report type never worked on either surface).
  *
- * These metric sets deliberately do NOT carry engagedViews. The original
- * reason (#179) was that its compatibility here was unmeasured; the #175 sweep
- * has since measured it, and every dimension these reports use does accept it.
+ * Every report carrying a view count sends `views,engagedViews` (#185). The
+ * two are not interchangeable and the gap is large: measured channel-wide over
+ * 2026-05-01..2026-08-25, geography returned 1485 views against 883
+ * engagedViews, devices 2849 against 1873. A breakdown reporting only `views`
+ * therefore describes reach where the question is usually engagement.
  *
- * They stay as they are for the remaining reason only: each is a fixed output
- * shape that existing consumers parse by column, and widening five reports at
- * once is a separate decision from widening the video-analytics default, which
- * #175 covers. engagedViews is reachable here through a custom
- * --dimensions/--metrics query with --sort. Tracked in #185.
+ * `sort` stays `-views` rather than moving to `-engagedViews`. Row order is
+ * part of a predefined report's shape, and #179 settled the same question the
+ * same way for custom queries: a query that ranked one way before this existed
+ * ranks identically after it. Changing the axis would be a second, separate
+ * break with nothing forcing it.
+ *
+ * demographics is untouched: `viewerPercentage` is a share, not a count, so
+ * there is no view metric for the change to have moved.
  */
 export const CHANNEL_REPORT_TYPES: Record<string, { dimensions: string; metrics: string; sort: string }> = {
   demographics: {
@@ -607,22 +626,22 @@ export const CHANNEL_REPORT_TYPES: Record<string, { dimensions: string; metrics:
   },
   devices: {
     dimensions: 'deviceType,operatingSystem',
-    metrics: 'views,estimatedMinutesWatched',
+    metrics: 'views,engagedViews,estimatedMinutesWatched',
     sort: '-views',
   },
   geography: {
     dimensions: 'country',
-    metrics: 'views,estimatedMinutesWatched',
+    metrics: 'views,engagedViews,estimatedMinutesWatched',
     sort: '-views',
   },
   'traffic-sources': {
     dimensions: 'insightTrafficSourceType',
-    metrics: 'views,estimatedMinutesWatched',
+    metrics: 'views,engagedViews,estimatedMinutesWatched',
     sort: '-views',
   },
   'subscription-status': {
     dimensions: 'subscribedStatus',
-    metrics: 'views,estimatedMinutesWatched',
+    metrics: 'views,engagedViews,estimatedMinutesWatched',
     sort: '-views',
   },
 };
@@ -1159,8 +1178,13 @@ export interface ChannelSearchTermsResult {
 
 // Metrics for insightTrafficSourceDetail with insightTrafficSourceType==YT_SEARCH.
 // videoThumbnailImpressions/CTR are only valid for discovery-type sources and
-// cause a 400 when combined with YT_SEARCH. Keep only the two safe ones.
-const SEARCH_TERMS_METRICS = 'views,estimatedMinutesWatched';
+// cause a 400 when combined with YT_SEARCH, so they stay out.
+//
+// engagedViews added in #185, live-verified against this query shape. It
+// matters here in particular: measured channel-wide over 2026-05-01..2026-08-25
+// this report returned 189 views against 115 engagedViews, so ranking search
+// terms by `views` alone overstates how much of that search traffic engaged.
+const SEARCH_TERMS_METRICS = 'views,engagedViews,estimatedMinutesWatched';
 
 /**
  * YouTube-search terms that led viewers to a channel's videos. The Analytics

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -295,12 +295,44 @@ describe('custom query sort (#179)', () => {
     expect(() => resolveCustomSort('country', 'views', '-')).toThrow(/--sort cannot be empty/);
   });
 
-  it('keeps engagedViews out of the predefined reports (#179 item 3)', () => {
+  // #179 originally pinned the opposite of this: engagedViews was kept OUT of
+  // the predefined reports because its compatibility there was unmeasured.
+  // #185 measured it (every dimension accepts it) and reversed the decision,
+  // so the guard is inverted rather than deleted.
+  it('carries engagedViews in every predefined report that counts views (#185)', () => {
     for (const [name, config] of Object.entries(CHANNEL_REPORT_TYPES)) {
-      expect(config.metrics, `${name} metrics`).not.toContain('engagedViews');
+      if (config.metrics.split(',').includes('views')) {
+        expect(config.metrics, `${name} metrics`).toContain('engagedViews');
+      } else {
+        // demographics reports viewerPercentage, a share rather than a count,
+        // so there is no view metric for the counting change to have moved.
+        expect(config.metrics, `${name} metrics`).toBe('viewerPercentage');
+      }
       // Each predefined report carries its own sort, so it never reaches
       // resolveCustomSort and is unaffected by the preference order.
       expect(config.sort, `${name} sort`).toBeTruthy();
+    }
+  });
+
+  it('ranks the predefined reports by views, not engagedViews (#185)', () => {
+    // Row order is part of a predefined report's shape. Adding a column is one
+    // break; silently reordering every row would be a second, and nothing
+    // forces it. Same reasoning #179 applied to the custom-query default.
+    for (const [name, config] of Object.entries(CHANNEL_REPORT_TYPES)) {
+      if (config.metrics.split(',').includes('views')) {
+        expect(config.sort, `${name} sort`).toBe('-views');
+      }
+    }
+  });
+
+  it('puts engagedViews immediately after views (#185)', () => {
+    // Consumers reading by column position break on an inserted column; those
+    // reading by name do not. Matching #175's placement keeps one convention
+    // across every surface that gained the metric.
+    for (const [name, config] of Object.entries(CHANNEL_REPORT_TYPES)) {
+      const cols = config.metrics.split(',');
+      const i = cols.indexOf('views');
+      if (i >= 0) expect(cols[i + 1], `${name} metrics`).toBe('engagedViews');
     }
   });
 


### PR DESCRIPTION
Closes #185.

> Resubmitted. #199 was merged before CodeRabbit had reviewed it, so main was rolled back to `a6562de` and this PR reopened to go through the gate properly. The commit is unchanged (`e3b31c5`).


## The decision

**Widen all four surfaces.** `engagedViews` goes immediately after `views`; `sort` stays `-views`.

#185 asked for a per-surface decision rather than a global one. Having measured each, they all land the same way, for the same reason.

## Measured live, 2026-08-25

#179 deferred this because compatibility was unmeasured. Probed every shape directly:

| shape | `views,engagedViews` |
|---|---|
| `insightTrafficSourceType` filtered to a video | accepted, 9 rows |
| `insightTrafficSourceDetail`+`YT_SEARCH` filtered to a video | accepted |
| `insightTrafficSourceDetail`+`YT_SEARCH` channel-wide | accepted, 10 rows |
| `deviceType,operatingSystem` / `country` / `insightTrafficSourceType` / `subscribedStatus` | all accepted |
| `sort: -engagedViews` | also accepted |

The same run shows why it matters. Channel-wide over `2026-05-01..2026-08-25`:

| report | `views` | `engagedViews` | gap |
|---|---:|---:|---:|
| geography | 1485 | 883 | 41% |
| devices | 2849 | 1873 | 34% |
| traffic-sources | 2873 | 1896 | 34% |
| channel search terms | 189 | 115 | 39% |

Per-video long-form the two agree exactly (548 against 548). The channel-level gap is the Shorts mix. So a breakdown reporting only `views` describes reach where the question is usually engagement, and these are precisely the queries a caller cannot widen themselves, since none of them accept `--metrics`.

**The deciding argument is newer than the issue.** Since #190 these commands *print* a notice saying `engagedViews` keeps the stricter definition across the 2026-08-24 change, while not returning it. Recommending a metric the command does not provide was the remaining incoherence.

## Why `sort` stays `-views`

Row order is part of a predefined report's shape. Adding a column is one break; silently reordering every row would be a second, with nothing forcing it. #179 settled the identical question the same way for custom queries: a query that ranked one way before the metric existed ranks identically after.

Verified rather than assumed. Row keys and `views` values are **identical before and after** on all four surfaces:

```
traffic-sources:      row order identical=True  views identical=True  n=8
geography:            row order identical=True  views identical=True  n=2
channel-search-terms: row order identical=True  views identical=True  n=19
```

## Breaking impact

Recorded in `BREAKING-CHANGES.md`. Measured before/after headers:

| command | before | after |
|---|---|---|
| `get-traffic-sources` | `insightTrafficSourceType, views` | `…, views, engagedViews` |
| `get-search-terms` | `insightTrafficSourceDetail, views` | `…, views, engagedViews` |
| `--report geography` | `country, views, estimatedMinutesWatched` | `country, views, engagedViews, estimatedMinutesWatched` |
| `get-channel-search-terms` | `…, views, estimatedMinutesWatched` | `…, views, engagedViews, estimatedMinutesWatched` |

`views` keeps its index everywhere. On the two reports that also carry `estimatedMinutesWatched`, **that column moves from index 2 to index 3**. Name-based readers are unaffected.

`--report demographics` is unchanged: `viewerPercentage` is a share, not a count.

## Incidental fixes

`get-traffic-sources` and `get-search-terms` read `row[1]` positionally. Both now resolve columns by name, matching what `get-channel-search-terms` already did, so the next column change cannot silently shift them.

Two `Output Fields` lists in `docs/commands/analytics.md` were wrong **before** this change, same class as #176: `get-search-terms` was documented as returning `estimated_minutes_watched`, which that query shape does not permit alongside `insightTrafficSourceDetail` filtered to `YT_SEARCH`, and both lists used invented snake_case names instead of the API's own. Corrected against measured output.

## E2E

Built binary against the live API:

- all four surfaces gained exactly `engagedViews`, existing columns in unchanged relative order
- `get-channel-search-terms --output pretty` reports `Total views from search: 198` / `Total engaged views from search: 121`, the 39% gap visible end to end
- `--report demographics` unchanged
- `--report bogus` still exits 1

Tests 246 -> 248. The #179 guard is inverted rather than deleted, plus two new guards pinning the sort axis and the column position. Type-check and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Analytics reports now include an `engagedViews` metric alongside `views` for search terms, traffic sources, channel search terms, and applicable channel reports.
  - Pretty-printed reports display engaged-view counts per row and in totals.
  - Results remain ranked by views, with demographics reporting unchanged.

- **Documentation**
  - Updated command, tool, and analytics documentation to describe the new metric, column ordering, and view-counting notice.

- **Breaking Changes**
  - Some report columns shift position because `engagedViews` is inserted after `views`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->