### PR TITLE
fix(#192): rebuild a damaged sidecar instead of serving the CSV unvalidated

### DIFF
--- a/commands/fetch-reports.ts
+++ b/commands/fetch-reports.ts
@@ -311,6 +311,7 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
       const index = await loadCacheIndex(channelId);
       let verified = 0;
       let corrupted = 0;
+      let rebuilt = 0;
 
       for (const entry of index.entries) {
         const metadata = await loadReportMetadata(channelId, entry.reportId, entry.reportTypeId);
@@ -321,16 +322,25 @@ async function fetchReportsCommand(options: FetchReportsOptions): Promise<void> 
           continue;
         }
 
-        if (!metadata.isComplete) {
+        if (metadata.isComplete === false) {
           warning(`Incomplete file: ${entry.reportId}`);
           corrupted++;
+          continue;
+        }
+
+        // A rebuilt sidecar is not an issue, but it is not a clean bill of
+        // health either: its completeness was never recorded, so --verify
+        // counts it separately rather than folding it into either total.
+        if (metadata.rebuiltAt) {
+          rebuilt++;
           continue;
         }
 
         verified++;
       }
 
-      spinner.succeed(`Verification complete: ${verified} OK, ${corrupted} issues`);
+      const rebuiltNote = rebuilt > 0 ? `, ${rebuilt} rebuilt (completeness unverifiable)` : '';
+      spinner.succeed(`Verification complete: ${verified} OK, ${corrupted} issues${rebuiltNote}`);
       console.log('');
     }
 

--- a/docs/commands/reporting-api.md
+++ b/docs/commands/reporting-api.md
@@ -436,7 +436,7 @@ Each cached report has a `<reportId>.metadata.json` sidecar recording what the
 report was at download time, including its column list and a completeness flag.
 `--verify` reads those sidecars, so the counts it prints describe them:
 
-```
+```text
 Verification complete: 3755 OK, 0 issues, 2 rebuilt (completeness unverifiable)
 ```
 

--- a/docs/commands/reporting-api.md
+++ b/docs/commands/reporting-api.md
@@ -432,6 +432,24 @@ Use `--verify` to check cached files:
 staqan-yt fetch-reports --verify
 ```
 
