### PR TITLE
fix(#197): stop reporting transport failures as verdicts about the request

### DIFF
--- a/docs/commands/configuration.md
+++ b/docs/commands/configuration.md
@@ -47,7 +47,10 @@ The CLI requires these scopes:
 - Access tokens expire after 1 hour
 - Refresh tokens are long-lived
 - CLI automatically refreshes expired tokens
-- If refresh fails, re-run `staqan-yt auth`
+- If refresh fails, read the message before acting: only `invalid_grant` means
+  the credentials are dead and need `staqan-yt auth`. A "Could not reach
+  Google" message is a network problem, and the saved credentials are still
+  valid.
 
 ### Authentication Issues
 

--- a/docs/commands/configuration.md
+++ b/docs/commands/configuration.md
@@ -61,9 +61,10 @@ mkdir -p ~/.staqan-yt-cli
 cp ~/Downloads/client_secret_*.json ~/.staqan-yt-cli/credentials.json
 ```
 
-**"Failed to refresh token":**
+**Token refresh failures:** re-authenticate only when the message says
+`invalid_grant`. A "Could not reach Google" message is a network problem and
+the saved credentials are still valid.
 ```bash
-# Re-authenticate
 staqan-yt auth
 ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -256,11 +256,17 @@ Access tokens expire after 1 hour. The CLI automatically:
 - Uses the refresh token to get a new access token
 - Updates `~/.staqan-yt-cli/token.json` automatically
 
-If you see authentication errors, simply re-run:
+If a refresh fails, read the message before acting. Only `invalid_grant` means
+the saved credentials are dead and need a new sign-in:
 
 ```bash
 staqan-yt auth
 ```
+
+A "Could not reach Google" message is a network problem, and `invalid_client`
+points at `~/.staqan-yt-cli/credentials.json` rather than the session. Neither
+is fixed by re-authenticating. See
+[Token refresh failures](troubleshooting.md#token-refresh-failures).
 
 ## Verification
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -380,15 +380,18 @@ cp ~/Downloads/client_secret_*.json ~/.staqan-yt-cli/credentials.json
 staqan-yt auth
 ```
 
-### "Failed to refresh token" Error
+### Token refresh failures
 
-**Problem:** Your refresh token has expired.
+**Problem:** Only `invalid_grant` means the refresh token is actually dead. A
+"Could not reach Google" message is a network problem and leaves the saved
+credentials valid, so re-authenticating would discard a working session.
 
-**Solution:**
+**Solution:** for `invalid_grant` only:
 ```bash
-# Re-authenticate
 staqan-yt auth
 ```
+
+See [Troubleshooting](troubleshooting.md#token-refresh-failures).
 
 ### Browser doesn't open
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -387,6 +387,7 @@ staqan-yt auth
 credentials valid, so re-authenticating would discard a working session.
 
 **Solution:** for `invalid_grant` only:
+
 ```bash
 staqan-yt auth
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,9 +113,10 @@ re-authenticating.
 **Refresh token rejected (`invalid_grant`).** The credentials really are dead:
 revoked, expired, or invalidated by an account password change.
 
-```
+```text
 ✗ Refresh token rejected by Google (invalid_grant): ...
 ```
+
 ```bash
 staqan-yt auth
 ```
@@ -123,7 +124,7 @@ staqan-yt auth
 **Could not reach Google.** A dropped connection, a proxy, or a Google 5xx. The
 saved credentials are untouched and still valid.
 
-```
+```text
 ✗ Could not reach Google to refresh the access token: ...
   The saved credentials are still valid, so this does not need a re-authentication.
 ```
@@ -134,7 +135,7 @@ connectivity and retry.
 **Anything else.** The underlying error is quoted, along with the OAuth error
 code when the token endpoint supplied one.
 
-```
+```text
 ✗ Failed to refresh the access token: <detail> (<oauth_error>)
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,19 +105,37 @@ staqan-yt auth
 
 ---
 
-### "Failed to refresh token"
+### Token refresh failures
 
-**Symptom:**
+The message distinguishes three causes, because only one of them is fixed by
+re-authenticating.
+
+**Refresh token rejected (`invalid_grant`).** The credentials really are dead:
+revoked, expired, or invalidated by an account password change.
+
 ```
-Error: Failed to refresh access token
+✗ Refresh token rejected by Google (invalid_grant): ...
 ```
-
-**Cause:** Refresh token has expired or is invalid.
-
-**Solution:**
 ```bash
-# Re-authenticate
 staqan-yt auth
+```
+
+**Could not reach Google.** A dropped connection, a proxy, or a Google 5xx. The
+saved credentials are untouched and still valid.
+
+```
+✗ Could not reach Google to refresh the access token: ...
+  The saved credentials are still valid, so this does not need a re-authentication.
+```
+
+Re-authenticating here would discard a working session for no reason. Check
+connectivity and retry.
+
+**Anything else.** The underlying error is quoted, along with the OAuth error
+code when the token endpoint supplied one.
+
+```
+✗ Failed to refresh the access token: <detail> (<oauth_error>)
 ```
 
 ---
@@ -629,7 +647,8 @@ curl https://www.googleapis.com/youtube/v3/search?key=YOUR_API_KEY&q=test
 | `Channel not found` | Invalid channel handle/ID | Verify channel exists and is public |
 | `Video not found` | Invalid video ID | Verify video ID (11 characters) |
 | `Invalid credentials` | Wrong OAuth credentials | Re-create credentials file |
-| `Failed to refresh token` | Token expired | Run `staqan-yt auth` |
+| `Refresh token rejected ... (invalid_grant)` | Credentials revoked or expired | Run `staqan-yt auth` |
+| `Could not reach Google to refresh ...` | Network or Google 5xx | Retry; credentials are still valid |
 | `Invalid output format` | Wrong format specified | Use: json, csv, table, text, pretty |
 
 ---

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -11,6 +11,8 @@ import {
   ensureConfigDir,
   info,
   loadJsonIfPresent,
+  isTransportFailure,
+  getOAuthErrorCode,
 } from './utils';
 import { OAuth2Credentials, OAuth2Token } from '../types';
 
@@ -125,8 +127,34 @@ async function getAuthenticatedClient(): Promise<OAuth2Client> {
       const { credentials } = await oauth2Client.refreshAccessToken();
       await saveToken(credentials as OAuth2Token);
       oauth2Client.setCredentials(credentials);
-    } catch {
-      throw new Error('Failed to refresh token. Please re-authenticate: staqan-yt auth');
+    } catch (err) {
+      // Only `invalid_grant` means the saved credentials are actually dead.
+      // A bare catch here prescribed a full re-auth for a dropped connection
+      // or a Google 5xx as well, which throws away a working session in
+      // response to a network blip (#197).
+      const oauthError = getOAuthErrorCode(err);
+      const detail = (err as Error).message;
+
+      if (oauthError === 'invalid_grant') {
+        throw new Error(
+          'Refresh token rejected by Google (invalid_grant): it has been revoked, ' +
+          'expired, or the account password changed. Please re-authenticate: staqan-yt auth'
+        );
+      }
+
+      if (isTransportFailure(err)) {
+        throw new Error(
+          `Could not reach Google to refresh the access token: ${detail}. ` +
+          'The saved credentials are still valid, so this does not need a re-authentication. ' +
+          'Retry once connectivity is restored.'
+        );
+      }
+
+      throw new Error(
+        `Failed to refresh the access token: ${detail}` +
+        (oauthError ? ` (${oauthError})` : '') +
+        '. If this persists, re-authenticate: staqan-yt auth'
+      );
     }
   }
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -150,10 +150,18 @@ async function getAuthenticatedClient(): Promise<OAuth2Client> {
         );
       }
 
