### PR TITLE
fix(#196): narrow best-effort cleanup catches to the errno they document

### DIFF
--- a/commands/cache.ts
+++ b/commands/cache.ts
@@ -46,6 +46,12 @@ async function cacheCommand(action?: string, options: CacheOptions = {}): Promis
       path.join(CACHE_DIR, 'handle-to-channel-id.json'),
     ];
 
+    // Anything that stopped a file being removed. This command's entire output
+    // is a claim about work done, so a failure must not be folded into the
+    // count. A swallowed EACCES used to print "Nothing to clean" with exit 0
+    // while every file was still on disk.
+    const failures: string[] = [];
+
     // Per-channel completion caches: cache/{channelId}/completion_cache.json
     try {
       const entries = await fs.readdir(CACHE_DIR, { withFileTypes: true });
@@ -54,8 +60,14 @@ async function cacheCommand(action?: string, options: CacheOptions = {}): Promis
           targets.push(path.join(CACHE_DIR, entry.name, 'completion_cache.json'));
         }
       }
-    } catch {
-      // cache/ may not exist yet — nothing to clean
+    } catch (err) {
+      // ENOENT means cache/ was never created, so there is nothing per-channel
+      // to enumerate. Any other error means the per-channel caches may exist
+      // and we cannot see them, so we still clean the global targets below but
+      // must not claim the cache is now empty.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        failures.push(`${CACHE_DIR}: cannot list per-channel caches: ${(err as Error).message}`);
+      }
     }
 
     let removed = 0;
@@ -63,9 +75,23 @@ async function cacheCommand(action?: string, options: CacheOptions = {}): Promis
       try {
         await fs.unlink(target);
         removed++;
-      } catch {
-        // File doesn't exist — skip silently
+      } catch (err) {
+        // Already gone is the outcome we wanted; it just does not count as
+        // work done. Anything else leaves the file in place.
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        failures.push(`${target}: ${(err as Error).message}`);
       }
+    }
+
+    if (failures.length > 0) {
+      if (removed > 0) {
+        info(`Cleared ${removed} cache file(s) before failing`);
+      }
+      throw new Error(
+        `Could not clear ${failures.length} cache location(s):\n` +
+        failures.map(f => `  ${f}`).join('\n') +
+        `\nFix the permissions on the paths above and run again.`
+      );
     }
 
     if (removed === 0) {

--- a/commands/config.ts
+++ b/commands/config.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { getConfig, getConfigValue, setConfigValue, getOutputFormat, DEFAULT_LOCK_TIMEOUT_MS } from '../lib/config';
-import { success, info, CACHE_DIR, writeStdout } from '../lib/utils';
+import { success, info, warning, CACHE_DIR, writeStdout, unlinkIfPresent } from '../lib/utils';
 import { formatData } from '../lib/formatters';
 import { ConfigKey, CONFIG_KEYS, CONFIG_KEY_HELP, OutputFormat } from '../types';
 import { installCompletion, detectShell } from '../lib/completion';
@@ -14,16 +14,38 @@ function availableConfigKeysHelp(): string {
 async function invalidateChannelCache(): Promise<void> {
   // Per-channel completion caches (video-id, playlist-id) are channel-specific.
   // When the default channel changes, wipe them all so stale IDs aren't suggested.
+  //
+  // This runs after the new channel has already been written, so a failure here
+  // must not be reported as the setting having failed. It also must not be
+  // silent: the surviving cache will keep offering the previous channel's IDs
+  // until it is removed by hand.
+  const failures: string[] = [];
+
   try {
     const entries = await fs.readdir(CACHE_DIR, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.isDirectory()) {
         const cachePath = path.join(CACHE_DIR, entry.name, 'completion_cache.json');
-        await fs.unlink(cachePath).catch(() => {});
+        try {
+          await unlinkIfPresent(cachePath);
+        } catch (err) {
+          failures.push(`${cachePath}: ${(err as Error).message}`);
+        }
       }
     }
-  } catch {
-    // cache/ may not exist yet — ignore
+  } catch (err) {
+    // ENOENT means cache/ was never created, so there is nothing to invalidate.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      failures.push(`${CACHE_DIR}: cannot list per-channel caches: ${(err as Error).message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    warning(
+      `Default channel updated, but ${failures.length} stale completion cache(s) could not be removed:\n` +
+      failures.map(f => `  ${f}`).join('\n') +
+      `\nTab completion may suggest the previous channel's IDs until you run: staqan-yt cache clean`
+    );
   }
 }
 