+Each cached report has a `<reportId>.metadata.json` sidecar recording what the
+report was at download time, including its column list and a completeness flag.
+`--verify` reads those sidecars, so the counts it prints describe them:
+
+```
+Verification complete: 3755 OK, 0 issues, 2 rebuilt (completeness unverifiable)
+```
+
+A **rebuilt** sidecar is one that was found damaged and reconstructed from the
+cache index and the report CSV on disk. The reconstruction recovers the
+identity, window and column fields, and re-measures the actual date range from
+the CSV. It cannot recover the job ID, the download URL, or the completeness
+flag, because those came from an API response that is no longer available, and
+it does not invent them. Such a report is still served normally; it is counted
+separately because its completeness can no longer be confirmed.
+
+To restore a full sidecar, re-download that report with `--force`.
+
 ### Cache Location
 
 ```

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -317,7 +317,41 @@ export type ReportMetadataLoad =
   | { status: 'damaged'; error: Error };
 
 /**
+ * Whether a parsed sidecar carries the fields its consumers read off it.
+ *
+ * Syntax is not shape. `{}` is valid JSON, and accepting it hands
+ * `readCachedReport` a record whose `columns` is undefined: it throws on
+ * `.join()`, the surrounding catch turns that into null, and the report drops
+ * out of every query with its sidecar left broken. Checking the shape here is
+ * what routes that file to the rebuild instead.
+ */
+function isReportMetadata(value: unknown): value is ReportMetadata {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as Record<string, unknown>;
+
+  const requiredStrings = [
+    'reportId', 'reportTypeId', 'channelId', 'startTime', 'endTime',
+    'startTimeActual', 'endTimeActual', 'downloadedAt', 'expiresAt',
+  ];
+  if (!requiredStrings.every((k) => typeof m[k] === 'string')) return false;
+  if (!Array.isArray(m.columns) || !m.columns.every((c) => typeof c === 'string')) return false;
+  if (typeof m.fileSize !== 'number') return false;
+
+  // Optional fields are absent or correctly typed, never junk. A rebuilt
+  // sidecar legitimately omits jobId, downloadUrl and isComplete.
+  const optional: [string, string][] = [
+    ['createTime', 'string'], ['jobId', 'string'], ['downloadUrl', 'string'],
+    ['isComplete', 'boolean'], ['rebuiltAt', 'string'], ['row_count', 'number'],
+  ];
+  return optional.every(([k, t]) => m[k] === undefined || typeof m[k] === t);
+}
+
+/**
  * Load report metadata, reporting absence and damage separately.
+ *
+ * A file that parses but is not a metadata record counts as damaged, not ok:
+ * it exists and cannot be used, which is the same situation as a syntax error
+ * and gets the same repair.
  */
 export async function loadReportMetadataResult(
   channelId: string,
@@ -326,12 +360,24 @@ export async function loadReportMetadataResult(
 ): Promise<ReportMetadataLoad> {
   const { metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
 
+  let parsed: unknown;
   try {
-    const metadata = await loadJsonIfPresent<ReportMetadata>(metadataPath, 'report metadata');
-    return metadata ? { status: 'ok', metadata } : { status: 'absent' };
+    parsed = await loadJsonIfPresent<unknown>(metadataPath, 'report metadata');
   } catch (err) {
     return { status: 'damaged', error: err as Error };
   }
+
+  if (parsed === null) return { status: 'absent' };
+  if (!isReportMetadata(parsed)) {
+    return {
+      status: 'damaged',
+      error: new Error(
+        `report metadata (${metadataPath}) parsed but is not a metadata record. ` +
+        `Fix the file, or delete it to start over.`
+      ),
+    };
+  }
+  return { status: 'ok', metadata: parsed };
 }
 
 /**

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -305,23 +305,128 @@ function getReportPaths(channelId: string, reportId: string, reportTypeId: strin
 // ─── Metadata ────────────────────────────────────────────────────────────────
 
 /**
- * Load report metadata
+ * Why a sidecar could not be returned as-is.
+ *
+ * `absent` is an older or interrupted write and implies nothing is wrong with
+ * the report. `damaged` implies the opposite, and the two need different
+ * responses, so they are not collapsed into a single null.
+ */
+export type ReportMetadataLoad =
+  | { status: 'ok'; metadata: ReportMetadata }
+  | { status: 'absent' }
+  | { status: 'damaged'; error: Error };
+
+/**
+ * Load report metadata, reporting absence and damage separately.
+ */
+export async function loadReportMetadataResult(
+  channelId: string,
+  reportId: string,
+  reportTypeId: string
+): Promise<ReportMetadataLoad> {
+  const { metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
+
+  try {
+    const metadata = await loadJsonIfPresent<ReportMetadata>(metadataPath, 'report metadata');
+    return metadata ? { status: 'ok', metadata } : { status: 'absent' };
+  } catch (err) {
+    return { status: 'damaged', error: err as Error };
+  }
+}
+
+/**
+ * Reconstruct a sidecar for a report whose own sidecar is unreadable.
+ *
+ * Two sources, both trustworthy, and nothing else:
+ *
+ * - the **index entry**, which is authoritative for the identity and window
+ *   fields and is already held in memory during any query;
+ * - the **CSV on disk**, re-measured for `columns` and the actual date range,
+ *   rather than inferred from anything.
+ *
+ * `jobId`, `downloadUrl` and `isComplete` came from an API response that is
+ * gone, so they are left absent. Returns null when the rebuild cannot be
+ * grounded in both sources, which keeps the caller's fallback explicit instead
+ * of handing back a half-populated record.
+ *
+ * Re-measuring `columns` makes the header check tautological for this one
+ * report, which is the honest outcome: the check compares a file against a
+ * record of what it was at download time, and once that record is lost it
+ * cannot be resurrected, only the current schema recorded afresh.
+ */
+export async function rebuildReportMetadata(
+  channelId: string,
+  reportId: string,
+  reportTypeId: string
+): Promise<ReportMetadata | null> {
+  const index = await loadCacheIndex(channelId);
+  const entry = index.entries.find(
+    (e) => e.reportId === reportId && e.reportTypeId === reportTypeId
+  );
+  if (!entry) {
+    debug(`Cannot rebuild metadata for ${reportId}: no index entry`);
+    return null;
+  }
+
+  const { csv: csvPath } = getReportPaths(channelId, reportId, reportTypeId);
+  let parsed: ReturnType<typeof parseCsvAndExtractRange>;
+  try {
+    parsed = parseCsvAndExtractRange(await fs.readFile(csvPath, 'utf-8'));
+  } catch (err) {
+    debug(`Cannot rebuild metadata for ${reportId}: ${(err as Error).message}`);
+    return null;
+  }
+
+  const rebuilt: ReportMetadata = {
+    reportId: entry.reportId,
+    reportTypeId: entry.reportTypeId,
+    channelId: entry.channelId,
+    startTime: entry.startTime,
+    endTime: entry.endTime,
+    createTime: entry.createTime,
+    downloadedAt: entry.downloadedAt,
+    expiresAt: entry.expiresAt,
+    fileSize: entry.fileSize,
+    row_count: entry.row_count,
+    columns: parsed.headers,
+    startTimeActual: parsed.minDate,
+    endTimeActual: parsed.maxDate,
+    rebuiltAt: new Date().toISOString(),
+  };
+
+  await saveReportMetadata(channelId, rebuilt);
+  return rebuilt;
+}
+
+/**
+ * Load report metadata, rebuilding it if the file on disk is damaged.
+ *
+ * Absence stays silent and returns null, which every caller already treats as
+ * "no record". Damage is reported and repaired where possible, because the
+ * alternative is what #192 describes: the sidecar is the only thing standing
+ * between a corrupted CSV and its consumer, and returning null for a damaged
+ * one disables that check exactly when a second corruption has occurred.
  */
 export async function loadReportMetadata(
   channelId: string,
   reportId: string,
   reportTypeId: string
 ): Promise<ReportMetadata | null> {
-  const { metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
+  const result = await loadReportMetadataResult(channelId, reportId, reportTypeId);
 
-  // Damage warns, absence does not. Both return null: the caller recovers the
-  // same way either way.
-  try {
-    return await loadJsonIfPresent<ReportMetadata>(metadataPath, 'report metadata');
-  } catch (err) {
-    warning(`Ignoring unreadable report metadata: ${(err as Error).message}`);
+  if (result.status === 'ok') return result.metadata;
+  if (result.status === 'absent') return null;
+
+  warning(`Report metadata unreadable, rebuilding it: ${result.error.message}`);
+  const rebuilt = await rebuildReportMetadata(channelId, reportId, reportTypeId);
+  if (!rebuilt) {
+    warning(`  Rebuild failed for ${reportId}. Its cached CSV cannot be validated.`);
     return null;
   }
+
+  warning(`  Rebuilt ${reportId} from the cache index and the CSV on disk.`);
+  warning(`  Completeness was not recorded at download time and is not inferred.`);
+  return rebuilt;
 }
 
 /**
@@ -428,7 +533,10 @@ export async function readCachedReport(
         return null;
       }
 
-      if (!metadata.isComplete) {
+      // `=== false`, not falsiness: absent means completeness was never
+      // recorded, which is the state of a rebuilt sidecar, and rejecting it
+      // would discard a CSV that is almost certainly fine.
+      if (metadata.isComplete === false) {
         debug(`Report ${reportId} marked as incomplete`);
         return null;
       }

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -16,6 +16,7 @@ import {
   findCachedReports,
   getDataDir,
   loadCacheIndex,
+  loadReportMetadata,
   pickNewestPerWindow,
   readCachedReport,
   saveReportToCache,
@@ -445,10 +446,12 @@ describe('loadCacheIndex: absent vs damaged (#195)', () => {
       'utf-8',
     );
 
-    const err = await captureWarnings(() => loadCacheIndex(channel));
+    let index: Awaited<ReturnType<typeof loadCacheIndex>> | null = null;
+    const err = await captureWarnings(async () => {
+      index = await loadCacheIndex(channel);
+    });
     expect(err).toContain('unexpected structure');
-    const index = await loadCacheIndex(channel);
-    expect(index.entries).toEqual([]);
+    expect(index!.entries).toEqual([]);
   });
 
   it('warns when an entry is an object but is missing required fields', async () => {
@@ -489,5 +492,167 @@ describe('loadCacheIndex: absent vs damaged (#195)', () => {
     const index = await loadCacheIndex(channel);
     expect(index.entries).toHaveLength(1);
     expect(index.entries[0].reportId).toBe('r1');
+  });
+});
+
+/**
+ * Rebuilding a damaged sidecar (#192).
+ *
+ * The sidecar is the only thing standing between a corrupted cached CSV and
+ * its consumer: `readCachedReport` checks the CSV header against
+ * `metadata.columns` and refuses an incomplete report. Returning null for a
+ * damaged sidecar disabled both checks precisely when a second corruption had
+ * occurred, and said nothing.
+ *
+ * The rebuild draws only on the index entry (authoritative) and the CSV on
+ * disk (re-measured). What came from the API response at download time is left
+ * absent, so these assert on that absence as much as on the values.
+ */
+describe('rebuildReportMetadata (#192)', () => {
+  const captureWarnings = async (fn: () => Promise<unknown>) => {
+    const written: string[] = [];
+    const orig = console.warn;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    console.warn = (...args: any[]) => { written.push(args.map(String).join(' ')); };
+    try {
+      await fn();
+    } finally {
+      console.warn = orig;
+    }
+    return written.join('\n');
+  };
+
+  const damageSidecar = async (reportId: string) => {
+    const p = path.join(tmpRoot, CHANNEL, 'reports', TYPE, `${reportId}.metadata.json`);
+    await fs.writeFile(p, '{"reportId": "trunc', 'utf-8');
+  };
+
+  it('rebuilds from the index entry and the CSV when the sidecar is damaged', async () => {
+    await store(metadataFor({ reportId: 'rb1' }), csvFor(['20260301', '20260302'], '10'));
+    await damageSidecar('rb1');
+
+    let meta: ReportMetadata | null = null;
+    await captureWarnings(async () => {
+      meta = await loadReportMetadata(CHANNEL, 'rb1', TYPE);
+    });
+
+    expect(meta).not.toBeNull();
+    expect(meta!.reportId).toBe('rb1');
+    expect(meta!.channelId).toBe(CHANNEL);
+    expect(meta!.rebuiltAt).toBeTruthy();
+  });
+
+  it('re-measures columns and the actual date range from the CSV', async () => {
+    await store(metadataFor({ reportId: 'rb2' }), csvFor(['20260305', '20260307'], '10'));
+    await damageSidecar('rb2');
+
+    let meta: ReportMetadata | null = null;
+    await captureWarnings(async () => {
+      meta = await loadReportMetadata(CHANNEL, 'rb2', TYPE);
+    });
+    // Measured from the file on disk, not copied from the damaged record.
+    expect(meta!.columns).toEqual(['date', 'channel_id', 'video_id', 'video_thumbnail_impressions']);
+    expect(meta!.startTimeActual).toBe('20260305');
+    expect(meta!.endTimeActual).toBe('20260307');
+  });
+
+  it('leaves jobId, downloadUrl and isComplete absent rather than inventing them', async () => {
+    // The constraint that shapes the whole design: a plausible-looking value
+    // here would turn a detectable gap into an undetectable lie.
+    await store(metadataFor({ reportId: 'rb3' }), csvFor(['20260301'], '10'));
+    await damageSidecar('rb3');
+
+    let meta: ReportMetadata | null = null;
+    await captureWarnings(async () => {
+      meta = await loadReportMetadata(CHANNEL, 'rb3', TYPE);
+    });
+    expect(meta!.jobId).toBeUndefined();
+    expect(meta!.downloadUrl).toBeUndefined();
+    expect(meta!.isComplete).toBeUndefined();
+  });
+
+  it('persists the rebuilt sidecar so the next read is clean', async () => {
+    await store(metadataFor({ reportId: 'rb4' }), csvFor(['20260301'], '10'));
+    await damageSidecar('rb4');
+
+    const first = await captureWarnings(() => loadReportMetadata(CHANNEL, 'rb4', TYPE));
+    expect(first).toContain('rebuilding it');
+
+    // Second read finds a valid file and must not warn again.
+    const second = await captureWarnings(() => loadReportMetadata(CHANNEL, 'rb4', TYPE));
+    expect(second).toBe('');
+  });
+
+  it('reports a damaged sidecar rather than passing it off as absent', async () => {
+    await store(metadataFor({ reportId: 'rb5' }), csvFor(['20260301'], '10'));
+    await damageSidecar('rb5');
+
+    const err = await captureWarnings(() => loadReportMetadata(CHANNEL, 'rb5', TYPE));
+    expect(err).toContain('unreadable');
+    expect(err).toContain('not recorded at download time');
+  });
+
+  it('stays silent and returns null when the sidecar is merely absent', async () => {
+    // The ordinary case for an older or interrupted write. Nothing is wrong,
+    // so nothing is said and no rebuild is attempted.
+    await store(metadataFor({ reportId: 'rb6' }), csvFor(['20260301'], '10'));
+    await fs.rm(path.join(tmpRoot, CHANNEL, 'reports', TYPE, 'rb6.metadata.json'));
+
+    let meta: ReportMetadata | null = null;
+    const err = await captureWarnings(async () => {
+      meta = await loadReportMetadata(CHANNEL, 'rb6', TYPE);
+    });
+    expect(err).toBe('');
+    expect(meta).toBeNull();
+  });
+
+  it('gives up when the report has no index entry to rebuild from', async () => {
+    // A stray CSV and sidecar with nothing authoritative behind them. Half a
+    // record would be worse than none.
+    const dir = path.join(tmpRoot, CHANNEL, 'reports', TYPE);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'orphan.csv'), csvFor(['20260301'], '10'), 'utf-8');
+    await fs.writeFile(path.join(dir, 'orphan.metadata.json'), '{"broken', 'utf-8');
+
+    let meta: ReportMetadata | null = {} as ReportMetadata;
+    const err = await captureWarnings(async () => {
+      meta = await loadReportMetadata(CHANNEL, 'orphan', TYPE);
+    });
+    expect(meta).toBeNull();
+    expect(err).toContain('Rebuild failed');
+  });
+
+  it('gives up when the CSV itself is gone', async () => {
+    await store(metadataFor({ reportId: 'rb7' }), csvFor(['20260301'], '10'));
+    await damageSidecar('rb7');
+    await fs.rm(path.join(tmpRoot, CHANNEL, 'reports', TYPE, 'rb7.csv'));
+
+    let meta: ReportMetadata | null = {} as ReportMetadata;
+    await captureWarnings(async () => {
+      meta = await loadReportMetadata(CHANNEL, 'rb7', TYPE);
+    });
+    expect(meta).toBeNull();
+  });
+
+  it('still serves the CSV through readCachedReport after a rebuild', async () => {
+    // The regression this could easily introduce: isComplete is absent on a
+    // rebuilt record, and a falsiness check would discard the report.
+    await store(metadataFor({ reportId: 'rb8' }), csvFor(['20260301', '20260302'], '42'));
+    await damageSidecar('rb8');
+
+    let report: Awaited<ReturnType<typeof readCachedReport>> = null;
+    await captureWarnings(async () => {
+      report = await readCachedReport(CHANNEL, 'rb8', TYPE);
+    });
+    expect(report).not.toBeNull();
+    expect(report!.data).toHaveLength(2);
+    expect(report!.data[0].video_thumbnail_impressions).toBe('42');
+  });
+
+  it('still refuses a report recorded as incomplete', async () => {
+    // `=== false` must keep rejecting, or the rebuild change would quietly
+    // widen what counts as servable.
+    await store(metadataFor({ reportId: 'rb9', isComplete: false }), csvFor(['20260301'], '10'));
+    expect(await readCachedReport(CHANNEL, 'rb9', TYPE)).toBeNull();
   });
 });

--- a/tests/cache-store.test.ts
+++ b/tests/cache-store.test.ts
@@ -649,6 +649,69 @@ describe('rebuildReportMetadata (#192)', () => {
     expect(report!.data[0].video_thumbnail_impressions).toBe('42');
   });
 
+  it('treats a sidecar that parses but is not a metadata record as damaged', async () => {
+    // `{}` is valid JSON. Accepting it handed readCachedReport a record whose
+    // columns is undefined: it threw on .join(), the surrounding catch turned
+    // that into null, and the report dropped out of every query with its
+    // sidecar left broken. Shape failure has to reach the same repair as a
+    // syntax failure.
+    await store(metadataFor({ reportId: 'sh1' }), csvFor(['20260301'], '10'));
+    const p = path.join(tmpRoot, CHANNEL, 'reports', TYPE, 'sh1.metadata.json');
+    await fs.writeFile(p, '{}', 'utf-8');
+
+    let meta: ReportMetadata | null = null;
+    const err = await captureWarnings(async () => {
+      meta = await loadReportMetadata(CHANNEL, 'sh1', TYPE);
+    });
+    expect(err).toContain('not a metadata record');
+    expect(meta).not.toBeNull();
+    expect(meta!.rebuiltAt).toBeTruthy();
+  });
+
+  it('rebuilds rather than losing the report when the shape is wrong', async () => {
+    // The consequence that made this worth fixing: the CSV is intact and must
+    // still be served.
+    await store(metadataFor({ reportId: 'sh2' }), csvFor(['20260301', '20260302'], '77'));
+    await fs.writeFile(
+      path.join(tmpRoot, CHANNEL, 'reports', TYPE, 'sh2.metadata.json'),
+      '{"reportId":"sh2"}',
+      'utf-8',
+    );
+
+    let report: Awaited<ReturnType<typeof readCachedReport>> = null;
+    await captureWarnings(async () => {
+      report = await readCachedReport(CHANNEL, 'sh2', TYPE);
+    });
+    expect(report).not.toBeNull();
+    expect(report!.data).toHaveLength(2);
+    expect(report!.data[0].video_thumbnail_impressions).toBe('77');
+  });
+
+  it('rejects a sidecar whose optional fields carry the wrong type', async () => {
+    await store(metadataFor({ reportId: 'sh3' }), csvFor(['20260301'], '10'));
+    const p = path.join(tmpRoot, CHANNEL, 'reports', TYPE, 'sh3.metadata.json');
+    const good = JSON.parse(await fs.readFile(p, 'utf-8'));
+    await fs.writeFile(p, JSON.stringify({ ...good, isComplete: 'yes' }), 'utf-8');
+
+    const err = await captureWarnings(() => loadReportMetadata(CHANNEL, 'sh3', TYPE));
+    expect(err).toContain('not a metadata record');
+  });
+
+  it('accepts a well-formed sidecar untouched', async () => {
+    // The guard must not reject valid records, including a rebuilt one whose
+    // jobId, downloadUrl and isComplete are legitimately absent.
+    await store(metadataFor({ reportId: 'sh4' }), csvFor(['20260301'], '10'));
+    const err = await captureWarnings(() => loadReportMetadata(CHANNEL, 'sh4', TYPE));
+    expect(err).toBe('');
+
+    await damageSidecar('sh4');
+    await captureWarnings(() => loadReportMetadata(CHANNEL, 'sh4', TYPE));
+    // Second read of the rebuilt record: it must pass the guard despite the
+    // three absent fields.
+    const second = await captureWarnings(() => loadReportMetadata(CHANNEL, 'sh4', TYPE));
+    expect(second).toBe('');
+  });
+
   it('still refuses a report recorded as incomplete', async () => {
     // `=== false` must keep rejecting, or the rebuild change would quietly
     // widen what counts as servable.

--- a/types/index.ts
+++ b/types/index.ts
@@ -461,7 +461,6 @@ export interface ReportMetadata {
   reportId: string;
   reportTypeId: string;
   channelId: string;          // Channel this report belongs to
-  jobId: string;
   startTime: string;          // From YouTube API
   endTime: string;            // From YouTube API
   createTime?: string;        // Report createTime from the API; orders reissues of the same window
@@ -469,11 +468,30 @@ export interface ReportMetadata {
   endTimeActual: string;      // Actual data range in CSV (parsed)
   downloadedAt: string;       // ISO 8601 timestamp
   expiresAt: string;          // ISO 8601 timestamp
-  downloadUrl: string;        // Original download URL
   columns: string[];          // CSV column names
-  isComplete: boolean;        // Completeness flag
   fileSize: number;
   row_count?: number;
+
+  /**
+   * The three fields below came from the API response at download time and
+   * cannot be recovered from anything on disk. They are optional so that a
+   * sidecar rebuilt by `rebuildReportMetadata` can leave them readably absent
+   * rather than defaulted: a plausible-looking value here would turn a
+   * detectable gap into an undetectable lie.
+   *
+   * Note `isComplete` in particular. Absent means "never recorded", which is
+   * not the same as `false` ("recorded as incomplete"), and consumers must
+   * test it with `=== false` rather than for falsiness.
+   */
+  jobId?: string;
+  downloadUrl?: string;       // Original download URL
+  isComplete?: boolean;       // Completeness flag
+
+  /**
+   * Set only on a sidecar reconstructed after the original was found damaged.
+   * Its absence means the record came from the API response at download time.
+   */
+  rebuiltAt?: string;         // ISO 8601 timestamp
 }
 
 /**


### PR DESCRIPTION
Closes #192. Depends on #195 (merged as `fead2da`), which made absent and damaged distinguishable in the shared loader.

## The problem

A report sidecar is the only thing standing between a corrupted cached CSV and its consumer. `readCachedReport` compares the CSV header against `metadata.columns` and refuses a report recorded as incomplete, but both checks sat behind `if (metadata)`:

```ts
const metadata = await loadReportMetadata(...);
if (metadata) {
  if (parsed.headers.join(',') !== metadata.columns.join(',')) return null;   // skipped
  if (!metadata.isComplete) return null;                                      // skipped
}
return parsed;
```

`loadReportMetadata` returned `null` for a damaged sidecar as readily as for a missing one, so a second corruption disabled the only mechanism that would have caught the first, with no output of any kind.

## The change

**Absent and damaged are now different answers.** `loadReportMetadataResult` returns a discriminated result. Absence is an older or interrupted write, implies nothing about the report, and stays silent. Damage is reported and repaired.

**`rebuildReportMetadata` draws on two sources and no others:**

| source | fields | why it is trustworthy |
|---|---|---|
| index entry | `reportId`, `reportTypeId`, `channelId`, `startTime`, `endTime`, `createTime`, `downloadedAt`, `expiresAt`, `fileSize`, `row_count` | authoritative, and already in memory during any query |
| the CSV on disk | `columns`, `startTimeActual`, `endTimeActual` | re-measured, not inferred |

`jobId`, `downloadUrl` and `isComplete` came from an API response that is gone. They are left **absent**, not defaulted. That constraint shapes the design: a plausible-looking value for any of them would convert a detectable gap into an undetectable lie, which is worse than the current silence. `ReportMetadata` makes the three optional and adds `rebuiltAt` so a reconstructed record is readable as such.

Re-measuring `columns` makes the header check tautological for that one report. That is the honest outcome, and it is stated in the code: the check compares a file against a record of what it was at download time, and once that record is lost it cannot be resurrected, only the current schema recorded afresh.

**A subtle consequence.** Absent `isComplete` is now reachable, so both consumers test `=== false` rather than falsiness. Reading it as falsy would have discarded every rebuilt report, turning a repair into data loss. `fetch-reports --verify` counts rebuilt sidecars separately, since they are neither an issue nor a clean bill of health:

```
Verification complete: 3755 OK, 0 issues, 2 rebuilt (completeness unverifiable)
```

## E2E against the real archive

Run against the real 3757-entry archive, backed up beforehand with a per-file SHA-256 manifest and restored afterwards.

Damaging a real sidecar and re-running the identical `get-report-data` command:

```
Retrieved 4 cached + 0 new report(s)
⚠ Report metadata unreadable, rebuilding it: ... is not valid JSON: JSON Parse error: Unterminated string.
⚠   Rebuilt 20170005867 from the cache index and the CSV on disk.
⚠   Completeness was not recorded at download time and is not inferred.
```

Rows served were **byte-identical** to the pre-damage baseline (13687 bytes), so the repair is invisible to the data path.

Comparing the rebuilt sidecar against the original it replaced:

```
faithfully reproduced (13): channelId, columns, createTime, downloadedAt, endTime,
                            endTimeActual, expiresAt, fileSize, reportId,
                            reportTypeId, row_count, startTime, startTimeActual