+      // Still not a reason to prescribe a re-auth. Google reports a dead
+      // refresh token as invalid_grant, handled above, so anything reaching
+      // here left the saved session intact. invalid_client in particular is
+      // about the OAuth client in credentials.json, which re-running auth
+      // cannot repair.
+      const hint = oauthError === 'invalid_client'
+        ? ` The OAuth client in ${CREDENTIALS_PATH} was rejected, and re-authenticating will not repair that.`
+        : ' The saved refresh token was not rejected, so re-authenticating is unlikely to help.';
+
       throw new Error(
         `Failed to refresh the access token: ${detail}` +
-        (oauthError ? ` (${oauthError})` : '') +
-        '. If this persists, re-authenticate: staqan-yt auth'
+        (oauthError ? ` (${oauthError})` : '') + '.' + hint
       );
     }
   }

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -161,15 +161,14 @@ export function detectShell(): ShellType {
     if (shell.includes('bash')) return 'bash';
   }
 
-  // Try to detect using ps
-  try {
-    const psOutput = execSync('ps -p $$ -o comm=', { encoding: 'utf-8' }).trim();
-    if (psOutput.includes('zsh')) return 'zsh';
-    if (psOutput.includes('bash')) return 'bash';
-  } catch {
-    // Ignore error
-  }
-
+  // A `ps -p $$ -o comm=` probe used to sit here. It could never work:
+  // execSync runs the command through /bin/sh, so `$$` expanded to that
+  // subshell rather than the invoking shell and the output was always "ps".
+  // Neither branch could match, so the probe was dead code that always fell
+  // through to the default below (#197). Detecting the real parent process
+  // would need process.ppid, which is a different change; removing the
+  // pretence is behaviour-identical and honest about what is known.
+  //
   // Default to zsh (default on macOS since Catalina)
   return 'zsh';
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -647,6 +647,48 @@ function getErrorReasons(err: unknown): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Whether a failure is transport-level: the request never got a verdict.
+ *
+ * A dropped connection, a DNS failure or a server-side 5xx says nothing about
+ * the request that was made, so a caller must not report it as a problem with
+ * the request's contents. Reuses the same sets `classifyRetryableError` uses,
+ * so the two cannot drift.
+ */
+export function isTransportFailure(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+
+  // A response arrived, so the server reached a verdict. Only its own 5xx
+  // class counts as transport; 401/403/429 are answers about the request.
+  const status = getErrorStatus(err);
+  if (status !== undefined) return TRANSIENT_STATUSES.has(status);
+
+  const code = (err as NodeJS.ErrnoException).code;
+  if (typeof code !== 'string') return false;
+  if (RETRIABLE_NETWORK_CODES.has(code)) return true;
+
+  // The errno names are runtime-specific: measured, Bun reports
+  // `ConnectionRefused` where Node reports `ECONNREFUSED`, so enumerating them
+  // would silently rot. What holds either way is that a request carrying a
+  // gaxios `config` but no `response` was sent and never got a verdict.
+  // Requiring `config` keeps unrelated coded errors, an ENOENT off the
+  // filesystem for instance, from being reported as a network problem.
+  const e = err as { config?: unknown; response?: unknown };
+  return e.config !== undefined && e.response === undefined;
+}
+
+/**
+ * The OAuth token endpoint's machine-readable error code, if the failure came
+ * from one. `invalid_grant` is the only verdict that actually means the saved
+ * credentials are dead; everything else leaves them usable.
+ */
+export function getOAuthErrorCode(err: unknown): string | undefined {
+  const data = (err as { response?: { data?: unknown } } | undefined)?.response?.data;
+  if (!data || typeof data !== 'object') return undefined;
+  const code = (data as { error?: unknown }).error;
+  return typeof code === 'string' ? code : undefined;
+}
+
 /** Collect every message string an API error might carry. */
 function collectErrorMessages(err: unknown): string[] {
   if (!err || typeof err !== 'object') return [];
@@ -879,8 +921,12 @@ async function withRateLimitRetry<T>(
 function getLocalTimeZone(): string {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
-  } catch {
-    // Fallback to UTC if timezone detection fails
+  } catch (err) {
+    // Near-theoretical: a runtime without full ICU resolves timeZone to "UTC"
+    // rather than throwing, so UTC is the right answer either way. Named under
+    // -v so a surprising timezone in the output has something to point at,
+    // instead of every timestamp silently shifting (#197).
+    debug(`Timezone detection failed, using UTC: ${(err as Error).message}`);
     return 'UTC';
   }
 }

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -32,7 +32,7 @@ export function getVersion(): string {
       if ((err as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
         process.emitWarning(
           `Ignoring unreadable ${rel}: ${(err as Error).message}`,
-          'StaqanVersionWarning'
+          { type: 'StaqanVersionWarning' }
         );
       }
     }

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -23,8 +23,18 @@ export function getVersion(): string {
       if (packageJson?.name === 'staqan-yt-cli' && packageJson.version) {
         return packageJson.version;
       }
-    } catch {
-      // try next layout
+    } catch (err) {
+      // MODULE_NOT_FOUND is the expected miss: exactly one candidate resolves
+      // per layout and the other cannot exist. Anything else means the file is
+      // there and unusable, such as a syntax error in the correct
+      // package.json, which would otherwise be indistinguishable from the
+      // wrong layout and silently yield FALLBACK_VERSION (#197).
+      if ((err as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
+        process.emitWarning(
+          `Ignoring unreadable ${rel}: ${(err as Error).message}`,
+          'StaqanVersionWarning'
+        );
+      }
     }
   }
   return FALLBACK_VERSION;

--- a/lib/youtube.ts
+++ b/lib/youtube.ts
@@ -207,30 +207,35 @@ async function getChannelId(handleOrId: string): Promise<string> {
       debug(`Found channel ID: ${channelId}`);
     }
   } else {
-    // Try to get channel directly by ID
-    try {
-      const response = await youtube.channels.list({
-        part: ['id'],
-        id: [handleOrId],
-      });
+    // Try to get channel directly by ID.
+    //
+    // Deliberately uncaught. The miss this lookup is allowed to have is "that
+    // string is not a channel ID", and the API expresses that as HTTP 200 with
+    // an empty `items`, not as an exception: measured, `channels.list({ id })`
+    // returns 200 for garbage input such as `not an id!!`. The empty-items
+    // check below already handles it. So a throw here is a 401, 403, 429 or a
+    // network failure, none of which say anything about the identifier, and
+    // swallowing them spent an extra quota unit on a `forUsername` lookup that
+    // was always going to fail too (#197).
+    const idResponse = await youtube.channels.list({
+      part: ['id'],
+      id: [handleOrId],
+    });
 
-      if (response.data.items && response.data.items.length > 0) {
-        channelId = response.data.items[0].id!;
-      }
-    } catch {
-      // Continue to legacy username lookup
+    if (idResponse.data.items && idResponse.data.items.length > 0) {
+      channelId = idResponse.data.items[0].id!;
     }
 
     // Fall back to legacy YouTube username (youtube.com/user/<name>) —
     // also an exact 1-unit lookup, unlike the search.list fallback it replaces
     if (!channelId) {
-      const response = await youtube.channels.list({
+      const usernameResponse = await youtube.channels.list({
         part: ['id'],
         forUsername: handleOrId,
       });
 
-      if (response.data.items && response.data.items.length > 0) {
-        channelId = response.data.items[0].id!;
+      if (usernameResponse.data.items && usernameResponse.data.items.length > 0) {
+        channelId = usernameResponse.data.items[0].id!;
       }
     }
   }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -17,6 +17,8 @@ import {
   retryPolicyFor,
   withRateLimitRetry,
   getRetryAfterMs,
+  isTransportFailure,
+  getOAuthErrorCode,
 } from '../lib/utils';
 
 describe('parseVideoId', () => {
@@ -399,5 +401,98 @@ describe('retryPolicyFor', () => {
 
   it('matches the constants the download path now shares', () => {
     expect(retryPolicyFor('transient')).toMatchObject({ baseDelayMs: 2_000, maxDelayMs: 60_000 });
+  });
+});
+
+/**
+ * Telling a transport failure apart from a verdict (#197).
+ *
+ * These back the token-refresh catch in lib/auth.ts, which used to answer a
+ * dropped connection and a revoked refresh token with the same instruction to
+ * re-authenticate. Acting on that advice discards a working session because
+ * the network blipped, so the classification has to be exact in both
+ * directions: a real credential failure must still say so.
+ */
+describe('isTransportFailure', () => {
+  it('recognises the network errno codes', () => {
+    for (const code of ['ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN', 'ECONNREFUSED', 'ESOCKETTIMEDOUT', 'EPIPE']) {
+      expect(isTransportFailure(Object.assign(new Error('boom'), { code }))).toBe(true);
+    }
+  });
+
+  it('recognises server-side statuses in the shapes googleapis uses', () => {
+    expect(isTransportFailure({ status: 503 })).toBe(true);
+    expect(isTransportFailure({ response: { status: 500 } })).toBe(true);
+    expect(isTransportFailure({ statusCode: 502 })).toBe(true);
+    expect(isTransportFailure({ status: 408 })).toBe(true);
+  });
+
+  it('does not claim client-side verdicts as transport failures', () => {
+    // The distinction that matters: these are answers, not failures to reach
+    // an answer, so they must not be reported as "retry when the network is
+    // back".
+    expect(isTransportFailure({ status: 400 })).toBe(false);
+    expect(isTransportFailure({ status: 401 })).toBe(false);
+    expect(isTransportFailure({ status: 403 })).toBe(false);
+    expect(isTransportFailure({ status: 404 })).toBe(false);
+    expect(isTransportFailure({ status: 429 })).toBe(false);
+  });
+
+  it('recognises a connection failure whose errno name is runtime-specific', () => {
+    // Measured: Bun reports `ConnectionRefused` where Node reports
+    // `ECONNREFUSED`, so the set of names cannot be the only signal. What
+    // holds either way is that no response arrived.
+    // `config` present with no `response` is the shape gaxios produces for a
+    // request that was sent and never answered.
+    expect(isTransportFailure({ code: 'ConnectionRefused', config: {}, response: undefined })).toBe(true);
+    expect(isTransportFailure({ code: 'ConnectionClosed', config: {} })).toBe(true);
+    expect(isTransportFailure({ code: 'SomeFutureBunName', config: {} })).toBe(true);
+  });
+
+  it('does not claim a coded error that never made a request', () => {
+    // No gaxios config, so nothing was sent. A filesystem errno reaching this
+    // helper must not be reported as a network problem.
+    expect(isTransportFailure({ code: 'ConnectionRefused' })).toBe(false);
+    expect(isTransportFailure(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(false);
+  });
+
+  it('does not treat a server verdict as transport just because the code is a string', () => {
+    // A response arrived, so the server answered. googleapis puts the status
+    // in `code` here, which must not be read as an errno.
+    expect(isTransportFailure({ code: 'x', response: { status: 401, data: {} } })).toBe(false);
+    expect(isTransportFailure({ code: 401, response: { status: 401 } })).toBe(false);
+  });
+
+  it('is safe on values that are not errors', () => {
+    expect(isTransportFailure(undefined)).toBe(false);
+    expect(isTransportFailure(null)).toBe(false);
+    expect(isTransportFailure('ECONNRESET')).toBe(false);
+    expect(isTransportFailure(new Error('no code'))).toBe(false);
+  });
+
+  it('does not treat an unrelated errno as transport', () => {
+    expect(isTransportFailure(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(false);
+  });
+});
+
+describe('getOAuthErrorCode', () => {
+  it('reads the token endpoint error code', () => {
+    expect(getOAuthErrorCode({ response: { data: { error: 'invalid_grant' } } })).toBe('invalid_grant');
+    expect(getOAuthErrorCode({ response: { data: { error: 'invalid_client' } } })).toBe('invalid_client');
+  });
+
+  it('returns undefined when there is no OAuth verdict to read', () => {
+    // A network failure carries no response body, which is exactly the case
+    // that must not be mistaken for a dead refresh token.
+    expect(getOAuthErrorCode(Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }))).toBeUndefined();
+    expect(getOAuthErrorCode({ response: {} })).toBeUndefined();
+    expect(getOAuthErrorCode({})).toBeUndefined();
+    expect(getOAuthErrorCode(null)).toBeUndefined();
+  });
+
+  it('ignores a non-string error field', () => {
+    // The Data API nests an object under `error`; only the OAuth token
+    // endpoint puts a bare string there.
+    expect(getOAuthErrorCode({ response: { data: { error: { message: 'nope' } } } })).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #197. Third of the four in the #194 family, after #195 (`fead2da`) and #192 (`7283915`).

## The genre

Five sites were structured as "try this, and if it does not work do something else", so a genuine failure of the first branch was indistinguishable from that branch simply not applying. The fix in each case is to say which of the two happened.

## `lib/auth.ts`: the one with a real cost

A bare catch around `refreshAccessToken()` answered a dropped connection, a Google 5xx and a revoked refresh token with one message prescribing a full re-authentication. Measured against the built CLI with an expired token, varying only connectivity:

| | message |
|---|---|
| **main**, network blocked | `Failed to refresh token. Please re-authenticate: staqan-yt auth` |
| **main**, server verdict | `Failed to refresh token. Please re-authenticate: staqan-yt auth` |
| **now**, network blocked | `Could not reach Google to refresh the access token: ... The saved credentials are still valid, so this does not need a re-authentication.` |
| **now**, server verdict | `Failed to refresh the access token: invalid_client (invalid_client)` |

On `main` the two are byte-identical. Acting on that advice discards a working session because the network blipped. Only `invalid_grant` now reports the credentials as dead.

### Why the classifier is shaped the way it is

`isTransportFailure` and `getOAuthErrorCode` live in `lib/utils.ts` and reuse the sets `classifyRetryableError` already owns, so the two cannot drift.

The first attempt at this failed its own E2E, which is worth recording: the POSIX errno list did not match. Measured, **Bun reports `ConnectionRefused` where Node reports `ECONNREFUSED`**, so enumerating names would silently rot as either runtime changes. What holds either way:

```
network blocked   : code="ConnectionRefused"  response=undefined
network reachable : code=401                  response=present status=401 data={"error":"invalid_client",...}
```

A request that carries a gaxios `config` but no `response` was sent and never got a verdict. Requiring `config` as well keeps an unrelated coded error, an `ENOENT` off the filesystem for instance, from being reported as a network problem. A 5xx still counts as transport even though a response arrived; 401/403/429 do not, because those are answers about the request.

## `lib/youtube.ts`: a catch with no legitimate trigger

The `try`/`catch` around `channels.list({ id })` existed to absorb "that string is not a channel ID", but the API expresses that as HTTP 200 with empty `items`, never as an exception, and the empty-items check below already handled it. So every exception it swallowed was genuine, and swallowing one cost a second `forUsername` lookup that was always going to fail too.

Measured by counting outbound connection attempts for the identical command against a blocked network:

```
main : CONNECTION_ATTEMPTS=6
now  : CONNECTION_ATTEMPTS=3
```

Behaviour on a real miss is unchanged: `Channel not found: zzz-not-a-real-channel-probe. Pass an @handle or a UC… channel ID.` on both.

## The rest

**`lib/version.ts`** separates `MODULE_NOT_FOUND`, which is the expected miss since exactly one candidate layout can resolve, from a parse error in the correct `package.json`, which previously yielded `FALLBACK_VERSION` in silence. Uses `process.emitWarning` rather than the `debug` helper to avoid an import cycle, since `lib/utils.ts` is a heavier module and `version.ts` is deliberately standalone.

**`lib/completion.ts`** drops a probe that could never work. `execSync('ps -p $$ -o comm=')` runs through `/bin/sh`, so `$$` expanded to that subshell and the output was always `"ps"`:

```
$ node -e "...execSync('ps -p $$ -o comm=')..."   ->  "ps"
```

Neither `includes('zsh')` nor `includes('bash')` could ever match, so the probe was dead code that always fell through to the `'zsh'` default. Removing it is behaviour-identical and honest about what is known. Reading the real parent process would need `process.ppid`, which is a different change.

**`lib/utils.ts`** names the `Intl` timezone fallback under `-v`, so a surprising timezone has something to point at.

**`lib/auth.ts:160` left alone.** Iterating redirect URIs and skipping malformed entries is exactly what that catch is for, as the issue notes.

## Verification

E2E against the built CLI, with a fabricated credentials file under a fake `HOME` so no real secrets were copied and the real token was never touched:

- network blocked and reachable, on `main` and on this branch (table above)
- **no regression on the happy path**: `list-videos --channel @staqan --limit 2` against real credentials still returns `Found 2 video(s)`
- `version` still reports `2.1.1`, so the `version.ts` change did not disturb resolution
- a bare non-`@`, non-`UC` name still reports not-found identically on both builds

`type-check` clean, `lint` 0 errors (4 pre-existing `any` warnings in `commands/mcp.ts`), **289 tests** (278 to 289). New coverage pins both classifiers in both directions, including that a client-side 401/403/429 is not called transport and that a coded error which never made a request is not either.

Docs corrected in `troubleshooting.md`, `setup.md` and `commands/configuration.md`, all three of which told the reader to re-authenticate for any refresh failure.

## Follow-up spotted, not fixed here

`classifyRetryableError` matches only the POSIX errno names, so under Bun a genuine `ConnectionRefused` is not classified `transient` and `withRateLimitRetry` will not retry it. That is a different defect, in retry behaviour rather than in reporting, and it deserves its own change with its own testing rather than being folded in here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error messages by distinguishing expired or revoked credentials from temporary network and service failures.
  * Preserved valid saved credentials during network-related token refresh failures, avoiding unnecessary re-authentication.
  * Improved error reporting for version information and channel lookup failures.
  * Shell detection now avoids an ineffective system probe.

* **Documentation**
  * Updated setup and troubleshooting guidance with clearer, error-specific token refresh recovery steps.

* **Tests**
  * Added coverage for network failure classification and OAuth error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->