--- a/commands/download-thumbnail.ts
+++ b/commands/download-thumbnail.ts
@@ -54,7 +54,13 @@ async function downloadFile(url: string, destPath: string): Promise<void> {
 
     await rename(tempPath, destPath);
   } catch (err) {
-    await unlink(tempPath).catch(() => {});
+    // Roll back the partial file, then rethrow the original error. The cleanup
+    // must not mask what actually went wrong, so its own failure is recorded
+    // at debug level rather than thrown (issue #196).
+    await unlink(tempPath).catch((unlinkErr: NodeJS.ErrnoException) => {
+      if (unlinkErr.code === 'ENOENT') return;
+      debug(`Could not remove partial thumbnail ${tempPath}: ${unlinkErr.message}`);
+    });
     throw err;
   }
 }

--- a/commands/mcp.ts
+++ b/commands/mcp.ts
@@ -22,7 +22,7 @@ import {
 } from '../lib/youtube';
 import { getAuthenticatedClient } from '../lib/auth';
 import { google } from 'googleapis';
-import { parseVideoId, initCommand, toLocalYmd, validateDateOption } from '../lib/utils';
+import { parseVideoId, initCommand, toLocalYmd, validateDateOption, debug } from '../lib/utils';
 import { fetchVideoAnalytics, fetchTrafficSources, fetchSearchTerms, fetchVideoRetention, fetchChannelAnalytics, fetchChannelSearchTerms, ALL_TIME_START_DATE } from '../lib/analytics';
 import { fetchReportTypes, fetchReportJobs, fetchReportData } from '../lib/reports';
 import { requireChannel } from '../lib/config';
@@ -1023,7 +1023,13 @@ async function handleToolCall(name: string, args: any) {
           await writeFile(tempDest, imageBytes);
           await rename(tempDest, dest);
         } catch (err) {
-          await unlink(tempDest).catch(() => {});
+          // Roll back the partial file, then rethrow the original error. The
+          // cleanup must not mask what actually went wrong, so its own failure
+          // is recorded at debug level rather than thrown (issue #196).
+          await unlink(tempDest).catch((unlinkErr: NodeJS.ErrnoException) => {
+            if (unlinkErr.code === 'ENOENT') return;
+            debug(`Could not remove partial thumbnail ${tempDest}: ${unlinkErr.message}`);
+          });
           throw err;
         }
         const note = resolvedQuality !== requestedQuality

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,6 +9,7 @@ import {
   CREDENTIALS_PATH,
   TOKEN_PATH,
   ensureConfigDir,
+  debug,
   info,
   loadJsonIfPresent,
   isTransportFailure,
@@ -188,8 +189,12 @@ function getRedirectHost(credentials: OAuth2Credentials | null): string {
       if (hostname === '127.0.0.1' || hostname === 'localhost') {
         return hostname;
       }
-    } catch {
-      // Ignore malformed redirect URI entries.
+    } catch (err) {
+      // A redirect_uris entry that does not parse is skipped rather than fatal:
+      // a later entry may still be usable, and the 'localhost' default below is
+      // correct for the common single-entry case. Record which entry was bad so
+      // a misconfigured credentials.json is diagnosable under --verbose.
+      debug(`Ignoring malformed redirect URI ${JSON.stringify(uri)}: ${(err as Error).message}`);
     }
   }
   return 'localhost';

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
-import { CONFIG_DIR, debug, warning, loadJsonIfPresent } from './utils';
+import { CONFIG_DIR, debug, warning, loadJsonIfPresent, unlinkIfPresent } from './utils';
 import { CacheIndex, CacheIndexEntry, ReportMetadata, CacheCoverage } from '../types';
 
 // Base data directory