differs: none
deliberately not reproduced: downloadUrl, isComplete, jobId
columns match original exactly: True (34 cols)
```

13 of 16 fields exact, zero differing, and exactly the three unrecoverable ones absent.

**Restore proof.** All 7520 files re-checksummed after testing and compared against the pre-test manifest. The four deliberately corrupted files (`config.json`, `credentials.json`, `cache-index.json`, the sidecar) each restored byte-identical, and the 833KB baseline report reproduces with an identical SHA-256.

`fetch-reports --verify` was **not** run live: it executes after the download pass, so exercising it against the real archive would spend quota and mutate the archive. Its counter change is covered by the code path and the unit tests instead. That gating is arguably worth its own issue, since there is currently no way to verify an archive without also downloading into it.

## Checks

`type-check` clean, `lint` 0 errors (4 pre-existing `any` warnings in `commands/mcp.ts`), **274 tests** (264 to 274). Ten new cases cover the rebuild, the deliberate absences, persistence so the second read is clean, silence on a merely absent sidecar, both give-up paths (no index entry, missing CSV), that `readCachedReport` still serves after a rebuild, and that a report recorded as incomplete is still refused.

Docs updated: `docs/commands/reporting-api.md` explains what a rebuilt sidecar is, why completeness cannot be confirmed for one, and that `--force` restores a full record.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Damaged report metadata can now be reconstructed from locally cached report data.
  - Reconstructed reports remain available for normal use, with recovered date and report details.

- **Bug Fixes**
  - Verification no longer incorrectly marks reports with missing completeness information as corrupted.
  - Reconstructed reports are counted separately from verified and corrupted reports.

- **Documentation**
  - Added guidance on rebuilt metadata, verification output, and restoring complete metadata by re-downloading reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->