### PR TITLE
fix(#195): tell a damaged optional-JSON file apart from an absent one

### DIFF
--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -12,7 +12,7 @@ import { getChannelVideos, listChannelPlaylists, getChannelId } from '../lib/you
 import { getConfigValue } from '../lib/config';
 import { getAuthenticatedClient } from '../lib/auth';
 import { acquireLock, getLockPath } from '../lib/lock';
-import { CACHE_DIR, debug } from '../lib/utils';
+import { CACHE_DIR, debug, loadJsonIfPresent } from '../lib/utils';
 import { CompletionType, CompletionCache } from '../types';
 
 const TTL: Record<CompletionType, number> = {
@@ -29,9 +29,15 @@ function getChannelCachePath(channelId: string): string {
 }
 
 async function loadCache(cachePath: string): Promise<CompletionCache> {
+  // Completion runs inside the user's interactive shell on every Tab, so this
+  // is the one site that must stay quiet on stdout and stderr no matter what:
+  // a warning here would print into the middle of the prompt. The error still
+  // goes to debug(), so `-v` can explain a cache that never seems to hit
+  // (#195).
   try {
-    return JSON.parse(await fs.readFile(cachePath, 'utf-8'));
-  } catch {
+    return (await loadJsonIfPresent<CompletionCache>(cachePath, 'completion cache')) || {};
+  } catch (err) {
+    debug(`Ignoring unreadable completion cache: ${(err as Error).message}`);
     return {};
   }
 }

--- a/commands/complete.ts
+++ b/commands/complete.ts
@@ -29,11 +29,10 @@ function getChannelCachePath(channelId: string): string {
 }
 
 async function loadCache(cachePath: string): Promise<CompletionCache> {
-  // Completion runs inside the user's interactive shell on every Tab, so this
-  // is the one site that must stay quiet on stdout and stderr no matter what:
-  // a warning here would print into the middle of the prompt. The error still
-  // goes to debug(), so `-v` can explain a cache that never seems to hit
-  // (#195).
+  // Runs in the interactive shell on every Tab, so this must stay quiet on
+  // stdout and stderr: a warning would print into the middle of the prompt.
+  // The error goes to debug(), so `-v` can still explain a cache that never
+  // seems to hit.
   try {
     return (await loadJsonIfPresent<CompletionCache>(cachePath, 'completion cache')) || {};
   } catch (err) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -22,22 +22,20 @@ const SCOPES = [
 ];
 
 /**
- * Load OAuth2 credentials from file
+ * Load OAuth2 credentials from file.
+ * Null if absent, so the caller prints setup guidance. Throws if damaged,
+ * since re-running auth does not repair a malformed credentials.json.
  */
 async function loadCredentials(): Promise<OAuth2Credentials | null> {
-  // Absent means "not set up yet" and the caller prints setup guidance.
-  // Damaged throws, because that guidance is wrong for a file that exists:
-  // re-running auth does not repair a malformed credentials.json (#195).
   return loadJsonIfPresent<OAuth2Credentials>(CREDENTIALS_PATH, 'OAuth credentials');
 }
 
 /**
- * Load saved token from file
+ * Load saved token from file.
+ * Null if absent, which triggers the sign-in prompt. Throws if damaged, so a
+ * corrupt token is not answered with a silent full re-auth.
  */
 async function loadToken(): Promise<OAuth2Token | null> {
-  // Same split as loadCredentials: absent triggers the sign-in prompt, damaged
-  // is reported so a corrupt token is not silently mistaken for a missing one
-  // and answered with a full re-auth (#195).
   return loadJsonIfPresent<OAuth2Token>(TOKEN_PATH, 'auth token');
 }
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -10,6 +10,7 @@ import {
   TOKEN_PATH,
   ensureConfigDir,
   info,
+  loadJsonIfPresent,
 } from './utils';
 import { OAuth2Credentials, OAuth2Token } from '../types';
 
@@ -24,24 +25,20 @@ const SCOPES = [
  * Load OAuth2 credentials from file
  */
 async function loadCredentials(): Promise<OAuth2Credentials | null> {
-  try {
-    const content = await fs.readFile(CREDENTIALS_PATH, 'utf-8');
-    return JSON.parse(content) as OAuth2Credentials;
-  } catch {
-    return null;
-  }
+  // Absent means "not set up yet" and the caller prints setup guidance.
+  // Damaged throws, because that guidance is wrong for a file that exists:
+  // re-running auth does not repair a malformed credentials.json (#195).
+  return loadJsonIfPresent<OAuth2Credentials>(CREDENTIALS_PATH, 'OAuth credentials');
 }
 
 /**
  * Load saved token from file
  */
 async function loadToken(): Promise<OAuth2Token | null> {
-  try {
-    const content = await fs.readFile(TOKEN_PATH, 'utf-8');
-    return JSON.parse(content) as OAuth2Token;
-  } catch {
-    return null;
-  }
+  // Same split as loadCredentials: absent triggers the sign-in prompt, damaged
+  // is reported so a corrupt token is not silently mistaken for a missing one
+  // and answered with a full re-auth (#195).
+  return loadJsonIfPresent<OAuth2Token>(TOKEN_PATH, 'auth token');
 }
 
 /**

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { CONFIG_DIR, debug, warning } from './utils';
+import { CONFIG_DIR, debug, warning, loadJsonIfPresent } from './utils';
 import { CacheIndex, CacheIndexEntry, ReportMetadata, CacheCoverage } from '../types';
 
 // Base data directory
@@ -74,8 +74,18 @@ export async function loadCacheIndex(channelId: string, channelHandle?: string):
     }
 
     return index;
-  } catch {
-    debug(`Cache index not found or invalid for channel ${channelId}, creating new one`);
+  } catch (err) {
+    // A damaged index is not the same as no index (#195), and the difference
+    // is expensive here: the archive files stay on disk, but an empty index
+    // makes every one of them invisible, so the next fetch re-downloads work
+    // already held locally and then writes an index that no longer references
+    // the old files. Reported with the same recovery guidance the version
+    // mismatch above uses, rather than a debug line nobody sees.
+    const indexPath = getChannelCacheIndexPath(channelId);
+    const channelArg = channelHandle ?? channelId;
+    warning(`Cache index unreadable, treating the archive as empty: ${(err as Error).message}`);
+    warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelArg}`);
+    warning(`  Index file: ${indexPath}`);
     return {
       version: CACHE_INDEX_VERSION,
       lastUpdated: new Date().toISOString(),
@@ -277,10 +287,15 @@ export async function loadReportMetadata(
 ): Promise<ReportMetadata | null> {
   const { metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
 
+  // A damaged sidecar is reported, not silently treated as absent (#195).
+  // Both still return null here, because the caller's recovery is the same
+  // either way today, but the two are no longer indistinguishable in the
+  // output. Rebuilding a damaged sidecar from the index is #192, and it
+  // depends on exactly this split existing.
   try {
-    const data = await fs.readFile(metadataPath, 'utf-8');
-    return JSON.parse(data) as ReportMetadata;
-  } catch {
+    return await loadJsonIfPresent<ReportMetadata>(metadataPath, 'report metadata');
+  } catch (err) {
+    warning(`Ignoring unreadable report metadata: ${(err as Error).message}`);
     return null;
   }
 }

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -60,11 +60,9 @@ export async function loadCacheIndex(channelId: string, channelHandle?: string):
     entries: [],
   });
 
-  // A damaged index is not the same as no index (#195). Absence is the normal
-  // first run for a channel and must stay silent. Damage is expensive and must
-  // not: the archive files stay on disk, but an empty index makes every one of
-  // them invisible, so the next fetch re-downloads work already held locally
-  // and then writes an index that no longer references the old files.
+  // Absence is the normal first run for a channel and stays silent. Damage
+  // warns: the archive files remain on disk, but an empty index hides them, so
+  // the next fetch re-downloads reports already held locally.
   let index: CacheIndex | null;
   try {
     index = await loadJsonIfPresent<CacheIndex>(indexPath, 'cache index');
@@ -292,11 +290,8 @@ export async function loadReportMetadata(
 ): Promise<ReportMetadata | null> {
   const { metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
 
-  // A damaged sidecar is reported, not silently treated as absent (#195).
-  // Both still return null here, because the caller's recovery is the same
-  // either way today, but the two are no longer indistinguishable in the
-  // output. Rebuilding a damaged sidecar from the index is #192, and it
-  // depends on exactly this split existing.
+  // Damage warns, absence does not. Both return null: the caller recovers the
+  // same way either way.
   try {
     return await loadJsonIfPresent<ReportMetadata>(metadataPath, 'report metadata');
   } catch (err) {

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -50,48 +50,53 @@ export async function ensureCacheDir(channelId: string): Promise<void> {
  * Load per-channel cache index
  */
 export async function loadCacheIndex(channelId: string, channelHandle?: string): Promise<CacheIndex> {
+  await ensureCacheDir(channelId);
+
+  const indexPath = getChannelCacheIndexPath(channelId);
+  const channelArg = channelHandle ?? channelId;
+  const freshIndex = (): CacheIndex => ({
+    version: CACHE_INDEX_VERSION,
+    lastUpdated: new Date().toISOString(),
+    entries: [],
+  });
+
+  // A damaged index is not the same as no index (#195). Absence is the normal
+  // first run for a channel and must stay silent. Damage is expensive and must
+  // not: the archive files stay on disk, but an empty index makes every one of
+  // them invisible, so the next fetch re-downloads work already held locally
+  // and then writes an index that no longer references the old files.
+  let index: CacheIndex | null;
   try {
-    await ensureCacheDir(channelId);
-    const data = await fs.readFile(getChannelCacheIndexPath(channelId), 'utf-8');
-    const index = JSON.parse(data) as CacheIndex;
-
-    if (!index.version || !Array.isArray(index.entries)) {
-      throw new Error('Invalid cache index structure');
-    }
-
-    // Validate version matches expected format
-    if (index.version !== CACHE_INDEX_VERSION) {
-      const indexPath = getChannelCacheIndexPath(channelId);
-      const channelArg = channelHandle ?? channelId;
-      warning(`Cache index is outdated (v${index.version} → v${CACHE_INDEX_VERSION}). Cached report data cleared.`);
-      warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelArg}`);
-      warning(`  To delete:  ${indexPath}`);
-      return {
-        version: CACHE_INDEX_VERSION,
-        lastUpdated: new Date().toISOString(),
-        entries: [],
-      };
-    }
-
-    return index;
+    index = await loadJsonIfPresent<CacheIndex>(indexPath, 'cache index');
   } catch (err) {
-    // A damaged index is not the same as no index (#195), and the difference
-    // is expensive here: the archive files stay on disk, but an empty index
-    // makes every one of them invisible, so the next fetch re-downloads work
-    // already held locally and then writes an index that no longer references
-    // the old files. Reported with the same recovery guidance the version
-    // mismatch above uses, rather than a debug line nobody sees.
-    const indexPath = getChannelCacheIndexPath(channelId);
-    const channelArg = channelHandle ?? channelId;
     warning(`Cache index unreadable, treating the archive as empty: ${(err as Error).message}`);
     warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelArg}`);
     warning(`  Index file: ${indexPath}`);
-    return {
-      version: CACHE_INDEX_VERSION,
-      lastUpdated: new Date().toISOString(),
-      entries: [],
-    };
+    return freshIndex();
   }
+
+  if (!index) {
+    debug(`No cache index for channel ${channelId}, starting a new one`);
+    return freshIndex();
+  }
+
+  // Parsed, but not the shape an index has. Same class as a parse failure:
+  // the file exists and cannot be used, so it is reported the same way.
+  if (!index.version || !Array.isArray(index.entries)) {
+    warning(`Cache index has an unexpected structure, treating the archive as empty.`);
+    warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelArg}`);
+    warning(`  Index file: ${indexPath}`);
+    return freshIndex();
+  }
+
+  if (index.version !== CACHE_INDEX_VERSION) {
+    warning(`Cache index is outdated (v${index.version} → v${CACHE_INDEX_VERSION}). Cached report data cleared.`);
+    warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelArg}`);
+    warning(`  To delete:  ${indexPath}`);
+    return freshIndex();
+  }
+
+  return index;
 }
 
 /**

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -47,6 +47,27 @@ export async function ensureCacheDir(channelId: string): Promise<void> {
 // ─── Cache index ──────────────────────────────────────────────────────────────
 
 /**
+ * Whether a parsed index member carries the fields consumers read off it.
+ *
+ * Only the required fields are checked. `createTime` and `row_count` are
+ * optional by design, and `fileSize` is not read on any path that a damaged
+ * index would reach first.
+ */
+function isCacheIndexEntry(entry: unknown): entry is CacheIndexEntry {
+  if (typeof entry !== 'object' || entry === null) return false;
+  const e = entry as Record<string, unknown>;
+  return (
+    typeof e.reportId === 'string' &&
+    typeof e.reportTypeId === 'string' &&
+    typeof e.channelId === 'string' &&
+    typeof e.startTime === 'string' &&
+    typeof e.endTime === 'string' &&
+    typeof e.downloadedAt === 'string' &&
+    typeof e.expiresAt === 'string'
+  );
+}
+
+/**
  * Load per-channel cache index
  */
 export async function loadCacheIndex(channelId: string, channelHandle?: string): Promise<CacheIndex> {
@@ -80,7 +101,10 @@ export async function loadCacheIndex(channelId: string, channelHandle?: string):
 
   // Parsed, but not the shape an index has. Same class as a parse failure:
   // the file exists and cannot be used, so it is reported the same way.
-  if (!index.version || !Array.isArray(index.entries)) {
+  // Entries are checked individually, not just the array: consumers read
+  // fields off each one, so a single malformed member would otherwise get past
+  // here and throw somewhere with no mention of the index at all.
+  if (!index.version || !Array.isArray(index.entries) || !index.entries.every(isCacheIndexEntry)) {
     warning(`Cache index has an unexpected structure, treating the archive as empty.`);
     warning(`  To rebuild: staqan-yt fetch-reports --channel ${channelArg}`);
     warning(`  Index file: ${indexPath}`);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { Config, ConfigKey, OutputFormat } from '../types';
-import { CONFIG_DIR, warning } from './utils';
+import { CONFIG_DIR, warning, loadJsonIfPresent } from './utils';
 
 const CONFIG_PATH = path.join(CONFIG_DIR, 'config.json');
 
@@ -48,13 +48,12 @@ async function ensureConfigDir(): Promise<void> {
  * Returns null if the file doesn't exist or is invalid.
  */
 async function loadRawConfig(): Promise<Config | null> {
-  try {
-    await ensureConfigDir();
-    const data = await fs.readFile(CONFIG_PATH, 'utf-8');
-    return JSON.parse(data) as Config;
-  } catch {
-    return null;
-  }
+  await ensureConfigDir();
+  // Damaged config throws rather than reading as "no config set" (#195). That
+  // silent fallback was the worst of the six: a stray comma from a hand-edit
+  // made default.channel and default.output stop applying, with the CLI
+  // behaving exactly as though they had never been set.
+  return loadJsonIfPresent<Config>(CONFIG_PATH, 'config');
 }
 
 /**
@@ -62,30 +61,31 @@ async function loadRawConfig(): Promise<Config | null> {
  * Returns default config if file doesn't exist
  */
 export async function loadConfig(): Promise<Config> {
-  try {
-    await ensureConfigDir();
-    const data = await fs.readFile(CONFIG_PATH, 'utf-8');
-    const config = JSON.parse(data) as Config;
+  await ensureConfigDir();
 
-    // Merge with defaults to ensure all keys exist
-    return {
-      cache: {
-        ...DEFAULT_CONFIG.cache,
-        ...config.cache,
-      },
-      default: {
-        ...DEFAULT_CONFIG.default,
-        ...config.default,
-      },
-      lock: {
-        ...DEFAULT_CONFIG.lock,
-        ...config.lock,
-      },
-    };
-  } catch {
-    // File doesn't exist or is invalid - return defaults
-    return { ...DEFAULT_CONFIG };
-  }
+  // Throws on a damaged config rather than returning defaults (#195). This is
+  // the function that decides what every command actually does, so the old
+  // catch-all was the most consequential of the six: a malformed config.json
+  // made default.channel and default.output stop applying with no message,
+  // which looks exactly like never having set them.
+  const config = await loadJsonIfPresent<Config>(CONFIG_PATH, 'config');
+  if (!config) return { ...DEFAULT_CONFIG };
+
+  // Merge with defaults to ensure all keys exist
+  return {
+    cache: {
+      ...DEFAULT_CONFIG.cache,
+      ...config.cache,
+    },
+    default: {
+      ...DEFAULT_CONFIG.default,
+      ...config.default,
+    },
+    lock: {
+      ...DEFAULT_CONFIG.lock,
+      ...config.lock,
+    },
+  };
 }
 
 /**

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -45,29 +45,28 @@ async function ensureConfigDir(): Promise<void> {
 
 /**
  * Load raw configuration from file without merging defaults.
- * Returns null if the file doesn't exist or is invalid.
+ * Returns null if the file does not exist. Throws if it exists and is damaged.
  */
 async function loadRawConfig(): Promise<Config | null> {
   await ensureConfigDir();
-  // Damaged config throws rather than reading as "no config set" (#195). That
-  // silent fallback was the worst of the six: a stray comma from a hand-edit
-  // made default.channel and default.output stop applying, with the CLI
-  // behaving exactly as though they had never been set.
+  // Damaged config throws rather than reading as "no config set" (#195). Only
+  // `config list` and `config get` call this, so the report reaches whoever is
+  // inspecting the file, which is the person able to fix it.
   return loadJsonIfPresent<Config>(CONFIG_PATH, 'config');
 }
 
 /**
- * Load configuration from file
- * Returns default config if file doesn't exist
+ * Load configuration from file.
+ * Returns default config if the file does not exist. Throws if it is damaged.
  */
 export async function loadConfig(): Promise<Config> {
   await ensureConfigDir();
 
-  // Throws on a damaged config rather than returning defaults (#195). This is
-  // the function that decides what every command actually does, so the old
-  // catch-all was the most consequential of the six: a malformed config.json
-  // made default.channel and default.output stop applying with no message,
-  // which looks exactly like never having set them.
+  // Throws on a damaged config rather than returning defaults (#195). Of the
+  // eight loaders this is the one every command actually calls, so the old
+  // catch-all was the most consequential: a stray comma from a hand-edit made
+  // default.channel and default.output stop applying with no message, which
+  // looks exactly like never having set them.
   const config = await loadJsonIfPresent<Config>(CONFIG_PATH, 'config');
   if (!config) return { ...DEFAULT_CONFIG };
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -49,9 +49,6 @@ async function ensureConfigDir(): Promise<void> {
  */
 async function loadRawConfig(): Promise<Config | null> {
   await ensureConfigDir();
-  // Damaged config throws rather than reading as "no config set" (#195). Only
-  // `config list` and `config get` call this, so the report reaches whoever is
-  // inspecting the file, which is the person able to fix it.
   return loadJsonIfPresent<Config>(CONFIG_PATH, 'config');
 }
 
@@ -62,11 +59,6 @@ async function loadRawConfig(): Promise<Config | null> {
 export async function loadConfig(): Promise<Config> {
   await ensureConfigDir();
 
-  // Throws on a damaged config rather than returning defaults (#195). Of the
-  // eight loaders this is the one every command actually calls, so the old
-  // catch-all was the most consequential: a stray comma from a hand-edit made
-  // default.channel and default.output stop applying with no message, which
-  // looks exactly like never having set them.
   const config = await loadJsonIfPresent<Config>(CONFIG_PATH, 'config');
   if (!config) return { ...DEFAULT_CONFIG };
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -32,16 +32,10 @@ async function ensureConfigDir(): Promise<void> {
 /**
  * Read and parse a JSON file that is allowed not to exist.
  *
- * Returns `null` **only** when the file is absent (`ENOENT`). Every other
- * failure throws: a permissions error, an I/O error, or a JSON syntax error
- * all mean the file is there and unusable, which is a different situation from
- * it never having been written (#195).
- *
- * That distinction is the whole point. Callers uniformly read `null` as "not
- * configured yet" and print guidance to match, so a corrupt file that reports
- * as absent sends the reader to fix the wrong problem. `credentials.json`
- * produced "run staqan-yt auth" for a file that already existed; a stray comma
- * in `config.json` made every setting silently revert to its default.
+ * Returns `null` only when the file is absent (`ENOENT`). A permissions error,
+ * an I/O error or a JSON syntax error all throw instead: the file is there and
+ * unusable, which is not the same as never having been written. Callers read
+ * `null` as "not configured yet", so the two must not collapse into one answer.
  *
  * `label` names the file in the thrown message, since the caller knows what
  * the file is for and this helper does not.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,6 +30,44 @@ async function ensureConfigDir(): Promise<void> {
 }
 
 /**
+ * Read and parse a JSON file that is allowed not to exist.
+ *
+ * Returns `null` **only** when the file is absent (`ENOENT`). Every other
+ * failure throws: a permissions error, an I/O error, or a JSON syntax error
+ * all mean the file is there and unusable, which is a different situation from
+ * it never having been written (#195).
+ *
+ * That distinction is the whole point. Callers uniformly read `null` as "not
+ * configured yet" and print guidance to match, so a corrupt file that reports
+ * as absent sends the reader to fix the wrong problem. `credentials.json`
+ * produced "run staqan-yt auth" for a file that already existed; a stray comma
+ * in `config.json` made every setting silently revert to its default.
+ *
+ * `label` names the file in the thrown message, since the caller knows what
+ * the file is for and this helper does not.
+ */
+export async function loadJsonIfPresent<T>(filePath: string, label: string): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf-8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw new Error(
+      `Cannot read ${label} (${filePath}): ${(err as Error).message}`
+    );
+  }
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(
+      `${label} (${filePath}) is not valid JSON: ${(err as Error).message}. ` +
+      `Fix the file, or delete it to start over.`
+    );
+  }
+}
+
+/**
  * Classify channel input (handle, ID, or URL) as a handle or a channel ID.
  * Throws on legacy /c/ and /user/ URLs — their path segment is neither a
  * handle nor a channel ID, so no downstream lookup could succeed (issue #123).

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -47,7 +47,8 @@ export async function loadJsonIfPresent<T>(filePath: string, label: string): Pro
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
     throw new Error(
-      `Cannot read ${label} (${filePath}): ${(err as Error).message}`
+      `Cannot read ${label} (${filePath}): ${(err as Error).message}. ` +
+      `Check that the path is a readable file and fix its permissions.`
     );
   }
 

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -12,10 +12,9 @@ import { debug, warning, CACHE_DIR, loadJsonIfPresent } from './utils';
 const HANDLE_CACHE_PATH = path.join(CACHE_DIR, 'handle-to-channel-id.json');
 
 async function loadHandleCache(): Promise<Record<string, string>> {
-  // A cache is optional by definition, so a damaged one must not abort the
-  // command the way a damaged config does. It is still reported rather than
-  // swallowed: silently running cold turns a one-off corruption into a
-  // permanent extra API call per handle, with nothing to point at (#195).
+  // A damaged cache must not abort the command the way a damaged config does,
+  // but it is still reported: running cold silently costs an extra API call
+  // per handle for as long as the file stays broken.
   try {
     return (await loadJsonIfPresent<Record<string, string>>(HANDLE_CACHE_PATH, 'handle cache')) || {};
   } catch (err) {

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -5,16 +5,21 @@ import { getAuthenticatedClient } from './auth';
 import { normalizeLanguage, getLanguageName, getAliasedLanguages } from './language';
 import { acquireLock, getLockPath } from './lock';
 import { VideoInfo, VideoListItem, VideoLocalization, VideoType, PrivacyStatus, PlaylistInfo, PlaylistListItem, CommentInfo, ChannelInfo, CaptionInfo, CaptionFormat, CaptionTrackStatus, CaptionAudioTrackType } from '../types';
-import { debug, warning, CACHE_DIR } from './utils';
+import { debug, warning, CACHE_DIR, loadJsonIfPresent } from './utils';
 
 // ─── Handle → channel ID cache ────────────────────────────────────────────────
 
 const HANDLE_CACHE_PATH = path.join(CACHE_DIR, 'handle-to-channel-id.json');
 
 async function loadHandleCache(): Promise<Record<string, string>> {
+  // A cache is optional by definition, so a damaged one must not abort the
+  // command the way a damaged config does. It is still reported rather than
+  // swallowed: silently running cold turns a one-off corruption into a
+  // permanent extra API call per handle, with nothing to point at (#195).
   try {
-    return JSON.parse(await fs.readFile(HANDLE_CACHE_PATH, 'utf-8'));
-  } catch {
+    return (await loadJsonIfPresent<Record<string, string>>(HANDLE_CACHE_PATH, 'handle cache')) || {};
+  } catch (err) {
+    warning(`Ignoring unreadable handle cache: ${(err as Error).message}`);
     return {};
   }
 }

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -430,4 +430,64 @@ describe('loadCacheIndex: absent vs damaged (#195)', () => {
     const err = await captureWarnings(() => loadCacheIndex(channel));
     expect(err).toContain('unexpected structure');
   });
+
+  it('warns when the index is well-formed but an entry is not', async () => {
+    // The shape check passes on the envelope: version is set and entries is an
+    // array. Consumers then read fields off each member, so an unusable entry
+    // that got past here surfaced as "null is not an object (evaluating
+    // 'entry.channelId')" from a call site that never mentions the index.
+    const channel = 'UCnullentry0000000000';
+    const dir = path.join(tmpRoot, channel, 'reports');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'cache-index.json'),
+      '{"version":"2.0","lastUpdated":"2026-01-01T00:00:00Z","entries":[null]}',
+      'utf-8',
+    );
+
+    const err = await captureWarnings(() => loadCacheIndex(channel));
+    expect(err).toContain('unexpected structure');
+    const index = await loadCacheIndex(channel);
+    expect(index.entries).toEqual([]);
+  });
+
+  it('warns when an entry is an object but is missing required fields', async () => {
+    // Same class as the null member: partial entries reach the same consumers.
+    const channel = 'UCpartialentry000000';
+    const dir = path.join(tmpRoot, channel, 'reports');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      path.join(dir, 'cache-index.json'),
+      '{"version":"2.0","lastUpdated":"2026-01-01T00:00:00Z","entries":[{"reportId":"r1"}]}',
+      'utf-8',
+    );
+
+    const err = await captureWarnings(() => loadCacheIndex(channel));
+    expect(err).toContain('unexpected structure');
+  });
+
+  it('accepts an index whose entries are complete', async () => {
+    // The guard must not reject valid data. createTime and row_count are
+    // deliberately absent here, since both are optional.
+    const channel = 'UCgoodentry000000000';
+    const dir = path.join(tmpRoot, channel, 'reports');
+    await fs.mkdir(dir, { recursive: true });
+    const entry = {
+      reportId: 'r1', reportTypeId: 'channel_basic_a3', channelId: channel,
+      startTime: '2026-01-01', endTime: '2026-01-02',
+      downloadedAt: '2026-01-03T00:00:00Z', expiresAt: '2026-07-03T00:00:00Z',
+      fileSize: 10,
+    };
+    await fs.writeFile(
+      path.join(dir, 'cache-index.json'),
+      JSON.stringify({ version: '2.0', lastUpdated: '2026-01-01T00:00:00Z', entries: [entry] }),
+      'utf-8',
+    );
+
+    const err = await captureWarnings(() => loadCacheIndex(channel));
+    expect(err).toBe('');
+    const index = await loadCacheIndex(channel);
+    expect(index.entries).toHaveLength(1);
+    expect(index.entries[0].reportId).toBe('r1');
+  });
 });

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -15,6 +15,7 @@ import {
   compareInstants,
   findCachedReports,
   getDataDir,
+  loadCacheIndex,
   pickNewestPerWindow,
   readCachedReport,
   saveReportToCache,
@@ -361,5 +362,72 @@ describe('findCachedReports', () => {
     await store(metadataFor({ reportId: 'mine' }), csvFor(['20260301'], '5'));
     const found = await findCachedReports(CHANNEL, 'channel_basic_a3', '2026-03-01', '2026-03-07');
     expect(found).toEqual([]);
+  });
+});
+
+/**
+ * Absence versus damage for the cache index (#195).
+ *
+ * A missing index is the normal first run for a channel and must stay silent.
+ * A damaged one must not, because the archive files remain on disk while an
+ * empty index hides every one of them: the next fetch re-downloads work
+ * already held locally, then writes an index that no longer references the
+ * old files.
+ *
+ * These assert on the returned value and on stderr, because the regression
+ * this guards against was purely a stderr one. The index came back empty in
+ * both cases; only the noise differed.
+ */
+describe('loadCacheIndex: absent vs damaged (#195)', () => {
+  // `warning()` goes through console.warn, not process.stderr.write, so the
+  // capture has to patch console.warn. Patching the stream instead silently
+  // captures nothing and every assertion below passes vacuously.
+  const captureWarnings = async (fn: () => Promise<unknown>) => {
+    const written: string[] = [];
+    const orig = console.warn;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    console.warn = (...args: any[]) => { written.push(args.map(String).join(' ')); };
+    try {
+      await fn();
+    } finally {
+      console.warn = orig;
+    }
+    return written.join('\n');
+  };
+
+  it('is silent when no index exists yet', async () => {
+    // The cold-start path. Every channel hits this once, so a warning here
+    // would fire for everyone on first use.
+    const err = await captureWarnings(() => loadCacheIndex('UCcoldstart0000000000'));
+    expect(err).toBe('');
+  });
+
+  it('returns a fresh empty index when none exists', async () => {
+    const index = await loadCacheIndex('UCcoldstart0000000001');
+    expect(index.entries).toEqual([]);
+    expect(index.version).toBeTruthy();
+  });
+
+  it('warns when the index exists but does not parse', async () => {
+    const channel = 'UCdamaged00000000000';
+    const dir = path.join(tmpRoot, channel, 'reports');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'cache-index.json'), 'not json{', 'utf-8');
+
+    const err = await captureWarnings(() => loadCacheIndex(channel));
+    expect(err).toContain('unreadable');
+    expect(err).toContain('To rebuild');
+  });
+
+  it('warns when the index parses but has the wrong shape', async () => {
+    // Valid JSON, not an index. The file exists and cannot be used, which is
+    // the same situation as a parse failure and is reported the same way.
+    const channel = 'UCwrongshape000000000';
+    const dir = path.join(tmpRoot, channel, 'reports');
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'cache-index.json'), '{"nope":true}', 'utf-8');
+
+    const err = await captureWarnings(() => loadCacheIndex(channel));
+    expect(err).toContain('unexpected structure');
   });
 });

--- a/tests/json-loader.test.ts
+++ b/tests/json-loader.test.ts
@@ -75,6 +75,15 @@ describe('loadJsonIfPresent (#195)', () => {
     await expect(loadJsonIfPresent(p, 'thing')).rejects.toThrow(/Cannot read thing/);
   });
 
+  it('tells the reader how to recover from a read error too', async () => {
+    // The parse branch carries remediation, so the read branch has to as well.
+    // Asserting on our own guidance rather than the errno text, since the
+    // wording of the underlying message is platform-dependent.
+    const p = path.join(dir, 'adirectory2.json');
+    await fs.mkdir(p);
+    await expect(loadJsonIfPresent(p, 'thing')).rejects.toThrow(/readable file and fix its permissions/);
+  });
+
   it('treats an empty file as damaged, not absent', async () => {
     // A truncated write leaves a zero-byte file. It exists, so it is not
     // absent, and it does not parse, so it is damaged.

--- a/tests/json-loader.test.ts
+++ b/tests/json-loader.test.ts
@@ -1,7 +1,7 @@
 /**
  * `loadJsonIfPresent`: absent versus damaged (#195).
  *
- * Six loaders across the codebase shared one shape, `readFile` then
+ * Eight loaders across the codebase shared one shape, `readFile` then
  * `JSON.parse` inside a `try` whose `catch` returned a neutral value. That
  * collapsed two situations callers treat very differently:
  *
@@ -11,7 +11,7 @@
  * A corrupt `credentials.json` produced "run staqan-yt auth" for a file that
  * already existed. A stray comma in `config.json` made every setting silently
  * revert to its default. These tests pin the distinction itself, which is the
- * only thing the six call sites rely on.
+ * only thing the eight call sites rely on.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { promises as fs } from 'fs';
@@ -41,7 +41,7 @@ describe('loadJsonIfPresent (#195)', () => {
   it('parses a valid file', async () => {
     const p = path.join(dir, 'ok.json');
     await fs.writeFile(p, JSON.stringify({ a: 1, nested: { b: 'two' } }));
-    expect(await loadJsonIfPresent(p, 'thing')).toEqual({ a: 1, nested: { b: 'two' } });
+    expect(await loadJsonIfPresent<Record<string, unknown>>(p, 'thing')).toEqual({ a: 1, nested: { b: 'two' } });
   });
 
   it('throws on malformed JSON instead of reporting the file as absent', async () => {

--- a/tests/json-loader.test.ts
+++ b/tests/json-loader.test.ts
@@ -1,0 +1,94 @@
+/**
+ * `loadJsonIfPresent`: absent versus damaged (#195).
+ *
+ * Six loaders across the codebase shared one shape, `readFile` then
+ * `JSON.parse` inside a `try` whose `catch` returned a neutral value. That
+ * collapsed two situations callers treat very differently:
+ *
+ *   - absent  -> "not configured yet", and the caller prints setup guidance
+ *   - damaged -> the file exists and is unusable, and that guidance is wrong
+ *
+ * A corrupt `credentials.json` produced "run staqan-yt auth" for a file that
+ * already existed. A stray comma in `config.json` made every setting silently
+ * revert to its default. These tests pin the distinction itself, which is the
+ * only thing the six call sites rely on.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { loadJsonIfPresent } from '../lib/utils';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'staqan-json-loader-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('loadJsonIfPresent (#195)', () => {
+  it('returns null when the file does not exist', () => {
+    // The only case that may be silent. Every caller reads this as
+    // "not configured yet".
+    return expect(
+      loadJsonIfPresent(path.join(dir, 'nope.json'), 'thing'),
+    ).resolves.toBeNull();
+  });
+
+  it('parses a valid file', async () => {
+    const p = path.join(dir, 'ok.json');
+    await fs.writeFile(p, JSON.stringify({ a: 1, nested: { b: 'two' } }));
+    expect(await loadJsonIfPresent(p, 'thing')).toEqual({ a: 1, nested: { b: 'two' } });
+  });
+
+  it('throws on malformed JSON instead of reporting the file as absent', async () => {
+    // The regression this exists for. A trailing comma is the realistic
+    // hand-edit, and it used to read as "no config".
+    const p = path.join(dir, 'bad.json');
+    await fs.writeFile(p, '{"default": {"channel": "@x",}}');
+    await expect(loadJsonIfPresent(p, 'config')).rejects.toThrow(/not valid JSON/);
+  });
+
+  it('names the file and its path in the parse error', async () => {
+    // The old failure sent readers to fix the wrong thing, so the message has
+    // to say which file is broken and where it is.
+    const p = path.join(dir, 'bad2.json');
+    await fs.writeFile(p, 'not json at all');
+    await expect(loadJsonIfPresent(p, 'auth token')).rejects.toThrow(/auth token/);
+    await expect(loadJsonIfPresent(p, 'auth token')).rejects.toThrow(p);
+  });
+
+  it('tells the reader how to recover', async () => {
+    const p = path.join(dir, 'bad3.json');
+    await fs.writeFile(p, '{');
+    await expect(loadJsonIfPresent(p, 'config')).rejects.toThrow(/Fix the file, or delete it/);
+  });
+
+  it('throws on a read error that is not ENOENT', async () => {
+    // A directory where a file is expected fails with EISDIR. Any non-ENOENT
+    // errno takes the same path, which is the point: only absence is silent.
+    const p = path.join(dir, 'adirectory.json');
+    await fs.mkdir(p);
+    await expect(loadJsonIfPresent(p, 'thing')).rejects.toThrow(/Cannot read thing/);
+  });
+
+  it('treats an empty file as damaged, not absent', async () => {
+    // A truncated write leaves a zero-byte file. It exists, so it is not
+    // absent, and it does not parse, so it is damaged.
+    const p = path.join(dir, 'empty.json');
+    await fs.writeFile(p, '');
+    await expect(loadJsonIfPresent(p, 'cache')).rejects.toThrow(/not valid JSON/);
+  });
+
+  it('returns JSON null as null, same as an absent file', async () => {
+    // A file containing the literal `null` parses successfully to null.
+    // Callers cannot distinguish it from absence, and none of them need to:
+    // both mean "nothing configured".
+    const p = path.join(dir, 'null.json');
+    await fs.writeFile(p, 'null');
+    expect(await loadJsonIfPresent(p, 'thing')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #195.

## The problem

Eight loaders read an optional JSON file and returned a neutral value on *any* failure, collapsing two different situations into one answer:

- **absent** (`ENOENT`): expected, and `null` is the correct control flow.
- **damaged** (JSON syntax error, `EACCES`, `EIO`): the file is there and unusable.

Because every caller reads `null` as "not configured yet" and prints guidance to match, a damaged file sent the reader to fix the wrong problem. `credentials.json` produced "run the auth command first" for a file that already existed. A stray comma in `config.json` made `default.channel` and `default.output` silently stop applying, with no output at any verbosity pointing at the file.

## The change

One helper, `loadJsonIfPresent<T>(path, label)` in `lib/utils.ts`, replacing all eight call sites. `ENOENT` returns `null`, which is the only case any caller ever meant by `null`. Everything else throws, carrying the path, the underlying parse error, and the remedy.

Each site then decides explicitly what to do, rather than inheriting silence from the loader:

| site | absent | damaged |
|---|---|---|
| `lib/auth.ts` credentials, token | setup guidance | throws, naming the file |
| `lib/config.ts` `loadConfig`, `loadRawConfig` | defaults | throws, naming the file |
| `lib/cache.ts` cache index | silent, fresh index | warns, fresh index |
| `lib/cache.ts` report sidecar | `null` | warns, `null` |
| `lib/youtube.ts` handle cache | silent, cold | warns, cold |
| `commands/complete.ts` completion cache | silent, cold | `debug()` only, cold |

The split follows what the caller can actually do about it. Config and credentials decide what a command does at all, so a damaged one stops the run. A cache is optional by definition and must not abort the command, but staying silent turns a one-off corruption into a permanent extra API call per handle with nothing to point at, so it warns and continues.

The completion cache is the one site that must stay quiet on **both** streams no matter what: it runs inside the interactive shell on every Tab, where a warning would print into the middle of the prompt. The error goes to `debug()`, so `-v` can still explain a cache that never seems to hit.

`loadCacheIndex` also gained a case it did not have before. A file that parses but is not index-shaped is the same class as a parse failure (present, unusable), so it is now reported the same way instead of falling into the silent `debug()` path.

## E2E proof

Built `main` (`f7053e3`) and this branch side by side, and ran identical commands against fake `HOME` / `STAQAN_YT_DATA_DIR` trees. No real credentials or archive touched.

**Corrupt `config.json`** (`{ "default": { "channel": "@staqan", }, }`):

```
before   exit=0   default.channel: (not set) / default.output: pretty
after    exit=1   ✗ config (…/config.json) is not valid JSON: JSON Parse error:
                    Property name must be a string literal. Fix the file, or delete it to start over.
```

On `main` that output is **byte-identical to a cold start**, which is precisely the defect.

**Corrupt `credentials.json`:**

```
before   ✗ Credentials not found. Please run the auth command first.
after    ✗ OAuth credentials (…/credentials.json) is not valid JSON: JSON Parse error:
           Unexpected identifier "not". Fix the file, or delete it to start over.
```

**Cache index**, with an archive CSV still on disk:

| index state | before | after |
|---|---|---|
| damaged JSON | silent, archive invisible | warns, names the file and the rebuild command |
| parses, wrong shape | silent, archive invisible | warns, names the file |
| version mismatch | warns | **identical to before** |
| absent | silent | **identical to before** |

**Handle cache** and **report sidecar**: damaged now warns and continues; absent is unchanged and silent; a valid sidecar still parses.

**Completion cache** (the non-regression that matters most), measured by byte count per stream:

```
completionCache=damaged  before  exit=0 stdout=0 stderr=0
completionCache=damaged  after   exit=0 stdout=0 stderr=0
completionCache=absent   before  exit=0 stdout=0 stderr=0
completionCache=absent   after   exit=0 stdout=0 stderr=0
```

**Controls.** Cold start stays silent on every path, and a valid config still applies: `config get default.channel` returns `@staqan` and `config list` still honours `output=csv`, identical on both builds.

## Checks

`type-check` clean, `lint` 0 errors (4 pre-existing `any` warnings in `commands/mcp.ts`), **258 tests pass**. Coverage added in `tests/json-loader.test.ts` (the absent/damaged/permission split) and `tests/cache-store.test.ts` (index damage vs. cold start, so the silent-first-run case cannot regress).

## Follow-ups

#192 depends on this landing: rebuilding a damaged sidecar is not reachable until `loadReportMetadata` can tell absent from damaged. #198 (lint rule banning bare `catch {}`) is the last of the family, after #196 and #197.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing, unreadable, and malformed configuration, credential, token, cache, and metadata files.
  - Added clearer warnings and recovery guidance when stored data is damaged or has an unexpected format.
  - Prevented corrupted files from being silently treated as missing or reset automatically.
- **Tests**
  - Added coverage for valid, missing, empty, malformed, and unreadable JSON files, including cache index recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->