@@ -641,17 +641,12 @@ export async function deleteReportFromCache(
 ): Promise<void> {
   const { csv: csvPath, metadata: metadataPath } = getReportPaths(channelId, reportId, reportTypeId);
 
-  try {
-    await fs.unlink(csvPath);
-  } catch {
-    // Ignore if file doesn't exist
-  }
-
-  try {
-    await fs.unlink(metadataPath);
-  } catch {
-    // Ignore if file doesn't exist
-  }
+  // Either file already being gone is fine. Anything else leaves the payload on
+  // disk, and dropping the index entry below would orphan it: the archive would
+  // still hold the bytes while nothing could find or re-download them. Throw
+  // before the index is touched so the two stay consistent.
+  await unlinkIfPresent(csvPath);
+  await unlinkIfPresent(metadataPath);
 
   await removeCacheEntry(channelId, reportId);
   debug(`Deleted report from cache: ${reportId}`);

--- a/lib/completion.ts
+++ b/lib/completion.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { execSync } from 'child_process';
-import { success, error } from './utils';
+import { success, error, debug } from './utils';
 
 export type ShellType = 'bash' | 'zsh' | 'auto';
 
@@ -188,8 +188,10 @@ export function getCompletionPath(shell: 'bash' | 'zsh'): string {
     if (!brewPrefix) {
       try {
         brewPrefix = execSync('brew --prefix', { encoding: 'utf-8' }).trim();
-      } catch {
-        // Homebrew not found, use user directory
+      } catch (err) {
+        // Homebrew not installed, or `brew` not on PATH. Expected on a plain
+        // zsh install; the user-directory fallback below is the right answer.
+        debug(`brew --prefix unavailable, using the user completion directory: ${(err as Error).message}`);
       }
     }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -33,14 +33,16 @@ const DEFAULT_CONFIG: Config = {
 };
 
 /**
- * Ensure config directory exists
+ * Ensure config directory exists.
+ *
+ * Note: mkdir with { recursive: true } is idempotent: it succeeds if the
+ * directory already exists, so we call it directly without an access probe.
+ * This avoids the TOCTOU window and is more efficient. Matches `ensureCacheDir`
+ * in lib/cache.ts. A real failure (EACCES, ENOTDIR) propagates, which is what
+ * `saveConfig` needs before it writes.
  */
 async function ensureConfigDir(): Promise<void> {
-  try {
-    await fs.access(CONFIG_DIR);
-  } catch {
-    await fs.mkdir(CONFIG_DIR, { recursive: true });
-  }
+  await fs.mkdir(CONFIG_DIR, { recursive: true });
 }
 
 /**

--- a/lib/lock.ts
+++ b/lib/lock.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { debug, CACHE_DIR } from './utils';
+import { debug, warning, CACHE_DIR } from './utils';
 import { getDataDir } from './cache';
 
 export interface LockOptions {
@@ -50,7 +50,20 @@ export async function acquireLock(
           await fs.unlink(lockPath);
           debug(`Released lock: ${lockPath}`);
         } catch (err) {
-          debug(`Failed to release lock ${lockPath}:`, (err as Error).message);
+          // Already gone means someone reaped it as stale. The lock is
+          // released either way, so this is not worth reporting.
+          if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            debug(`Lock ${lockPath} was already removed`);
+            return;
+          }
+          // Anything else leaves the file in place, so the next invocation
+          // blocks for its full timeout and then fails to acquire, with
+          // nothing pointing back here. Say so rather than throw: the work
+          // this lock guarded has already completed.
+          warning(
+            `Could not release lock ${lockPath}: ${(err as Error).message}. ` +
+            `Other staqan-yt runs may block until it is removed by hand or ages out.`
+          );
         }
       };
     } catch (err) {
@@ -66,7 +79,12 @@ export async function acquireLock(
             await fs.unlink(lockPath);
             continue; // Try to acquire again
           } catch (unlinkErr) {
-            debug(`Failed to remove stale lock:`, (unlinkErr as Error).message);
+            // ENOENT means another process reaped the same stale lock first,
+            // which is the outcome we wanted. Fall through either way: the
+            // wait-and-retry below re-attempts acquisition.
+            if ((unlinkErr as NodeJS.ErrnoException).code !== 'ENOENT') {
+              debug(`Failed to remove stale lock ${lockPath}:`, (unlinkErr as Error).message);
+            }
           }
         }
 

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -318,25 +318,30 @@ export async function downloadReport(
     throw new Error(`Download failed for ${report.id} after ${maxRetries} attempts`);
   }
 
-  const csvData = await fs.readFile(tmpPath, 'utf-8');
-  const parsed = parseCsvAndExtractRange(csvData);
-
-  // Cleanup. The CSV has already been read and parsed into memory above, so a
-  // failure here costs a leaked temp file and nothing else. Throwing would
-  // discard a report that downloaded and parsed successfully.
+  // The read and the parse are inside the try so the temp file is removed even
+  // when one of them throws. Previously they ran ahead of the cleanup, so a
+  // malformed CSV leaked the download it failed on.
   try {
-    await unlink(tmpPath);
-  } catch (err) {
-    noteTempCleanupFailure(tmpPath, err);
-  }
+    const csvData = await fs.readFile(tmpPath, 'utf-8');
+    const parsed = parseCsvAndExtractRange(csvData);
 
-  return {
-    csvData,
-    headers: parsed.headers,
-    data: parsed.data,
-    minDate: parsed.minDate,
-    maxDate: parsed.maxDate,
-  };
+    return {
+      csvData,
+      headers: parsed.headers,
+      data: parsed.data,
+      minDate: parsed.minDate,
+      maxDate: parsed.maxDate,
+    };
+  } finally {
+    // Best effort on both paths. On success the payload is already in memory;
+    // on failure the read or parse error is the one worth surfacing. Either
+    // way a cleanup complaint must not replace it.
+    try {
+      await unlink(tmpPath);
+    } catch (err) {
+      noteTempCleanupFailure(tmpPath, err);
+    }
+  }
 }
 
 // ─── Reporting API queries (report types, jobs, report data) — #102 phase 4 ──

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -116,6 +116,21 @@ export function safeReportPath(tmpDir: string, reportId: string | null | undefin
 }
 
 /**
+ * Record a temp-download cleanup that did not happen.
+ *
+ * Deliberately does not throw. Every caller is either already unwinding a
+ * failure (so throwing here would replace the real error with a temp-file
+ * complaint) or has the payload safely in memory (so throwing would discard a
+ * completed download). `ENOENT` is the expected case and stays quiet; anything
+ * else means a temp file leaked into the data directory, which is otherwise
+ * invisible. See issue #196.
+ */
+function noteTempCleanupFailure(tmpPath: string, err: unknown): void {
+  if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+  debug(`Could not remove temp download ${tmpPath}: ${(err as Error).message}`);
+}
+
+/**
  * Single-attempt HTTPS GET that streams the response body into `dest`.
  * Resolves with the final HTTP status code (200 = success). Caller decides
  * whether to retry based on the status.
@@ -154,7 +169,7 @@ export function downloadOnce(
         // retry loop can decide. Drain the body so the socket closes cleanly.
         if (response.statusCode === 429) {
           response.resume();
-          unlink(dest).catch(() => {});
+          unlink(dest).catch(err => noteTempCleanupFailure(dest, err));
           resolve({
             statusCode: 429,
             retryAfterSec: Number(response.headers['retry-after']) || 0,
@@ -164,7 +179,7 @@ export function downloadOnce(
 
         if (response.statusCode !== 200) {
           response.resume();
-          unlink(dest).catch(() => {});
+          unlink(dest).catch(err => noteTempCleanupFailure(dest, err));
           // Carry the status on the error so the caller can tell a retriable
           // 5xx from a permanent 4xx. Without it every non-200 looked alike
           // and a transient 500 aborted the whole report.
@@ -184,7 +199,7 @@ export function downloadOnce(
         pipeline(response, file).then(
           () => resolve({ statusCode: 200, retryAfterSec: 0 }),
           (err) => {
-            unlink(dest).catch(() => {});
+            unlink(dest).catch(err => noteTempCleanupFailure(dest, err));
             reject(err);
           },
         );
@@ -200,7 +215,7 @@ export function downloadOnce(
         req.destroy(timeoutErr);
       })
       .on('error', (err) => {
-        unlink(dest).catch(() => {});
+        unlink(dest).catch(err => noteTempCleanupFailure(dest, err));
         reject(err);
       });
   });
@@ -306,11 +321,13 @@ export async function downloadReport(
   const csvData = await fs.readFile(tmpPath, 'utf-8');
   const parsed = parseCsvAndExtractRange(csvData);
 
-  // Cleanup
+  // Cleanup. The CSV has already been read and parsed into memory above, so a
+  // failure here costs a leaked temp file and nothing else. Throwing would
+  // discard a report that downloaded and parsed successfully.
   try {
     await unlink(tmpPath);
-  } catch {
-    // Ignore cleanup errors
+  } catch (err) {
+    noteTempCleanupFailure(tmpPath, err);
   }
 
   return {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -19,13 +19,37 @@ let isVerboseEnabled = false;
 let isQuietEnabled = false;
 
 /**
- * Ensure config directory exists
+ * Ensure config directory exists.
+ *
+ * Note: mkdir with { recursive: true } is idempotent: it succeeds if the
+ * directory already exists, so we call it directly without an access probe.
+ * This avoids the TOCTOU window and is more efficient. Matches `ensureCacheDir`
+ * in lib/cache.ts. A real failure (EACCES, ENOTDIR) propagates, which is what
+ * the callers that write into this directory need.
  */
 async function ensureConfigDir(): Promise<void> {
+  await fs.mkdir(CONFIG_DIR, { recursive: true });
+}
+
+/**
+ * Delete a file that is allowed not to exist.
+ *
+ * Swallows `ENOENT` only: the file being already gone is the outcome we wanted.
+ * Anything else (`EACCES`, `EPERM`, `EBUSY`, `EROFS`, `EIO`) means the file is
+ * still on disk, so it throws rather than letting the caller report a deletion
+ * that did not happen.
+ *
+ * Use this wherever a failed delete would make a subsequent claim untrue. For
+ * cleanup on a path that is already failing (rolling back a partial download
+ * before rethrowing the original error), swallowing is correct and a `debug()`
+ * line is the right amount of noise. Do not use this helper there.
+ */
+export async function unlinkIfPresent(filePath: string): Promise<void> {
   try {
-    await fs.access(CONFIG_DIR);
-  } catch {
-    await fs.mkdir(CONFIG_DIR, { recursive: true });
+    await fs.unlink(filePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
   }
 }
 

--- a/tests/cleanup-errors.test.ts
+++ b/tests/cleanup-errors.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Best-effort cleanup that swallowed more than the errno it documented (#196).
+ *
+ * The shape was always the same: a filesystem operation whose failure is
+ * genuinely fine in one specific case, guarded by a catch that discarded every
+ * case. `// Ignore if file doesn't exist` sat on top of a catch that also
+ * ignored EACCES, EPERM, EBUSY, EROFS and EIO.
+ *
+ * The user-visible instance is `cache clean`, whose whole output is a count of
+ * work done. With the cache directory unwritable, every unlink failed, the
+ * counter never advanced, and it printed `Nothing to clean` with exit 0 while
+ * all three files were still on disk. That is worse than an undercount: it
+ * reports that there was nothing to remove.
+ *
+ * Two things these tests deliberately pin as NOT throwing: rolling back a
+ * partial download (the original error must survive) and removing a temp file
+ * whose contents are already parsed in memory. Making those strict would
+ * replace a real error, or a completed download, with a temp-file complaint.
+ *
+ * The permission cases are skipped when running as root, since root bypasses
+ * the mode bits and every `unlink` would succeed.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { unlinkIfPresent } from '../lib/utils';
+import { deleteReportFromCache, loadCacheIndex, saveReportToCache } from '../lib/cache';
+
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+const describeUnlessRoot = isRoot ? describe.skip : describe;
+
+const CHANNEL = 'UCtesttesttesttesttest0';
+const TYPE = 'channel_reach_basic_a1';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'staqan-cleanup-'));
+});
+
+/**
+ * Restore write permission on every directory under `root` before removal.
+ * Several tests chmod a directory to 555 to make `unlink` fail, and `rm -r`
+ * cannot unlink through a read-only parent, so a shallow reset leaves the
+ * temp tree (and the next test) behind.
+ */
+async function restorePermissions(root: string): Promise<void> {
+  await fs.chmod(root, 0o700).catch(() => undefined);
+  const entries = await fs.readdir(root, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (entry.isDirectory()) await restorePermissions(path.join(root, entry.name));
+  }
+}
+
+afterEach(async () => {
+  await restorePermissions(dir);
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('unlinkIfPresent (#196)', () => {
+  it('removes a file that is there', async () => {
+    const p = path.join(dir, 'present.json');
+    await fs.writeFile(p, '{}');
+    await unlinkIfPresent(p);
+    expect(await fs.access(p).then(() => true, () => false)).toBe(false);
+  });
+
+  it('is a no-op when the file is already gone', async () => {
+    // The one case that may be silent: the file being absent is the outcome
+    // the caller wanted.
+    await expect(unlinkIfPresent(path.join(dir, 'never-existed.json'))).resolves.toBeUndefined();
+  });
+});
+
+describeUnlessRoot('unlinkIfPresent, unremovable file (#196)', () => {
+  it('throws instead of reporting the file as already gone', async () => {
+    // The regression. unlink fails EACCES because the *parent* is read-only,
+    // and the old catch treated that identically to ENOENT.
+    const p = path.join(dir, 'locked.json');
+    await fs.writeFile(p, '{}');
+    await fs.chmod(dir, 0o555);
+
+    await expect(unlinkIfPresent(p)).rejects.toThrow();
+    // And the file really is still there, which is the point.
+    await fs.chmod(dir, 0o700);
+    expect(await fs.access(p).then(() => true, () => false)).toBe(true);
+  });
+
+  it('surfaces the errno rather than flattening it to a generic message', async () => {
+    const p = path.join(dir, 'locked2.json');
+    await fs.writeFile(p, '{}');
+    await fs.chmod(dir, 0o555);
+
+    const err = await unlinkIfPresent(p).catch((e: NodeJS.ErrnoException) => e);
+    expect((err as NodeJS.ErrnoException).code).toBe('EACCES');
+  });
+});
+
+describeUnlessRoot('deleteReportFromCache (#196)', () => {
+  let previousDataDir: string | undefined;
+
+  beforeEach(() => {
+    previousDataDir = process.env.STAQAN_YT_DATA_DIR;
+    process.env.STAQAN_YT_DATA_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (previousDataDir === undefined) delete process.env.STAQAN_YT_DATA_DIR;
+    else process.env.STAQAN_YT_DATA_DIR = previousDataDir;
+  });
+
+  it('does not drop the index entry when the payload could not be removed', async () => {
+    // Orphaning is the failure mode: the CSV stays on disk holding the bytes
+    // while the index entry that names it is gone, so nothing can find it and
+    // nothing will re-download it.
+    await saveReportToCache(CHANNEL, 'report-1', TYPE, 'day,views\n2026-01-01,5\n', {
+      reportId: 'report-1',
+      reportTypeId: TYPE,
+      channelId: CHANNEL,
+      startTime: '2026-01-01',
+      endTime: '2026-01-01',
+      startTimeActual: '2026-01-01',
+      endTimeActual: '2026-01-01',
+      downloadedAt: '2026-01-02T00:00:00.000Z',
+      expiresAt: '2126-01-02T00:00:00.000Z',
+      columns: ['day', 'views'],
+      fileSize: 24,
+      jobId: 'job-1',
+    });
+
+    // The payload lives under reports/<typeId>/, so that is the directory
+    // whose write bit governs the unlink.
+    const reportTypeDir = path.join(dir, CHANNEL, 'reports', TYPE);
+    await fs.chmod(reportTypeDir, 0o555);
+
+    await expect(deleteReportFromCache(CHANNEL, 'report-1', TYPE)).rejects.toThrow();
+
+    await fs.chmod(reportTypeDir, 0o700);
+    const index = await loadCacheIndex(CHANNEL);
+    expect(index.entries.some(e => e.reportId === 'report-1')).toBe(true);
+  });
+});
+
+/**
+ * `cache clean` end to end.
+ *
+ * Driven as a child process because CACHE_DIR is derived from os.homedir() at
+ * module load, so the scratch HOME has to be set before the CLI is imported.
+ * `os.homedir()` honours $HOME on POSIX, which is the seam.
+ */
+describe('cache clean (#196)', () => {
+  const CLI = path.resolve('dist/bin/staqan-yt.js');
+
+  async function seed(home: string): Promise<void> {
+    await fs.mkdir(path.join(home, '.staqan-yt-cli', 'cache', 'UCtest'), { recursive: true });
+    for (const rel of [
+      ['cache', 'completion_cache.json'],
+      ['cache', 'handle-to-channel-id.json'],
+      ['cache', 'UCtest', 'completion_cache.json'],
+    ]) {
+      await fs.writeFile(path.join(home, '.staqan-yt-cli', ...rel), '{}');
+    }
+  }
+
+  function run(home: string): { stdout: string; stderr: string; status: number } {
+    const res = spawnSync('bun', [CLI, 'cache', 'clean', '--yes'], {
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    return { stdout: res.stdout ?? '', stderr: res.stderr ?? '', status: res.status ?? -1 };
+  }
+
+  async function remaining(home: string): Promise<number> {
+    const root = path.join(home, '.staqan-yt-cli', 'cache');
+    let n = 0;
+    for (const entry of await fs.readdir(root, { withFileTypes: true }).catch(() => [])) {
+      if (entry.isFile() && entry.name.endsWith('.json')) n++;
+      else if (entry.isDirectory()) {
+        n += (await fs.readdir(path.join(root, entry.name)).catch(() => []))
+          .filter(f => f.endsWith('.json')).length;
+      }
+    }
+    return n;
+  }
+
+  it('reports the count and exits 0 when every file is removable', async () => {
+    // Positive control: the behaviour that must not regress.
+    const home = path.join(dir, 'ok');
+    await seed(home);
+    const res = run(home);
+    expect(res.status).toBe(0);
+    expect(res.stdout + res.stderr).toContain('Cleared 3 cache file(s)');
+    expect(await remaining(home)).toBe(0);
+  });
+
+  it('reports nothing to clean, and exits 0, on an empty cache', async () => {
+    // The other legitimate quiet path: absent is not failure.
+    const home = path.join(dir, 'empty');
+    await fs.mkdir(path.join(home, '.staqan-yt-cli', 'cache'), { recursive: true });
+    const res = run(home);
+    expect(res.status).toBe(0);
+    expect(res.stdout + res.stderr).toContain('Nothing to clean');
+  });
+});
+
+describeUnlessRoot('cache clean, unwritable cache (#196)', () => {
+  const CLI = path.resolve('dist/bin/staqan-yt.js');
+
+  it('fails loudly instead of printing "Nothing to clean" with the files intact', async () => {
+    const home = path.join(dir, 'ro');
+    const cache = path.join(home, '.staqan-yt-cli', 'cache');
+    await fs.mkdir(path.join(cache, 'UCtest'), { recursive: true });
+    await fs.writeFile(path.join(cache, 'completion_cache.json'), '{}');
+    await fs.writeFile(path.join(cache, 'handle-to-channel-id.json'), '{}');
+    await fs.writeFile(path.join(cache, 'UCtest', 'completion_cache.json'), '{}');
+    await fs.chmod(path.join(cache, 'UCtest'), 0o555);
+    await fs.chmod(cache, 0o555);
+
+    const res = spawnSync('bun', [CLI, 'cache', 'clean', '--yes'], {
+      env: { ...process.env, HOME: home },
+      encoding: 'utf-8',
+    });
+    const out = (res.stdout ?? '') + (res.stderr ?? '');
+
+    await fs.chmod(cache, 0o700);
+    await fs.chmod(path.join(cache, 'UCtest'), 0o700);
+
+    expect(res.status).not.toBe(0);
+    expect(out).not.toContain('Nothing to clean');
+    expect(out).toContain('Could not clear');
+    // Names the paths that failed, since the errno alone does not say where.
+    expect(out).toContain(path.join(cache, 'completion_cache.json'));
+    expect(out).toContain(path.join(cache, 'UCtest', 'completion_cache.json'));
+  });
+});


### PR DESCRIPTION
Closes #196. Last of the four genre issues split out of #194.

## Why this one mattered more than "lowest severity" suggested

`cache clean`'s entire output is a claim about work done:

```ts
try { await fs.unlink(target); removed++; } catch { }
```

`removed++` sits after the `await`, so it counts successes rather than files
that should be gone, and the catch discarded every errno rather than the
`ENOENT` its comment named. Measured against the compiled binary with a
scratch `HOME` and three seeded cache files, on `0c90f67`:

| scenario | output | exit | files left |
|---|---|---|---|
| writable cache | `Cleared 3 cache file(s)` | 0 | 0 |
| whole cache dir `chmod 555` | `Nothing to clean` | 0 | **3** |
| one channel dir unwritable | `Cleared 2 cache file(s)` | 0 | **1** |
| cache dir `chmod 000` (readdir fails) | `Nothing to clean` | 0 | **3** |

The total-failure rows are the worst: not an undercount, but a report that
there was nothing to remove.

After this change, same four scenarios, same binary path:

| scenario | output | exit | files left |
|---|---|---|---|
| writable cache | `Cleared 3 cache file(s)` | 0 | 0 |
| whole cache dir `chmod 555` | `Could not clear 3 cache location(s)` + each path | **1** | 3 |
| one channel dir unwritable | `Cleared 2 cache file(s) before failing` + `Could not clear 1` | **1** | 1 |
| cache dir `chmod 000` | `Could not clear 3` incl. `cannot list per-channel caches` | **1** | 3 |

## What changed, and what deliberately did not

`unlinkIfPresent(path)` in `lib/utils.ts` swallows `ENOENT` only. Applied
where a failed delete would make a later claim untrue:

- `commands/cache.ts`: `cache clean` collects failures (including a failed
  `readdir`, which means per-channel caches may exist unseen), names each
  path, and exits non-zero.
- `commands/config.ts`: `invalidateChannelCache` runs *after* the new channel
  is written, so a failure must not read as the setting having failed. It
  warns and points at `staqan-yt cache clean` instead of throwing.
- `lib/cache.ts`: `deleteReportFromCache` no longer drops the index entry
  when the payload could not be removed. Orphaning is the real failure mode:
  the CSV keeps the bytes while the entry naming it is gone, so nothing can
  find or re-download it. (Note this function currently has no callers; it is
  exported API and was fixed on that basis.)

**Left best-effort on purpose**, because each runs on a path that is already
failing or after the payload is safely in memory, so throwing would replace a
real error (or a completed download) with a temp-file complaint:

- the four partial-download `unlink`s in `lib/reports.ts` (429, non-200,
  pipeline failure, socket error)
- `lib/reports.ts` post-read temp cleanup, where the CSV is already parsed, so
  this one would have been a **regression** if made strict
- the two thumbnail rollbacks in `commands/download-thumbnail.ts` and
  `commands/mcp.ts`, which rethrow the original error

All seven gain a `debug()` line so a leaked temp file is not wholly invisible.

## Corrections to the issue's site table

Re-verified against `0c90f67` before starting; three of #196's rows had
drifted or were wrong:

- `lib/cache.ts:453/459` are now **645/651** after #192 and #195 edited the file.
- The four `lib/reports.ts` rows are `.catch(() => {})` promise handlers, not
  `try`/`catch`, so a census regex matching only `catch (…) {` misses them
  entirely.
- The verification comment's claim that `loadRawConfig`/`loadConfig` swallow a
  config-dir `EACCES` **no longer holds**: #195 moved `ensureConfigDir()`
  outside the `try`, so it already propagates.

The `ensure-directory` family is handled as the issue proposed: the `fs.access`
probe is deleted from both byte-identical copies of `ensureConfigDir`
(`lib/config.ts`, `lib/utils.ts`) and `mkdir` is called bare. Recursive `mkdir`
cannot throw `EEXIST` on an existing directory, so the probe bought nothing and
reintroduced the exact TOCTOU window `ensureCacheDir` was written to avoid.

`commands/complete.ts` (debug-only, runs on every Tab) and `lib/youtube.ts`
(already warns) are unchanged: they were already correct.

## Unblocking #198

Census of every catch block in `lib/`, `commands/`, `bin/`, by script rather
than by reading:

| | at #194 | before this PR | after |
|---|---|---|---|
| bare `catch {}` (no statement) | 11 | 8 | **0** |

Getting to zero required two non-filesystem sites the issue did not list, both
now `debug()`: a malformed `redirect_uris` entry in `lib/auth.ts`, and
`brew --prefix` failing in `lib/completion.ts`. Without them #198's lint rule
would still go red on merge.

## Verification

**Regression tests fail on main.** `tests/cleanup-errors.test.ts` run against
an `origin/main` worktree: the two behavioral guards fail (`deleteReportFromCache`
resolved instead of rejecting; `cache clean` exited 0), and the two positive
controls pass on both sides.

**Real archive unaffected.** `loadCacheIndex` + `loadReportMetadata` +
`readCachedReport` over the whole live archive, under main and under this
branch:

```
channels=1 entries=3757 served=3757 nullReports=0 rows=39908 metaOk=3757 metaNull=0
digest=e239e655e0f2f81e87be5bbc52ea68e66b8049dc850854680d255925f4527150
```

Identical on both. The archive was backed up beforehand with a SHA-256 manifest
over all 7520 files; re-hashed afterwards, every hash matches, so nothing was
mutated (all permission scenarios ran against a scratch `HOME`).

`bun run type-check && bun run lint && bun run build && bun test`: clean,
**297 pass / 0 fail** (up from 289; 4 pre-existing `no-explicit-any` warnings).

The permission-based tests skip when running as root, since root bypasses the
mode bits and every `unlink` would succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVX6zWYkZfs63BKm5s8bdr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cache cleanup now reports failed deletions instead of silently succeeding.
  - Stale caches, lock files, and temporary downloads are handled more reliably.
  - Cleanup failures now preserve the original error and provide clearer diagnostics.
  - Configuration directory creation works consistently when the directory already exists.
  - Invalid OAuth redirect entries are skipped with diagnostic logging.

- **Tests**
  - Added coverage for cache cleanup failures, missing files, permission errors, and report-cache deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->